### PR TITLE
Add hsk

### DIFF
--- a/vocab/mandarin/hsk/1/vocab.csv
+++ b/vocab/mandarin/hsk/1/vocab.csv
@@ -1,0 +1,151 @@
+PRIMARY	PRIMARY	INTERMEDIATE	INTERMEDIATE	NATIVE
+爱	愛	ai4	ài	love
+八	八	ba1	bā	eight
+爸爸	爸爸	ba4ba5	bàba	Dad
+杯子	杯子	bei1zi5	bēizi	cup; glass
+北京	北京	Bei3jing1	Běijīng	Beijing
+本	本	ben3	běn	measure word for books
+不客气	不客氣	bu2 ke4qi5	bú kèqi	you're welcome; don't be polite
+不	不	bu4	bù	no; not
+菜	菜	cai4	cài	dish (type of food); vegetables
+茶	茶	cha2	chá	tea
+吃	吃	chi1	chī	eat
+出租车	出租車	chu1zu1che1	chūzūchē	taxi; cab
+打电话	打電話	da3 dian4hua4	dǎ diànhuà	make a phone call
+大	大	da4	dà	big; large
+的	的	de5	de	indicates possession, like adding 's to a noun
+点	點	dian3	diǎn	a dot; a little; o'clock
+电脑	電腦	dian4nao3	diànnǎo	computer
+电视	電視	dian4shi4	diànshì	television; TV
+电影	電影	dian4ying3	diànyǐng	movie; film
+东西	東西	dong1xi5	dōngxi	things; stuff
+都	都	dou1	dōu	all; both
+读	讀	du2	dú	to read; to study
+对不起	對不起	dui4bu5qi3	duìbuqǐ	sorry
+多	多	duo1	duō	many
+多少	多少	duo1shao5	duōshao	how much?; how many?
+儿子	兒子	er2zi5	érzi	son
+二	二	er4	èr	two
+饭店	飯店	fan4dian4	fàndiàn	restaurant; hotel
+飞机	飛機	fei1ji1	fēijī	airplane
+分钟	分鐘	fen1zhong1	fēnzhōng	minute; (measure word for time)
+高兴	高興	gao1xing4	gāoxìng	happy; glad
+个	個	ge5	ge	general measure word
+工作	工作	gong1zuo4	gōngzuò	work; a job
+狗	狗	gou3	gǒu	dog
+汉语	漢語	Han4yu3	Hànyǔ	Chinese language
+好	好	hao3	hǎo	good
+号	號	hao4	hào	number; day of a month
+喝	喝	he1	hē	to drink
+和	和	he2	hé	and; with
+很	很	hen3	hěn	very; quite
+后面	后面	hou4mian5	hòumian	back; behind
+回	回	hui2	huí	to return; to reply; to go back
+会	會	hui4	huì	know how to
+几	幾	ji3	jǐ	how many; several; a few
+家	家	jia1	jiā	family; home
+叫	叫	jiao4	jiào	to be called
+今天	今天	jin1tian1	jīntiān	today
+九	九	jiu3	jiǔ	nine
+开	開	kai1	kāi	to open; to start; to operate (a vehicle)
+看	看	kan4	kàn	see; look at; to watch
+看见	看見	kan4jian4	kànjiàn	see; catch sight of
+块	塊	kuai4	kuài	lump; piece; sum of money
+来	來	lai2	lái	come; arrive; ever since; next
+老师	老師	lao3shi1	lǎoshī	teacher
+了	了	le5	le	indicates a completed or finished action
+冷	冷	leng3	lěng	cold
+里	裡	li3	lǐ	inside; Chinese mile (~.5 km)
+六	六	liu4	liù	six
+妈妈	媽媽	ma1ma5	māma	mom; mum
+吗	嗎	ma5	ma	indicates a yes/no question (added to a statement)
+买	買	mai3	mǎi	to buy
+猫	貓	mao1	māo	cat
+没关系	沒關系	mei2 guan1xi5	méi guānxi	it doesn't matter; never mind
+没有	沒有	mei2you3	méiyǒu	not have; there is not
+米饭	米飯	mi3fan4	mǐfàn	(cooked) rice
+明天	明天	ming2tian1	míngtiān	tomorrow
+名字	名字	ming2zi5	míngzi	name
+哪	哪	na3	nǎa	which; how
+哪儿	哪兒	na3r5	nǎr	where? (Beijing accent)
+那	那	na4	nà	that; then
+呢	呢	ne5	ne	indicates a question; how about...?;
+能	能	neng2	néng	can; be able
+你	你	ni3	nǐ	you (singular)
+年	年	nian2	nián	year
+女儿	女兒	nv3'er2	nǚ'ér	daughter
+朋友	朋友	peng2you5	péngyou	friend
+漂亮	漂亮	piao4liang5	piàoliang	pretty; beautiful
+苹果	蘋果	ping2guo3	píngguǒ	apple
+七	七	qi1	qī	seven
+钱	錢	qian2	qián	money; coin
+前面	前面	qian2mian4	qiánmiàn	in front
+请	請	qing3	qǐng	please; invite; to treat someone to something
+去	去	qu4	qù	go; to leave
+热	熱	re4	rè	heat; hot
+人	人	ren2	rén	person; man; people
+认识	認識	ren4shi5	rènshi	recognize; know (a person)
+三	三	san1	sān	three
+商店	商店	shang1dian4	shāngdiàn	shop; store
+上	上	shang4	shàng	above; up
+上午	上午	shang4wu3	shàngwǔ	late morning (before noon)
+少	少	shao3	shǎo	few; little
+谁	誰	shei2	shéi	who
+什么	什麼	shen2me5	shénme	what? (replaces the noun to turn a statement into a question)
+十	十	shi2	shí	ten
+时候	時候	shi2hou5	shíhou	time
+是	是	shi4	shì	be; is; are; am
+书	書	shu1	shū	book; letter
+水	水	shui3	shuǐ	water
+水果	水果	shui3guo3	shuǐguǒ	fruit
+睡觉	睡覺	shui4 jiao4	shuì jiào	to sleep; go to bed
+说	說	shuo1	shuō	speak
+四	四	si4	sì	four
+岁	歲	sui4	suì	years old; age
+他	他	ta1	tā	he; him
+她	她	ta1	tā	she
+太	太	tai4	tài	too (much)
+天气	天氣	tian1qi4	tiānqì	weather
+听	聽	ting1	tīng	listen; hear
+同学	同學	tong2xue2	tóngxué	fellow student; schoolmate
+喂	喂	wei4	wèi	hello (on the phone)
+我	我	wo3	wǒ	I; me
+我们	我們	wo3men5	wǒmen	we; us
+五	五	wu3	wǔ	five
+喜欢	喜歡	xi3huan5	xǐhuan	to like
+下	下	xia4	xià	fall; below
+下午	下午	xia4wu3	xiàwǔ	afternoon
+下雨	下雨	xia4yu3	xiàyǔ	to rain
+先生	先生	xian1sheng5	xiānsheng	Mr.; Sir
+现在	現在	xian4zai4	xiànzài	now
+想	想	xiang3	xiǎng	think; believe; suppose; would like to
+小	小	xiao3	xiǎo	small; young
+小姐	小姐	xiao3jie5	xiǎojie	young lady; miss; Ms.
+些	些	xie1	xiē	some; few; several
+写	寫	xie3	xiě	to write; to compose
+谢谢	謝謝	xie4xie5	xièxie	thank you
+星期	星期	xing1qi1	xīngqī	week
+学生	學生	xue2sheng5	xuésheng	student
+学习	學習	xue2xi2	xuéxí	learn; to study
+学校	學校	xue2xiao4	xuéxiào	school
+一	一	yi1	yī	one; once; a
+衣服	衣服	yi1fu5	yīfu	clothes
+医生	醫生	yi1sheng1	yīshēng	doctor
+医院	醫院	yi1yuan4	yīyuàn	hospital
+椅子	椅子	yi3zi5	yǐzi	chair
+一点儿	一點兒	yi4dian3r5	yìdiǎnr	a bit; a few
+有	有	you3	yǒu	have
+月	月	yue4	yuè	moon; month
+在	在	zai4	zài	at; on; in; indicates an action in progress
+再见	再見	zai4jian4	zàijiàn	goodbye; see you later
+怎么	怎麼	zen3me5	zěnme	how?
+怎么样	怎麼樣	zen3me5yang4	zěnmeyàng	how about?; how is/was it?
+这	這	zhe4	zhè	this
+中国	中國	Zhong1guo2	Zhōngguó	China
+中午	中午	zhong1wu3	zhōngwǔ	noon; midday
+住	住	zhu4	zhù	to live; reside; to stop
+桌子	桌子	zhuo1zi5	zhuōzi	table; desk
+字	字	zi4	zì	letter; character
+昨天	昨天	zuo2tian1	zuótiān	yesterday
+做	做	zuo4	zuò	do; make
+坐	坐	zuo4	zuò	sit

--- a/vocab/mandarin/hsk/1/vocab.json
+++ b/vocab/mandarin/hsk/1/vocab.json
@@ -1,0 +1,1052 @@
+[
+    {
+        "intermediate_1": "ai4",
+        "intermediate_2": "ài",
+        "native_1": "love",
+        "primary_1": "爱",
+        "primary_2": "愛"
+    },
+    {
+        "intermediate_1": "ba1",
+        "intermediate_2": "bā",
+        "native_1": "eight",
+        "primary_1": "八",
+        "primary_2": "八"
+    },
+    {
+        "intermediate_1": "ba4ba5",
+        "intermediate_2": "bàba",
+        "native_1": "Dad",
+        "primary_1": "爸爸",
+        "primary_2": "爸爸"
+    },
+    {
+        "intermediate_1": "bei1zi5",
+        "intermediate_2": "bēizi",
+        "native_1": "cup; glass",
+        "primary_1": "杯子",
+        "primary_2": "杯子"
+    },
+    {
+        "intermediate_1": "Bei3jing1",
+        "intermediate_2": "Běijīng",
+        "native_1": "Beijing",
+        "primary_1": "北京",
+        "primary_2": "北京"
+    },
+    {
+        "intermediate_1": "ben3",
+        "intermediate_2": "běn",
+        "native_1": "measure word for books",
+        "primary_1": "本",
+        "primary_2": "本"
+    },
+    {
+        "intermediate_1": "bu2 ke4qi5",
+        "intermediate_2": "bú kèqi",
+        "native_1": "you're welcome; don't be polite",
+        "primary_1": "不客气",
+        "primary_2": "不客氣"
+    },
+    {
+        "intermediate_1": "bu4",
+        "intermediate_2": "bù",
+        "native_1": "no; not",
+        "primary_1": "不",
+        "primary_2": "不"
+    },
+    {
+        "intermediate_1": "cai4",
+        "intermediate_2": "cài",
+        "native_1": "dish (type of food); vegetables",
+        "primary_1": "菜",
+        "primary_2": "菜"
+    },
+    {
+        "intermediate_1": "cha2",
+        "intermediate_2": "chá",
+        "native_1": "tea",
+        "primary_1": "茶",
+        "primary_2": "茶"
+    },
+    {
+        "intermediate_1": "chi1",
+        "intermediate_2": "chī",
+        "native_1": "eat",
+        "primary_1": "吃",
+        "primary_2": "吃"
+    },
+    {
+        "intermediate_1": "chu1zu1che1",
+        "intermediate_2": "chūzūchē",
+        "native_1": "taxi; cab",
+        "primary_1": "出租车",
+        "primary_2": "出租車"
+    },
+    {
+        "intermediate_1": "da3 dian4hua4",
+        "intermediate_2": "dǎ diànhuà",
+        "native_1": "make a phone call",
+        "primary_1": "打电话",
+        "primary_2": "打電話"
+    },
+    {
+        "intermediate_1": "da4",
+        "intermediate_2": "dà",
+        "native_1": "big; large",
+        "primary_1": "大",
+        "primary_2": "大"
+    },
+    {
+        "intermediate_1": "de5",
+        "intermediate_2": "de",
+        "native_1": "indicates possession, like adding 's to a noun",
+        "primary_1": "的",
+        "primary_2": "的"
+    },
+    {
+        "intermediate_1": "dian3",
+        "intermediate_2": "diǎn",
+        "native_1": "a dot; a little; o'clock",
+        "primary_1": "点",
+        "primary_2": "點"
+    },
+    {
+        "intermediate_1": "dian4nao3",
+        "intermediate_2": "diànnǎo",
+        "native_1": "computer",
+        "primary_1": "电脑",
+        "primary_2": "電腦"
+    },
+    {
+        "intermediate_1": "dian4shi4",
+        "intermediate_2": "diànshì",
+        "native_1": "television; TV",
+        "primary_1": "电视",
+        "primary_2": "電視"
+    },
+    {
+        "intermediate_1": "dian4ying3",
+        "intermediate_2": "diànyǐng",
+        "native_1": "movie; film",
+        "primary_1": "电影",
+        "primary_2": "電影"
+    },
+    {
+        "intermediate_1": "dong1xi5",
+        "intermediate_2": "dōngxi",
+        "native_1": "things; stuff",
+        "primary_1": "东西",
+        "primary_2": "東西"
+    },
+    {
+        "intermediate_1": "dou1",
+        "intermediate_2": "dōu",
+        "native_1": "all; both",
+        "primary_1": "都",
+        "primary_2": "都"
+    },
+    {
+        "intermediate_1": "du2",
+        "intermediate_2": "dú",
+        "native_1": "to read; to study",
+        "primary_1": "读",
+        "primary_2": "讀"
+    },
+    {
+        "intermediate_1": "dui4bu5qi3",
+        "intermediate_2": "duìbuqǐ",
+        "native_1": "sorry",
+        "primary_1": "对不起",
+        "primary_2": "對不起"
+    },
+    {
+        "intermediate_1": "duo1",
+        "intermediate_2": "duō",
+        "native_1": "many",
+        "primary_1": "多",
+        "primary_2": "多"
+    },
+    {
+        "intermediate_1": "duo1shao5",
+        "intermediate_2": "duōshao",
+        "native_1": "how much?; how many?",
+        "primary_1": "多少",
+        "primary_2": "多少"
+    },
+    {
+        "intermediate_1": "er2zi5",
+        "intermediate_2": "érzi",
+        "native_1": "son",
+        "primary_1": "儿子",
+        "primary_2": "兒子"
+    },
+    {
+        "intermediate_1": "er4",
+        "intermediate_2": "èr",
+        "native_1": "two",
+        "primary_1": "二",
+        "primary_2": "二"
+    },
+    {
+        "intermediate_1": "fan4dian4",
+        "intermediate_2": "fàndiàn",
+        "native_1": "restaurant; hotel",
+        "primary_1": "饭店",
+        "primary_2": "飯店"
+    },
+    {
+        "intermediate_1": "fei1ji1",
+        "intermediate_2": "fēijī",
+        "native_1": "airplane",
+        "primary_1": "飞机",
+        "primary_2": "飛機"
+    },
+    {
+        "intermediate_1": "fen1zhong1",
+        "intermediate_2": "fēnzhōng",
+        "native_1": "minute; (measure word for time)",
+        "primary_1": "分钟",
+        "primary_2": "分鐘"
+    },
+    {
+        "intermediate_1": "gao1xing4",
+        "intermediate_2": "gāoxìng",
+        "native_1": "happy; glad",
+        "primary_1": "高兴",
+        "primary_2": "高興"
+    },
+    {
+        "intermediate_1": "ge5",
+        "intermediate_2": "ge",
+        "native_1": "general measure word",
+        "primary_1": "个",
+        "primary_2": "個"
+    },
+    {
+        "intermediate_1": "gong1zuo4",
+        "intermediate_2": "gōngzuò",
+        "native_1": "work; a job",
+        "primary_1": "工作",
+        "primary_2": "工作"
+    },
+    {
+        "intermediate_1": "gou3",
+        "intermediate_2": "gǒu",
+        "native_1": "dog",
+        "primary_1": "狗",
+        "primary_2": "狗"
+    },
+    {
+        "intermediate_1": "Han4yu3",
+        "intermediate_2": "Hànyǔ",
+        "native_1": "Chinese language",
+        "primary_1": "汉语",
+        "primary_2": "漢語"
+    },
+    {
+        "intermediate_1": "hao3",
+        "intermediate_2": "hǎo",
+        "native_1": "good",
+        "primary_1": "好",
+        "primary_2": "好"
+    },
+    {
+        "intermediate_1": "hao4",
+        "intermediate_2": "hào",
+        "native_1": "number; day of a month",
+        "primary_1": "号",
+        "primary_2": "號"
+    },
+    {
+        "intermediate_1": "he1",
+        "intermediate_2": "hē",
+        "native_1": "to drink",
+        "primary_1": "喝",
+        "primary_2": "喝"
+    },
+    {
+        "intermediate_1": "he2",
+        "intermediate_2": "hé",
+        "native_1": "and; with",
+        "primary_1": "和",
+        "primary_2": "和"
+    },
+    {
+        "intermediate_1": "hen3",
+        "intermediate_2": "hěn",
+        "native_1": "very; quite",
+        "primary_1": "很",
+        "primary_2": "很"
+    },
+    {
+        "intermediate_1": "hou4mian5",
+        "intermediate_2": "hòumian",
+        "native_1": "back; behind",
+        "primary_1": "后面",
+        "primary_2": "后面"
+    },
+    {
+        "intermediate_1": "hui2",
+        "intermediate_2": "huí",
+        "native_1": "to return; to reply; to go back",
+        "primary_1": "回",
+        "primary_2": "回"
+    },
+    {
+        "intermediate_1": "hui4",
+        "intermediate_2": "huì",
+        "native_1": "know how to",
+        "primary_1": "会",
+        "primary_2": "會"
+    },
+    {
+        "intermediate_1": "ji3",
+        "intermediate_2": "jǐ",
+        "native_1": "how many; several; a few",
+        "primary_1": "几",
+        "primary_2": "幾"
+    },
+    {
+        "intermediate_1": "jia1",
+        "intermediate_2": "jiā",
+        "native_1": "family; home",
+        "primary_1": "家",
+        "primary_2": "家"
+    },
+    {
+        "intermediate_1": "jiao4",
+        "intermediate_2": "jiào",
+        "native_1": "to be called",
+        "primary_1": "叫",
+        "primary_2": "叫"
+    },
+    {
+        "intermediate_1": "jin1tian1",
+        "intermediate_2": "jīntiān",
+        "native_1": "today",
+        "primary_1": "今天",
+        "primary_2": "今天"
+    },
+    {
+        "intermediate_1": "jiu3",
+        "intermediate_2": "jiǔ",
+        "native_1": "nine",
+        "primary_1": "九",
+        "primary_2": "九"
+    },
+    {
+        "intermediate_1": "kai1",
+        "intermediate_2": "kāi",
+        "native_1": "to open; to start; to operate (a vehicle)",
+        "primary_1": "开",
+        "primary_2": "開"
+    },
+    {
+        "intermediate_1": "kan4",
+        "intermediate_2": "kàn",
+        "native_1": "see; look at; to watch",
+        "primary_1": "看",
+        "primary_2": "看"
+    },
+    {
+        "intermediate_1": "kan4jian4",
+        "intermediate_2": "kànjiàn",
+        "native_1": "see; catch sight of",
+        "primary_1": "看见",
+        "primary_2": "看見"
+    },
+    {
+        "intermediate_1": "kuai4",
+        "intermediate_2": "kuài",
+        "native_1": "lump; piece; sum of money",
+        "primary_1": "块",
+        "primary_2": "塊"
+    },
+    {
+        "intermediate_1": "lai2",
+        "intermediate_2": "lái",
+        "native_1": "come; arrive; ever since; next",
+        "primary_1": "来",
+        "primary_2": "來"
+    },
+    {
+        "intermediate_1": "lao3shi1",
+        "intermediate_2": "lǎoshī",
+        "native_1": "teacher",
+        "primary_1": "老师",
+        "primary_2": "老師"
+    },
+    {
+        "intermediate_1": "le5",
+        "intermediate_2": "le",
+        "native_1": "indicates a completed or finished action",
+        "primary_1": "了",
+        "primary_2": "了"
+    },
+    {
+        "intermediate_1": "leng3",
+        "intermediate_2": "lěng",
+        "native_1": "cold",
+        "primary_1": "冷",
+        "primary_2": "冷"
+    },
+    {
+        "intermediate_1": "li3",
+        "intermediate_2": "lǐ",
+        "native_1": "inside; Chinese mile (~.5 km)",
+        "primary_1": "里",
+        "primary_2": "裡"
+    },
+    {
+        "intermediate_1": "liu4",
+        "intermediate_2": "liù",
+        "native_1": "six",
+        "primary_1": "六",
+        "primary_2": "六"
+    },
+    {
+        "intermediate_1": "ma1ma5",
+        "intermediate_2": "māma",
+        "native_1": "mom; mum",
+        "primary_1": "妈妈",
+        "primary_2": "媽媽"
+    },
+    {
+        "intermediate_1": "ma5",
+        "intermediate_2": "ma",
+        "native_1": "indicates a yes/no question (added to a statement)",
+        "primary_1": "吗",
+        "primary_2": "嗎"
+    },
+    {
+        "intermediate_1": "mai3",
+        "intermediate_2": "mǎi",
+        "native_1": "to buy",
+        "primary_1": "买",
+        "primary_2": "買"
+    },
+    {
+        "intermediate_1": "mao1",
+        "intermediate_2": "māo",
+        "native_1": "cat",
+        "primary_1": "猫",
+        "primary_2": "貓"
+    },
+    {
+        "intermediate_1": "mei2 guan1xi5",
+        "intermediate_2": "méi guānxi",
+        "native_1": "it doesn't matter; never mind",
+        "primary_1": "没关系",
+        "primary_2": "沒關系"
+    },
+    {
+        "intermediate_1": "mei2you3",
+        "intermediate_2": "méiyǒu",
+        "native_1": "not have; there is not",
+        "primary_1": "没有",
+        "primary_2": "沒有"
+    },
+    {
+        "intermediate_1": "mi3fan4",
+        "intermediate_2": "mǐfàn",
+        "native_1": "(cooked) rice",
+        "primary_1": "米饭",
+        "primary_2": "米飯"
+    },
+    {
+        "intermediate_1": "ming2tian1",
+        "intermediate_2": "míngtiān",
+        "native_1": "tomorrow",
+        "primary_1": "明天",
+        "primary_2": "明天"
+    },
+    {
+        "intermediate_1": "ming2zi5",
+        "intermediate_2": "míngzi",
+        "native_1": "name",
+        "primary_1": "名字",
+        "primary_2": "名字"
+    },
+    {
+        "intermediate_1": "na3",
+        "intermediate_2": "nǎa",
+        "native_1": "which; how",
+        "primary_1": "哪",
+        "primary_2": "哪"
+    },
+    {
+        "intermediate_1": "na3r5",
+        "intermediate_2": "nǎr",
+        "native_1": "where? (Beijing accent)",
+        "primary_1": "哪儿",
+        "primary_2": "哪兒"
+    },
+    {
+        "intermediate_1": "na4",
+        "intermediate_2": "nà",
+        "native_1": "that; then",
+        "primary_1": "那",
+        "primary_2": "那"
+    },
+    {
+        "intermediate_1": "ne5",
+        "intermediate_2": "ne",
+        "native_1": "indicates a question; how about...?;",
+        "primary_1": "呢",
+        "primary_2": "呢"
+    },
+    {
+        "intermediate_1": "neng2",
+        "intermediate_2": "néng",
+        "native_1": "can; be able",
+        "primary_1": "能",
+        "primary_2": "能"
+    },
+    {
+        "intermediate_1": "ni3",
+        "intermediate_2": "nǐ",
+        "native_1": "you (singular)",
+        "primary_1": "你",
+        "primary_2": "你"
+    },
+    {
+        "intermediate_1": "nian2",
+        "intermediate_2": "nián",
+        "native_1": "year",
+        "primary_1": "年",
+        "primary_2": "年"
+    },
+    {
+        "intermediate_1": "nv3'er2",
+        "intermediate_2": "nǚ'ér",
+        "native_1": "daughter",
+        "primary_1": "女儿",
+        "primary_2": "女兒"
+    },
+    {
+        "intermediate_1": "peng2you5",
+        "intermediate_2": "péngyou",
+        "native_1": "friend",
+        "primary_1": "朋友",
+        "primary_2": "朋友"
+    },
+    {
+        "intermediate_1": "piao4liang5",
+        "intermediate_2": "piàoliang",
+        "native_1": "pretty; beautiful",
+        "primary_1": "漂亮",
+        "primary_2": "漂亮"
+    },
+    {
+        "intermediate_1": "ping2guo3",
+        "intermediate_2": "píngguǒ",
+        "native_1": "apple",
+        "primary_1": "苹果",
+        "primary_2": "蘋果"
+    },
+    {
+        "intermediate_1": "qi1",
+        "intermediate_2": "qī",
+        "native_1": "seven",
+        "primary_1": "七",
+        "primary_2": "七"
+    },
+    {
+        "intermediate_1": "qian2",
+        "intermediate_2": "qián",
+        "native_1": "money; coin",
+        "primary_1": "钱",
+        "primary_2": "錢"
+    },
+    {
+        "intermediate_1": "qian2mian4",
+        "intermediate_2": "qiánmiàn",
+        "native_1": "in front",
+        "primary_1": "前面",
+        "primary_2": "前面"
+    },
+    {
+        "intermediate_1": "qing3",
+        "intermediate_2": "qǐng",
+        "native_1": "please; invite; to treat someone to something",
+        "primary_1": "请",
+        "primary_2": "請"
+    },
+    {
+        "intermediate_1": "qu4",
+        "intermediate_2": "qù",
+        "native_1": "go; to leave",
+        "primary_1": "去",
+        "primary_2": "去"
+    },
+    {
+        "intermediate_1": "re4",
+        "intermediate_2": "rè",
+        "native_1": "heat; hot",
+        "primary_1": "热",
+        "primary_2": "熱"
+    },
+    {
+        "intermediate_1": "ren2",
+        "intermediate_2": "rén",
+        "native_1": "person; man; people",
+        "primary_1": "人",
+        "primary_2": "人"
+    },
+    {
+        "intermediate_1": "ren4shi5",
+        "intermediate_2": "rènshi",
+        "native_1": "recognize; know (a person)",
+        "primary_1": "认识",
+        "primary_2": "認識"
+    },
+    {
+        "intermediate_1": "san1",
+        "intermediate_2": "sān",
+        "native_1": "three",
+        "primary_1": "三",
+        "primary_2": "三"
+    },
+    {
+        "intermediate_1": "shang1dian4",
+        "intermediate_2": "shāngdiàn",
+        "native_1": "shop; store",
+        "primary_1": "商店",
+        "primary_2": "商店"
+    },
+    {
+        "intermediate_1": "shang4",
+        "intermediate_2": "shàng",
+        "native_1": "above; up",
+        "primary_1": "上",
+        "primary_2": "上"
+    },
+    {
+        "intermediate_1": "shang4wu3",
+        "intermediate_2": "shàngwǔ",
+        "native_1": "late morning (before noon)",
+        "primary_1": "上午",
+        "primary_2": "上午"
+    },
+    {
+        "intermediate_1": "shao3",
+        "intermediate_2": "shǎo",
+        "native_1": "few; little",
+        "primary_1": "少",
+        "primary_2": "少"
+    },
+    {
+        "intermediate_1": "shei2",
+        "intermediate_2": "shéi",
+        "native_1": "who",
+        "primary_1": "谁",
+        "primary_2": "誰"
+    },
+    {
+        "intermediate_1": "shen2me5",
+        "intermediate_2": "shénme",
+        "native_1": "what? (replaces the noun to turn a statement into a question)",
+        "primary_1": "什么",
+        "primary_2": "什麼"
+    },
+    {
+        "intermediate_1": "shi2",
+        "intermediate_2": "shí",
+        "native_1": "ten",
+        "primary_1": "十",
+        "primary_2": "十"
+    },
+    {
+        "intermediate_1": "shi2hou5",
+        "intermediate_2": "shíhou",
+        "native_1": "time",
+        "primary_1": "时候",
+        "primary_2": "時候"
+    },
+    {
+        "intermediate_1": "shi4",
+        "intermediate_2": "shì",
+        "native_1": "be; is; are; am",
+        "primary_1": "是",
+        "primary_2": "是"
+    },
+    {
+        "intermediate_1": "shu1",
+        "intermediate_2": "shū",
+        "native_1": "book; letter",
+        "primary_1": "书",
+        "primary_2": "書"
+    },
+    {
+        "intermediate_1": "shui3",
+        "intermediate_2": "shuǐ",
+        "native_1": "water",
+        "primary_1": "水",
+        "primary_2": "水"
+    },
+    {
+        "intermediate_1": "shui3guo3",
+        "intermediate_2": "shuǐguǒ",
+        "native_1": "fruit",
+        "primary_1": "水果",
+        "primary_2": "水果"
+    },
+    {
+        "intermediate_1": "shui4 jiao4",
+        "intermediate_2": "shuì jiào",
+        "native_1": "to sleep; go to bed",
+        "primary_1": "睡觉",
+        "primary_2": "睡覺"
+    },
+    {
+        "intermediate_1": "shuo1",
+        "intermediate_2": "shuō",
+        "native_1": "speak",
+        "primary_1": "说",
+        "primary_2": "說"
+    },
+    {
+        "intermediate_1": "si4",
+        "intermediate_2": "sì",
+        "native_1": "four",
+        "primary_1": "四",
+        "primary_2": "四"
+    },
+    {
+        "intermediate_1": "sui4",
+        "intermediate_2": "suì",
+        "native_1": "years old; age",
+        "primary_1": "岁",
+        "primary_2": "歲"
+    },
+    {
+        "intermediate_1": "ta1",
+        "intermediate_2": "tā",
+        "native_1": "he; him",
+        "primary_1": "他",
+        "primary_2": "他"
+    },
+    {
+        "intermediate_1": "ta1",
+        "intermediate_2": "tā",
+        "native_1": "she",
+        "primary_1": "她",
+        "primary_2": "她"
+    },
+    {
+        "intermediate_1": "tai4",
+        "intermediate_2": "tài",
+        "native_1": "too (much)",
+        "primary_1": "太",
+        "primary_2": "太"
+    },
+    {
+        "intermediate_1": "tian1qi4",
+        "intermediate_2": "tiānqì",
+        "native_1": "weather",
+        "primary_1": "天气",
+        "primary_2": "天氣"
+    },
+    {
+        "intermediate_1": "ting1",
+        "intermediate_2": "tīng",
+        "native_1": "listen; hear",
+        "primary_1": "听",
+        "primary_2": "聽"
+    },
+    {
+        "intermediate_1": "tong2xue2",
+        "intermediate_2": "tóngxué",
+        "native_1": "fellow student; schoolmate",
+        "primary_1": "同学",
+        "primary_2": "同學"
+    },
+    {
+        "intermediate_1": "wei4",
+        "intermediate_2": "wèi",
+        "native_1": "hello (on the phone)",
+        "primary_1": "喂",
+        "primary_2": "喂"
+    },
+    {
+        "intermediate_1": "wo3",
+        "intermediate_2": "wǒ",
+        "native_1": "I; me",
+        "primary_1": "我",
+        "primary_2": "我"
+    },
+    {
+        "intermediate_1": "wo3men5",
+        "intermediate_2": "wǒmen",
+        "native_1": "we; us",
+        "primary_1": "我们",
+        "primary_2": "我們"
+    },
+    {
+        "intermediate_1": "wu3",
+        "intermediate_2": "wǔ",
+        "native_1": "five",
+        "primary_1": "五",
+        "primary_2": "五"
+    },
+    {
+        "intermediate_1": "xi3huan5",
+        "intermediate_2": "xǐhuan",
+        "native_1": "to like",
+        "primary_1": "喜欢",
+        "primary_2": "喜歡"
+    },
+    {
+        "intermediate_1": "xia4",
+        "intermediate_2": "xià",
+        "native_1": "fall; below",
+        "primary_1": "下",
+        "primary_2": "下"
+    },
+    {
+        "intermediate_1": "xia4wu3",
+        "intermediate_2": "xiàwǔ",
+        "native_1": "afternoon",
+        "primary_1": "下午",
+        "primary_2": "下午"
+    },
+    {
+        "intermediate_1": "xia4yu3",
+        "intermediate_2": "xiàyǔ",
+        "native_1": "to rain",
+        "primary_1": "下雨",
+        "primary_2": "下雨"
+    },
+    {
+        "intermediate_1": "xian1sheng5",
+        "intermediate_2": "xiānsheng",
+        "native_1": "Mr.; Sir",
+        "primary_1": "先生",
+        "primary_2": "先生"
+    },
+    {
+        "intermediate_1": "xian4zai4",
+        "intermediate_2": "xiànzài",
+        "native_1": "now",
+        "primary_1": "现在",
+        "primary_2": "現在"
+    },
+    {
+        "intermediate_1": "xiang3",
+        "intermediate_2": "xiǎng",
+        "native_1": "think; believe; suppose; would like to",
+        "primary_1": "想",
+        "primary_2": "想"
+    },
+    {
+        "intermediate_1": "xiao3",
+        "intermediate_2": "xiǎo",
+        "native_1": "small; young",
+        "primary_1": "小",
+        "primary_2": "小"
+    },
+    {
+        "intermediate_1": "xiao3jie5",
+        "intermediate_2": "xiǎojie",
+        "native_1": "young lady; miss; Ms.",
+        "primary_1": "小姐",
+        "primary_2": "小姐"
+    },
+    {
+        "intermediate_1": "xie1",
+        "intermediate_2": "xiē",
+        "native_1": "some; few; several",
+        "primary_1": "些",
+        "primary_2": "些"
+    },
+    {
+        "intermediate_1": "xie3",
+        "intermediate_2": "xiě",
+        "native_1": "to write; to compose",
+        "primary_1": "写",
+        "primary_2": "寫"
+    },
+    {
+        "intermediate_1": "xie4xie5",
+        "intermediate_2": "xièxie",
+        "native_1": "thank you",
+        "primary_1": "谢谢",
+        "primary_2": "謝謝"
+    },
+    {
+        "intermediate_1": "xing1qi1",
+        "intermediate_2": "xīngqī",
+        "native_1": "week",
+        "primary_1": "星期",
+        "primary_2": "星期"
+    },
+    {
+        "intermediate_1": "xue2sheng5",
+        "intermediate_2": "xuésheng",
+        "native_1": "student",
+        "primary_1": "学生",
+        "primary_2": "學生"
+    },
+    {
+        "intermediate_1": "xue2xi2",
+        "intermediate_2": "xuéxí",
+        "native_1": "learn; to study",
+        "primary_1": "学习",
+        "primary_2": "學習"
+    },
+    {
+        "intermediate_1": "xue2xiao4",
+        "intermediate_2": "xuéxiào",
+        "native_1": "school",
+        "primary_1": "学校",
+        "primary_2": "學校"
+    },
+    {
+        "intermediate_1": "yi1",
+        "intermediate_2": "yī",
+        "native_1": "one; once; a",
+        "primary_1": "一",
+        "primary_2": "一"
+    },
+    {
+        "intermediate_1": "yi1fu5",
+        "intermediate_2": "yīfu",
+        "native_1": "clothes",
+        "primary_1": "衣服",
+        "primary_2": "衣服"
+    },
+    {
+        "intermediate_1": "yi1sheng1",
+        "intermediate_2": "yīshēng",
+        "native_1": "doctor",
+        "primary_1": "医生",
+        "primary_2": "醫生"
+    },
+    {
+        "intermediate_1": "yi1yuan4",
+        "intermediate_2": "yīyuàn",
+        "native_1": "hospital",
+        "primary_1": "医院",
+        "primary_2": "醫院"
+    },
+    {
+        "intermediate_1": "yi3zi5",
+        "intermediate_2": "yǐzi",
+        "native_1": "chair",
+        "primary_1": "椅子",
+        "primary_2": "椅子"
+    },
+    {
+        "intermediate_1": "yi4dian3r5",
+        "intermediate_2": "yìdiǎnr",
+        "native_1": "a bit; a few",
+        "primary_1": "一点儿",
+        "primary_2": "一點兒"
+    },
+    {
+        "intermediate_1": "you3",
+        "intermediate_2": "yǒu",
+        "native_1": "have",
+        "primary_1": "有",
+        "primary_2": "有"
+    },
+    {
+        "intermediate_1": "yue4",
+        "intermediate_2": "yuè",
+        "native_1": "moon; month",
+        "primary_1": "月",
+        "primary_2": "月"
+    },
+    {
+        "intermediate_1": "zai4",
+        "intermediate_2": "zài",
+        "native_1": "at; on; in; indicates an action in progress",
+        "primary_1": "在",
+        "primary_2": "在"
+    },
+    {
+        "intermediate_1": "zai4jian4",
+        "intermediate_2": "zàijiàn",
+        "native_1": "goodbye; see you later",
+        "primary_1": "再见",
+        "primary_2": "再見"
+    },
+    {
+        "intermediate_1": "zen3me5",
+        "intermediate_2": "zěnme",
+        "native_1": "how?",
+        "primary_1": "怎么",
+        "primary_2": "怎麼"
+    },
+    {
+        "intermediate_1": "zen3me5yang4",
+        "intermediate_2": "zěnmeyàng",
+        "native_1": "how about?; how is/was it?",
+        "primary_1": "怎么样",
+        "primary_2": "怎麼樣"
+    },
+    {
+        "intermediate_1": "zhe4",
+        "intermediate_2": "zhè",
+        "native_1": "this",
+        "primary_1": "这",
+        "primary_2": "這"
+    },
+    {
+        "intermediate_1": "Zhong1guo2",
+        "intermediate_2": "Zhōngguó",
+        "native_1": "China",
+        "primary_1": "中国",
+        "primary_2": "中國"
+    },
+    {
+        "intermediate_1": "zhong1wu3",
+        "intermediate_2": "zhōngwǔ",
+        "native_1": "noon; midday",
+        "primary_1": "中午",
+        "primary_2": "中午"
+    },
+    {
+        "intermediate_1": "zhu4",
+        "intermediate_2": "zhù",
+        "native_1": "to live; reside; to stop",
+        "primary_1": "住",
+        "primary_2": "住"
+    },
+    {
+        "intermediate_1": "zhuo1zi5",
+        "intermediate_2": "zhuōzi",
+        "native_1": "table; desk",
+        "primary_1": "桌子",
+        "primary_2": "桌子"
+    },
+    {
+        "intermediate_1": "zi4",
+        "intermediate_2": "zì",
+        "native_1": "letter; character",
+        "primary_1": "字",
+        "primary_2": "字"
+    },
+    {
+        "intermediate_1": "zuo2tian1",
+        "intermediate_2": "zuótiān",
+        "native_1": "yesterday",
+        "primary_1": "昨天",
+        "primary_2": "昨天"
+    },
+    {
+        "intermediate_1": "zuo4",
+        "intermediate_2": "zuò",
+        "native_1": "do; make",
+        "primary_1": "做",
+        "primary_2": "做"
+    },
+    {
+        "intermediate_1": "zuo4",
+        "intermediate_2": "zuò",
+        "native_1": "sit",
+        "primary_1": "坐",
+        "primary_2": "坐"
+    }
+]

--- a/vocab/mandarin/hsk/2/vocab.csv
+++ b/vocab/mandarin/hsk/2/vocab.csv
@@ -1,0 +1,152 @@
+PRIMARY	PRIMARY	INTERMEDIATE	INTERMEDIATE	NATIVE
+吧	吧	ba5	ba	particle indicating polite suggestion; | onomatopoeia | bar (serving drinks, providing internet access, etc.)
+白	白	bai2	bái	white; snowy; pure; bright; empty (Kangxi radical 106)
+百	百	bai3	bǎi	hundred
+帮助	幫助	bang1zhu4	bāngzhù	help; assist; aid
+报纸	報紙	bao4zhi3	bàozhǐ	newspaper
+比	比	bi3	bǐ	compare; (indicates comparison) (Kangxi radical 81); to gesticulate as one talks
+别	別	bie2	bié	don't do something; don't | depart; | other; difference; distinguish
+宾馆	賓館	bin1guan3	bīnguǎn	guesthouse; hotel
+长	長	chang2, zhang3	cháng, zhǎng	long; length | grow; chief (Kangxi radical 168)
+唱歌	唱歌	chang4ge1	chànggē	sing (a song)
+出	出	chu1	chū	go out; occur
+穿	穿	chuan1	chuān	to wear; put on; penetrate
+次	次	ci4	cì	(mw for number of times of occurrence); nth; order
+从	從	cong2	cóng	from; obey; observe
+错	錯	cuo4	cuò	mistake; error; blunder; miss an opportunity
+打篮球	打籃球	da3 lan2qiu2	dǎ lánqiú	play basketball
+大家	大家	da4jia1	dàjiā	everyone
+到	到	dao4	dào	arrive (at a place); until (a time)
+得	得	de5	de	(complement particle)
+等	等	deng3	děng	to wait; rank; equal; etc.
+弟弟	弟弟	di4di5	dìdi	younger brother
+第一	第一	di4yi1	dìyī	first; number 1
+懂	懂	dong3	dǒng	understand; know
+对	對	dui4	duì	correct; a pair; to face; be opposite; to; towards
+房间	房間	fang2jian1	fángjiān	room
+非常	非常	fei1chang2	fēicháng	extremely; extraordinary; very
+服务员	服務員	fu2wu4yuan2	fúwùyuán	waiter/waitress; server; attendant
+高	高	gao1	gāo	high; tall (Kangxi radical 189)
+告诉	告訴	gao4su5	gàosu	to tell; inform
+哥哥	哥哥	ge1ge5	gēge	older brother
+给	給	gei3	gěi	to give; to grant; (passive particle)
+公共汽车	公共汽車	gong1gong4 qi4che1	gōnggòng qìchē	(public) bus
+公司	公司	gong1si1	gōngsī	company; corporation
+贵	貴	gui4	guì	expensive; noble; honorable; Guizhou province (abbreviation)
+过	過	guo4	guò	to pass; to cross; go over; (indicates a past experience)
+还	還	hai2	hái	still; yet; in addition; even
+孩子	孩子	hai2zi5	háizi	child; children; son or daughter
+好吃	好吃	hao3chi1	hǎochī	tasty
+黑	黑	hei1	hēi	black; dark (Kangxi radical 203); Heilongjiang province (abbreviation)
+红	紅	hong2	hóng	red; symbol of success; bonus; popular
+火车站	火車站	huo3che1zhan4	huǒchēzhàn	train station
+机场	機場	ji1chang3	jīchǎng	airport; airfield
+鸡蛋	雞蛋	ji1dan4	jīdàn	(chicken) egg
+件	件	jian4	jiàn	(mw for things, clothes, and items)
+教室	教室	jiao4shi4	jiàoshì	classroom
+姐姐	姐姐	jie3jie5	jiějie	older sister
+介绍	介紹	jie4shao4	jièshào	to introduce; recommend; introduction
+进	進	jin4	jìn	enter; come in
+近	近	jin4	jìn	near; close (to)
+就	就	jiu4	jiù	then; at once; just; only; with regard to
+觉得	覺得	jue2de5	juéde	feel; think
+咖啡	咖啡	ka1fei1	kāfēi	coffee
+开始	開始	kai1shi3	kāishǐ	begin; to start; beginning
+考试	考試	kao3shi4	kǎoshì	test; exam; to give or take a test
+可能	可能	ke3neng2	kěnéng	possible; maybe
+可以	可以	ke3yi3	kěyǐ	can; may; possible; okay
+课	課	ke4	kè	class; subject; lesson; course
+快	快	kuai4	kuài	fast; quick; swift
+快乐	快樂	kuai4le4	kuàilè	happy
+累	累	lei4	lèi	tired
+离	離	li2	lí	leave; depart; go away; apart from
+两	兩	liang3	liǎng	two; 2; both; (unit of weight equal to 50 grams)
+零	零	ling2	líng	zero; remnant
+路	路	lu4	lù	road; path; journey; route
+旅游	旅游	lv3you2	lǚyóu	trip; journey; tour
+卖	賣	mai4	mài	to sell
+慢	慢	man4	màn	slow
+忙	忙	mang2	máng	busy
+每	每	mei3	měi	each; every
+妹妹	妹妹	mei4mei5	mèimei	younger sister
+门	門	men2	mén	door; opening; gate (Kangxi radical 169)
+面条	面條	mian4tiao2	miàntiáo	noodles
+男	男	nan2	nán	male
+您	您	nin2	nín	you (polite)
+牛奶	牛奶	niu2nai3	niúnǎi	cow's milk
+女	女	nv3	nǚ	woman; female (Kangxi radical 38)
+旁边	旁邊	pang2bian1	pángbiān	side, beside
+跑步	跑步	pao3bu4	pǎobù	to run; to jog
+便宜	便宜	pian2yi5	piányi	cheap
+票	票	piao4	piào	ticket; bank note; a vote
+妻子	妻子	qi1zi5	qīzi	wife
+起床	起床	qi3chuang2	qǐ chuáng	get out of bed
+千	千	qian1	qiān	one thousand
+铅笔	鉛筆	qian1bi3	qiānbǐ	pencil
+晴	晴	qing2	qíng	clear; fine (as of weather)
+去年	去年	qu4nian2	qùnián	last year
+让	讓	rang4	ràng	ask; let; yield
+日	日	ri4	rì	sun; day; date; time (Kangxi radical 72)
+上班	上班	shang4ban1	shàngbān	go to work; be on duty
+身体	身體	shen1ti3	shēntǐ	health; (human) body
+生病	生病	sheng1bing4	shēngbìng	get sick; fall ill
+生日	生日	sheng1ri4	shēngrì	birthday
+时间	時間	shi2jian1	shíjiān	time; period
+事情	事情	shi4qing5	shìqing	matter; affair; thing; business
+手表	手表	shou3biao3	shǒubiǎo	wristwatch
+手机	手機	shou3ji1	shǒujī	mobile (cell) phone
+说话	說話	shuo1hua4	shuōhuà	to talk; speak
+送	送	song4	sòng	deliver; to carry; to give; send
+虽然	雖然	sui1ran2	suīrán	although; even though
+但是	但是	dan4shi4	dànshì	but; however
+它	它	ta1	tā	it
+踢足球	踢足球	ti1zu2qiu2	tīzúqiú	to play football/soccer
+题	題	ti2	tí	topic; subject; question on a test or assignment
+跳舞	跳舞	tiao4wu3	tiàowǔ	to dance
+外	外	wai4	wài	outer; outside; in addition; foreign
+完	完	wan2	wán	to finish; be over; complete
+玩	玩	wan2	wán	to play; have a good time; visit; enjoy
+晚上	晚上	wan3shang5	wǎnshang	evening; night
+往	往	wang3	wǎng	to go (in a direction); towards; in the past
+为什么	為什麼	wei4shen2me5	wèishénme	why?; for what reason?
+问	問	wen4	wèn	ask; inquire
+问题	問題	wen4ti2	wèntí	question; problem
+西瓜	西瓜	xi1gua1	xīguā	watermelon
+希望	希望	xi1wang4	xīwàng	to hope; wish for; to desire
+洗	洗	xi3	xǐ	to wash; bathe
+小时	小時	xiao3shi2	xiǎoshí	hour
+笑	笑	xiao4	xiào	to laugh; to smile
+新	新	xin1	xīn	new; Xinjiang autonomous region (abbreviation)
+姓	姓	xing4	xìng	surname; family name
+休息	休息	xiu1xi5	xiūxi	to rest; take a break
+雪	雪	xue3	xuě	snow
+颜色	顏色	yan2se4	yánsè	color
+眼睛	眼睛	yan3jing5	yǎnjing	eye
+羊肉	羊肉	yang2rou4	yángròu	mutton; lamb
+药	藥	yao4	yào	medicine; drug; cure; chemical
+要	要	yao4	yào	to want; to need; will/shall; important
+也	也	ye3	yě	also; too
+一起	一起	yi4qi3	yìqǐ	together; in the same place
+一下	一下	yi2xia4	yíxià	a little bit/while; one time; once
+已经	已經	yi3jing5	yǐjing	already
+意思	意思	yi4si5	yìsi	meaning; idea; opinion
+因为	因為	yin1wei4	yīnwèi	because
+所以	所以	suo3yi3	suǒyǐ	so; therefore; as a result
+阴	陰	yin1	yīn	cloudy (weather); yin (the negative principle of Yin and Yang); secret; the moon; negative; shade
+游泳	游泳	you2yong3	yóuyǒng	to swim
+右边	右邊	you4bian5	yòubian	the right (as opposed to left) side
+鱼	魚	yu2	yú	fish (Kangxi radical 195)
+远	遠	yuan3	yuǎn	far; distant; remote
+运动	運動	yun4dong4	yùndòng	(physical) exercise; movement; sports; campaign
+再	再	zai4	zài	again; once more
+早上	早上	zao3shang5	zǎoshang	(early) morning
+丈夫	丈夫	zhang4fu5	zhàngfu	husband; man
+找	找	zhao3	zhǎo	try to find; look for; seek; to give change
+着	著	zhe5	zhe	-ing (indicating action in progress)
+真	真	zhen1	zhēn	real; true; genuine
+正在	正在	zheng4zai4	zhèngzài	in the process of (doing something); currently
+知道	知道	zhi1dao5	zhīdao	know; be aware of
+准备	准備	zhun3bei4	zhǔnbèi	prepare; get ready
+走	走	zou3	zǒu	to walk; to go; to move (Kangxi radical 156)
+最	最	zui4	zuì	the most; -est; (indicator for superlative)
+左边	左邊	zuo3bian5	zuǒbian	the left side; the left

--- a/vocab/mandarin/hsk/2/vocab.json
+++ b/vocab/mandarin/hsk/2/vocab.json
@@ -1,0 +1,1059 @@
+[
+    {
+        "intermediate_1": "ba5",
+        "intermediate_2": "ba",
+        "native_1": "particle indicating polite suggestion; | onomatopoeia | bar (serving drinks, providing internet access, etc.)",
+        "primary_1": "吧",
+        "primary_2": "吧"
+    },
+    {
+        "intermediate_1": "bai2",
+        "intermediate_2": "bái",
+        "native_1": "white; snowy; pure; bright; empty (Kangxi radical 106)",
+        "primary_1": "白",
+        "primary_2": "白"
+    },
+    {
+        "intermediate_1": "bai3",
+        "intermediate_2": "bǎi",
+        "native_1": "hundred",
+        "primary_1": "百",
+        "primary_2": "百"
+    },
+    {
+        "intermediate_1": "bang1zhu4",
+        "intermediate_2": "bāngzhù",
+        "native_1": "help; assist; aid",
+        "primary_1": "帮助",
+        "primary_2": "幫助"
+    },
+    {
+        "intermediate_1": "bao4zhi3",
+        "intermediate_2": "bàozhǐ",
+        "native_1": "newspaper",
+        "primary_1": "报纸",
+        "primary_2": "報紙"
+    },
+    {
+        "intermediate_1": "bi3",
+        "intermediate_2": "bǐ",
+        "native_1": "compare; (indicates comparison) (Kangxi radical 81); to gesticulate as one talks",
+        "primary_1": "比",
+        "primary_2": "比"
+    },
+    {
+        "intermediate_1": "bie2",
+        "intermediate_2": "bié",
+        "native_1": "don't do something; don't | depart; | other; difference; distinguish",
+        "primary_1": "别",
+        "primary_2": "別"
+    },
+    {
+        "intermediate_1": "bin1guan3",
+        "intermediate_2": "bīnguǎn",
+        "native_1": "guesthouse; hotel",
+        "primary_1": "宾馆",
+        "primary_2": "賓館"
+    },
+    {
+        "intermediate_1": "chang2, zhang3",
+        "intermediate_2": "cháng, zhǎng",
+        "native_1": "long; length | grow; chief (Kangxi radical 168)",
+        "primary_1": "长",
+        "primary_2": "長"
+    },
+    {
+        "intermediate_1": "chang4ge1",
+        "intermediate_2": "chànggē",
+        "native_1": "sing (a song)",
+        "primary_1": "唱歌",
+        "primary_2": "唱歌"
+    },
+    {
+        "intermediate_1": "chu1",
+        "intermediate_2": "chū",
+        "native_1": "go out; occur",
+        "primary_1": "出",
+        "primary_2": "出"
+    },
+    {
+        "intermediate_1": "chuan1",
+        "intermediate_2": "chuān",
+        "native_1": "to wear; put on; penetrate",
+        "primary_1": "穿",
+        "primary_2": "穿"
+    },
+    {
+        "intermediate_1": "ci4",
+        "intermediate_2": "cì",
+        "native_1": "(mw for number of times of occurrence); nth; order",
+        "primary_1": "次",
+        "primary_2": "次"
+    },
+    {
+        "intermediate_1": "cong2",
+        "intermediate_2": "cóng",
+        "native_1": "from; obey; observe",
+        "primary_1": "从",
+        "primary_2": "從"
+    },
+    {
+        "intermediate_1": "cuo4",
+        "intermediate_2": "cuò",
+        "native_1": "mistake; error; blunder; miss an opportunity",
+        "primary_1": "错",
+        "primary_2": "錯"
+    },
+    {
+        "intermediate_1": "da3 lan2qiu2",
+        "intermediate_2": "dǎ lánqiú",
+        "native_1": "play basketball",
+        "primary_1": "打篮球",
+        "primary_2": "打籃球"
+    },
+    {
+        "intermediate_1": "da4jia1",
+        "intermediate_2": "dàjiā",
+        "native_1": "everyone",
+        "primary_1": "大家",
+        "primary_2": "大家"
+    },
+    {
+        "intermediate_1": "dao4",
+        "intermediate_2": "dào",
+        "native_1": "arrive (at a place); until (a time)",
+        "primary_1": "到",
+        "primary_2": "到"
+    },
+    {
+        "intermediate_1": "de5",
+        "intermediate_2": "de",
+        "native_1": "(complement particle)",
+        "primary_1": "得",
+        "primary_2": "得"
+    },
+    {
+        "intermediate_1": "deng3",
+        "intermediate_2": "děng",
+        "native_1": "to wait; rank; equal; etc.",
+        "primary_1": "等",
+        "primary_2": "等"
+    },
+    {
+        "intermediate_1": "di4di5",
+        "intermediate_2": "dìdi",
+        "native_1": "younger brother",
+        "primary_1": "弟弟",
+        "primary_2": "弟弟"
+    },
+    {
+        "intermediate_1": "di4yi1",
+        "intermediate_2": "dìyī",
+        "native_1": "first; number 1",
+        "primary_1": "第一",
+        "primary_2": "第一"
+    },
+    {
+        "intermediate_1": "dong3",
+        "intermediate_2": "dǒng",
+        "native_1": "understand; know",
+        "primary_1": "懂",
+        "primary_2": "懂"
+    },
+    {
+        "intermediate_1": "dui4",
+        "intermediate_2": "duì",
+        "native_1": "correct; a pair; to face; be opposite; to; towards",
+        "primary_1": "对",
+        "primary_2": "對"
+    },
+    {
+        "intermediate_1": "fang2jian1",
+        "intermediate_2": "fángjiān",
+        "native_1": "room",
+        "primary_1": "房间",
+        "primary_2": "房間"
+    },
+    {
+        "intermediate_1": "fei1chang2",
+        "intermediate_2": "fēicháng",
+        "native_1": "extremely; extraordinary; very",
+        "primary_1": "非常",
+        "primary_2": "非常"
+    },
+    {
+        "intermediate_1": "fu2wu4yuan2",
+        "intermediate_2": "fúwùyuán",
+        "native_1": "waiter/waitress; server; attendant",
+        "primary_1": "服务员",
+        "primary_2": "服務員"
+    },
+    {
+        "intermediate_1": "gao1",
+        "intermediate_2": "gāo",
+        "native_1": "high; tall (Kangxi radical 189)",
+        "primary_1": "高",
+        "primary_2": "高"
+    },
+    {
+        "intermediate_1": "gao4su5",
+        "intermediate_2": "gàosu",
+        "native_1": "to tell; inform",
+        "primary_1": "告诉",
+        "primary_2": "告訴"
+    },
+    {
+        "intermediate_1": "ge1ge5",
+        "intermediate_2": "gēge",
+        "native_1": "older brother",
+        "primary_1": "哥哥",
+        "primary_2": "哥哥"
+    },
+    {
+        "intermediate_1": "gei3",
+        "intermediate_2": "gěi",
+        "native_1": "to give; to grant; (passive particle)",
+        "primary_1": "给",
+        "primary_2": "給"
+    },
+    {
+        "intermediate_1": "gong1gong4 qi4che1",
+        "intermediate_2": "gōnggòng qìchē",
+        "native_1": "(public) bus",
+        "primary_1": "公共汽车",
+        "primary_2": "公共汽車"
+    },
+    {
+        "intermediate_1": "gong1si1",
+        "intermediate_2": "gōngsī",
+        "native_1": "company; corporation",
+        "primary_1": "公司",
+        "primary_2": "公司"
+    },
+    {
+        "intermediate_1": "gui4",
+        "intermediate_2": "guì",
+        "native_1": "expensive; noble; honorable; Guizhou province (abbreviation)",
+        "primary_1": "贵",
+        "primary_2": "貴"
+    },
+    {
+        "intermediate_1": "guo4",
+        "intermediate_2": "guò",
+        "native_1": "to pass; to cross; go over; (indicates a past experience)",
+        "primary_1": "过",
+        "primary_2": "過"
+    },
+    {
+        "intermediate_1": "hai2",
+        "intermediate_2": "hái",
+        "native_1": "still; yet; in addition; even",
+        "primary_1": "还",
+        "primary_2": "還"
+    },
+    {
+        "intermediate_1": "hai2zi5",
+        "intermediate_2": "háizi",
+        "native_1": "child; children; son or daughter",
+        "primary_1": "孩子",
+        "primary_2": "孩子"
+    },
+    {
+        "intermediate_1": "hao3chi1",
+        "intermediate_2": "hǎochī",
+        "native_1": "tasty",
+        "primary_1": "好吃",
+        "primary_2": "好吃"
+    },
+    {
+        "intermediate_1": "hei1",
+        "intermediate_2": "hēi",
+        "native_1": "black; dark (Kangxi radical 203); Heilongjiang province (abbreviation)",
+        "primary_1": "黑",
+        "primary_2": "黑"
+    },
+    {
+        "intermediate_1": "hong2",
+        "intermediate_2": "hóng",
+        "native_1": "red; symbol of success; bonus; popular",
+        "primary_1": "红",
+        "primary_2": "紅"
+    },
+    {
+        "intermediate_1": "huo3che1zhan4",
+        "intermediate_2": "huǒchēzhàn",
+        "native_1": "train station",
+        "primary_1": "火车站",
+        "primary_2": "火車站"
+    },
+    {
+        "intermediate_1": "ji1chang3",
+        "intermediate_2": "jīchǎng",
+        "native_1": "airport; airfield",
+        "primary_1": "机场",
+        "primary_2": "機場"
+    },
+    {
+        "intermediate_1": "ji1dan4",
+        "intermediate_2": "jīdàn",
+        "native_1": "(chicken) egg",
+        "primary_1": "鸡蛋",
+        "primary_2": "雞蛋"
+    },
+    {
+        "intermediate_1": "jian4",
+        "intermediate_2": "jiàn",
+        "native_1": "(mw for things, clothes, and items)",
+        "primary_1": "件",
+        "primary_2": "件"
+    },
+    {
+        "intermediate_1": "jiao4shi4",
+        "intermediate_2": "jiàoshì",
+        "native_1": "classroom",
+        "primary_1": "教室",
+        "primary_2": "教室"
+    },
+    {
+        "intermediate_1": "jie3jie5",
+        "intermediate_2": "jiějie",
+        "native_1": "older sister",
+        "primary_1": "姐姐",
+        "primary_2": "姐姐"
+    },
+    {
+        "intermediate_1": "jie4shao4",
+        "intermediate_2": "jièshào",
+        "native_1": "to introduce; recommend; introduction",
+        "primary_1": "介绍",
+        "primary_2": "介紹"
+    },
+    {
+        "intermediate_1": "jin4",
+        "intermediate_2": "jìn",
+        "native_1": "enter; come in",
+        "primary_1": "进",
+        "primary_2": "進"
+    },
+    {
+        "intermediate_1": "jin4",
+        "intermediate_2": "jìn",
+        "native_1": "near; close (to)",
+        "primary_1": "近",
+        "primary_2": "近"
+    },
+    {
+        "intermediate_1": "jiu4",
+        "intermediate_2": "jiù",
+        "native_1": "then; at once; just; only; with regard to",
+        "primary_1": "就",
+        "primary_2": "就"
+    },
+    {
+        "intermediate_1": "jue2de5",
+        "intermediate_2": "juéde",
+        "native_1": "feel; think",
+        "primary_1": "觉得",
+        "primary_2": "覺得"
+    },
+    {
+        "intermediate_1": "ka1fei1",
+        "intermediate_2": "kāfēi",
+        "native_1": "coffee",
+        "primary_1": "咖啡",
+        "primary_2": "咖啡"
+    },
+    {
+        "intermediate_1": "kai1shi3",
+        "intermediate_2": "kāishǐ",
+        "native_1": "begin; to start; beginning",
+        "primary_1": "开始",
+        "primary_2": "開始"
+    },
+    {
+        "intermediate_1": "kao3shi4",
+        "intermediate_2": "kǎoshì",
+        "native_1": "test; exam; to give or take a test",
+        "primary_1": "考试",
+        "primary_2": "考試"
+    },
+    {
+        "intermediate_1": "ke3neng2",
+        "intermediate_2": "kěnéng",
+        "native_1": "possible; maybe",
+        "primary_1": "可能",
+        "primary_2": "可能"
+    },
+    {
+        "intermediate_1": "ke3yi3",
+        "intermediate_2": "kěyǐ",
+        "native_1": "can; may; possible; okay",
+        "primary_1": "可以",
+        "primary_2": "可以"
+    },
+    {
+        "intermediate_1": "ke4",
+        "intermediate_2": "kè",
+        "native_1": "class; subject; lesson; course",
+        "primary_1": "课",
+        "primary_2": "課"
+    },
+    {
+        "intermediate_1": "kuai4",
+        "intermediate_2": "kuài",
+        "native_1": "fast; quick; swift",
+        "primary_1": "快",
+        "primary_2": "快"
+    },
+    {
+        "intermediate_1": "kuai4le4",
+        "intermediate_2": "kuàilè",
+        "native_1": "happy",
+        "primary_1": "快乐",
+        "primary_2": "快樂"
+    },
+    {
+        "intermediate_1": "lei4",
+        "intermediate_2": "lèi",
+        "native_1": "tired",
+        "primary_1": "累",
+        "primary_2": "累"
+    },
+    {
+        "intermediate_1": "li2",
+        "intermediate_2": "lí",
+        "native_1": "leave; depart; go away; apart from",
+        "primary_1": "离",
+        "primary_2": "離"
+    },
+    {
+        "intermediate_1": "liang3",
+        "intermediate_2": "liǎng",
+        "native_1": "two; 2; both; (unit of weight equal to 50 grams)",
+        "primary_1": "两",
+        "primary_2": "兩"
+    },
+    {
+        "intermediate_1": "ling2",
+        "intermediate_2": "líng",
+        "native_1": "zero; remnant",
+        "primary_1": "零",
+        "primary_2": "零"
+    },
+    {
+        "intermediate_1": "lu4",
+        "intermediate_2": "lù",
+        "native_1": "road; path; journey; route",
+        "primary_1": "路",
+        "primary_2": "路"
+    },
+    {
+        "intermediate_1": "lv3you2",
+        "intermediate_2": "lǚyóu",
+        "native_1": "trip; journey; tour",
+        "primary_1": "旅游",
+        "primary_2": "旅游"
+    },
+    {
+        "intermediate_1": "mai4",
+        "intermediate_2": "mài",
+        "native_1": "to sell",
+        "primary_1": "卖",
+        "primary_2": "賣"
+    },
+    {
+        "intermediate_1": "man4",
+        "intermediate_2": "màn",
+        "native_1": "slow",
+        "primary_1": "慢",
+        "primary_2": "慢"
+    },
+    {
+        "intermediate_1": "mang2",
+        "intermediate_2": "máng",
+        "native_1": "busy",
+        "primary_1": "忙",
+        "primary_2": "忙"
+    },
+    {
+        "intermediate_1": "mei3",
+        "intermediate_2": "měi",
+        "native_1": "each; every",
+        "primary_1": "每",
+        "primary_2": "每"
+    },
+    {
+        "intermediate_1": "mei4mei5",
+        "intermediate_2": "mèimei",
+        "native_1": "younger sister",
+        "primary_1": "妹妹",
+        "primary_2": "妹妹"
+    },
+    {
+        "intermediate_1": "men2",
+        "intermediate_2": "mén",
+        "native_1": "door; opening; gate (Kangxi radical 169)",
+        "primary_1": "门",
+        "primary_2": "門"
+    },
+    {
+        "intermediate_1": "mian4tiao2",
+        "intermediate_2": "miàntiáo",
+        "native_1": "noodles",
+        "primary_1": "面条",
+        "primary_2": "面條"
+    },
+    {
+        "intermediate_1": "nan2",
+        "intermediate_2": "nán",
+        "native_1": "male",
+        "primary_1": "男",
+        "primary_2": "男"
+    },
+    {
+        "intermediate_1": "nin2",
+        "intermediate_2": "nín",
+        "native_1": "you (polite)",
+        "primary_1": "您",
+        "primary_2": "您"
+    },
+    {
+        "intermediate_1": "niu2nai3",
+        "intermediate_2": "niúnǎi",
+        "native_1": "cow's milk",
+        "primary_1": "牛奶",
+        "primary_2": "牛奶"
+    },
+    {
+        "intermediate_1": "nv3",
+        "intermediate_2": "nǚ",
+        "native_1": "woman; female (Kangxi radical 38)",
+        "primary_1": "女",
+        "primary_2": "女"
+    },
+    {
+        "intermediate_1": "pang2bian1",
+        "intermediate_2": "pángbiān",
+        "native_1": "side, beside",
+        "primary_1": "旁边",
+        "primary_2": "旁邊"
+    },
+    {
+        "intermediate_1": "pao3bu4",
+        "intermediate_2": "pǎobù",
+        "native_1": "to run; to jog",
+        "primary_1": "跑步",
+        "primary_2": "跑步"
+    },
+    {
+        "intermediate_1": "pian2yi5",
+        "intermediate_2": "piányi",
+        "native_1": "cheap",
+        "primary_1": "便宜",
+        "primary_2": "便宜"
+    },
+    {
+        "intermediate_1": "piao4",
+        "intermediate_2": "piào",
+        "native_1": "ticket; bank note; a vote",
+        "primary_1": "票",
+        "primary_2": "票"
+    },
+    {
+        "intermediate_1": "qi1zi5",
+        "intermediate_2": "qīzi",
+        "native_1": "wife",
+        "primary_1": "妻子",
+        "primary_2": "妻子"
+    },
+    {
+        "intermediate_1": "qi3chuang2",
+        "intermediate_2": "qǐ chuáng",
+        "native_1": "get out of bed",
+        "primary_1": "起床",
+        "primary_2": "起床"
+    },
+    {
+        "intermediate_1": "qian1",
+        "intermediate_2": "qiān",
+        "native_1": "one thousand",
+        "primary_1": "千",
+        "primary_2": "千"
+    },
+    {
+        "intermediate_1": "qian1bi3",
+        "intermediate_2": "qiānbǐ",
+        "native_1": "pencil",
+        "primary_1": "铅笔",
+        "primary_2": "鉛筆"
+    },
+    {
+        "intermediate_1": "qing2",
+        "intermediate_2": "qíng",
+        "native_1": "clear; fine (as of weather)",
+        "primary_1": "晴",
+        "primary_2": "晴"
+    },
+    {
+        "intermediate_1": "qu4nian2",
+        "intermediate_2": "qùnián",
+        "native_1": "last year",
+        "primary_1": "去年",
+        "primary_2": "去年"
+    },
+    {
+        "intermediate_1": "rang4",
+        "intermediate_2": "ràng",
+        "native_1": "ask; let; yield",
+        "primary_1": "让",
+        "primary_2": "讓"
+    },
+    {
+        "intermediate_1": "ri4",
+        "intermediate_2": "rì",
+        "native_1": "sun; day; date; time (Kangxi radical 72)",
+        "primary_1": "日",
+        "primary_2": "日"
+    },
+    {
+        "intermediate_1": "shang4ban1",
+        "intermediate_2": "shàngbān",
+        "native_1": "go to work; be on duty",
+        "primary_1": "上班",
+        "primary_2": "上班"
+    },
+    {
+        "intermediate_1": "shen1ti3",
+        "intermediate_2": "shēntǐ",
+        "native_1": "health; (human) body",
+        "primary_1": "身体",
+        "primary_2": "身體"
+    },
+    {
+        "intermediate_1": "sheng1bing4",
+        "intermediate_2": "shēngbìng",
+        "native_1": "get sick; fall ill",
+        "primary_1": "生病",
+        "primary_2": "生病"
+    },
+    {
+        "intermediate_1": "sheng1ri4",
+        "intermediate_2": "shēngrì",
+        "native_1": "birthday",
+        "primary_1": "生日",
+        "primary_2": "生日"
+    },
+    {
+        "intermediate_1": "shi2jian1",
+        "intermediate_2": "shíjiān",
+        "native_1": "time; period",
+        "primary_1": "时间",
+        "primary_2": "時間"
+    },
+    {
+        "intermediate_1": "shi4qing5",
+        "intermediate_2": "shìqing",
+        "native_1": "matter; affair; thing; business",
+        "primary_1": "事情",
+        "primary_2": "事情"
+    },
+    {
+        "intermediate_1": "shou3biao3",
+        "intermediate_2": "shǒubiǎo",
+        "native_1": "wristwatch",
+        "primary_1": "手表",
+        "primary_2": "手表"
+    },
+    {
+        "intermediate_1": "shou3ji1",
+        "intermediate_2": "shǒujī",
+        "native_1": "mobile (cell) phone",
+        "primary_1": "手机",
+        "primary_2": "手機"
+    },
+    {
+        "intermediate_1": "shuo1hua4",
+        "intermediate_2": "shuōhuà",
+        "native_1": "to talk; speak",
+        "primary_1": "说话",
+        "primary_2": "說話"
+    },
+    {
+        "intermediate_1": "song4",
+        "intermediate_2": "sòng",
+        "native_1": "deliver; to carry; to give; send",
+        "primary_1": "送",
+        "primary_2": "送"
+    },
+    {
+        "intermediate_1": "sui1ran2",
+        "intermediate_2": "suīrán",
+        "native_1": "although; even though",
+        "primary_1": "虽然",
+        "primary_2": "雖然"
+    },
+    {
+        "intermediate_1": "dan4shi4",
+        "intermediate_2": "dànshì",
+        "native_1": "but; however",
+        "primary_1": "但是",
+        "primary_2": "但是"
+    },
+    {
+        "intermediate_1": "ta1",
+        "intermediate_2": "tā",
+        "native_1": "it",
+        "primary_1": "它",
+        "primary_2": "它"
+    },
+    {
+        "intermediate_1": "ti1zu2qiu2",
+        "intermediate_2": "tīzúqiú",
+        "native_1": "to play football/soccer",
+        "primary_1": "踢足球",
+        "primary_2": "踢足球"
+    },
+    {
+        "intermediate_1": "ti2",
+        "intermediate_2": "tí",
+        "native_1": "topic; subject; question on a test or assignment",
+        "primary_1": "题",
+        "primary_2": "題"
+    },
+    {
+        "intermediate_1": "tiao4wu3",
+        "intermediate_2": "tiàowǔ",
+        "native_1": "to dance",
+        "primary_1": "跳舞",
+        "primary_2": "跳舞"
+    },
+    {
+        "intermediate_1": "wai4",
+        "intermediate_2": "wài",
+        "native_1": "outer; outside; in addition; foreign",
+        "primary_1": "外",
+        "primary_2": "外"
+    },
+    {
+        "intermediate_1": "wan2",
+        "intermediate_2": "wán",
+        "native_1": "to finish; be over; complete",
+        "primary_1": "完",
+        "primary_2": "完"
+    },
+    {
+        "intermediate_1": "wan2",
+        "intermediate_2": "wán",
+        "native_1": "to play; have a good time; visit; enjoy",
+        "primary_1": "玩",
+        "primary_2": "玩"
+    },
+    {
+        "intermediate_1": "wan3shang5",
+        "intermediate_2": "wǎnshang",
+        "native_1": "evening; night",
+        "primary_1": "晚上",
+        "primary_2": "晚上"
+    },
+    {
+        "intermediate_1": "wang3",
+        "intermediate_2": "wǎng",
+        "native_1": "to go (in a direction); towards; in the past",
+        "primary_1": "往",
+        "primary_2": "往"
+    },
+    {
+        "intermediate_1": "wei4shen2me5",
+        "intermediate_2": "wèishénme",
+        "native_1": "why?; for what reason?",
+        "primary_1": "为什么",
+        "primary_2": "為什麼"
+    },
+    {
+        "intermediate_1": "wen4",
+        "intermediate_2": "wèn",
+        "native_1": "ask; inquire",
+        "primary_1": "问",
+        "primary_2": "問"
+    },
+    {
+        "intermediate_1": "wen4ti2",
+        "intermediate_2": "wèntí",
+        "native_1": "question; problem",
+        "primary_1": "问题",
+        "primary_2": "問題"
+    },
+    {
+        "intermediate_1": "xi1gua1",
+        "intermediate_2": "xīguā",
+        "native_1": "watermelon",
+        "primary_1": "西瓜",
+        "primary_2": "西瓜"
+    },
+    {
+        "intermediate_1": "xi1wang4",
+        "intermediate_2": "xīwàng",
+        "native_1": "to hope; wish for; to desire",
+        "primary_1": "希望",
+        "primary_2": "希望"
+    },
+    {
+        "intermediate_1": "xi3",
+        "intermediate_2": "xǐ",
+        "native_1": "to wash; bathe",
+        "primary_1": "洗",
+        "primary_2": "洗"
+    },
+    {
+        "intermediate_1": "xiao3shi2",
+        "intermediate_2": "xiǎoshí",
+        "native_1": "hour",
+        "primary_1": "小时",
+        "primary_2": "小時"
+    },
+    {
+        "intermediate_1": "xiao4",
+        "intermediate_2": "xiào",
+        "native_1": "to laugh; to smile",
+        "primary_1": "笑",
+        "primary_2": "笑"
+    },
+    {
+        "intermediate_1": "xin1",
+        "intermediate_2": "xīn",
+        "native_1": "new; Xinjiang autonomous region (abbreviation)",
+        "primary_1": "新",
+        "primary_2": "新"
+    },
+    {
+        "intermediate_1": "xing4",
+        "intermediate_2": "xìng",
+        "native_1": "surname; family name",
+        "primary_1": "姓",
+        "primary_2": "姓"
+    },
+    {
+        "intermediate_1": "xiu1xi5",
+        "intermediate_2": "xiūxi",
+        "native_1": "to rest; take a break",
+        "primary_1": "休息",
+        "primary_2": "休息"
+    },
+    {
+        "intermediate_1": "xue3",
+        "intermediate_2": "xuě",
+        "native_1": "snow",
+        "primary_1": "雪",
+        "primary_2": "雪"
+    },
+    {
+        "intermediate_1": "yan2se4",
+        "intermediate_2": "yánsè",
+        "native_1": "color",
+        "primary_1": "颜色",
+        "primary_2": "顏色"
+    },
+    {
+        "intermediate_1": "yan3jing5",
+        "intermediate_2": "yǎnjing",
+        "native_1": "eye",
+        "primary_1": "眼睛",
+        "primary_2": "眼睛"
+    },
+    {
+        "intermediate_1": "yang2rou4",
+        "intermediate_2": "yángròu",
+        "native_1": "mutton; lamb",
+        "primary_1": "羊肉",
+        "primary_2": "羊肉"
+    },
+    {
+        "intermediate_1": "yao4",
+        "intermediate_2": "yào",
+        "native_1": "medicine; drug; cure; chemical",
+        "primary_1": "药",
+        "primary_2": "藥"
+    },
+    {
+        "intermediate_1": "yao4",
+        "intermediate_2": "yào",
+        "native_1": "to want; to need; will/shall; important",
+        "primary_1": "要",
+        "primary_2": "要"
+    },
+    {
+        "intermediate_1": "ye3",
+        "intermediate_2": "yě",
+        "native_1": "also; too",
+        "primary_1": "也",
+        "primary_2": "也"
+    },
+    {
+        "intermediate_1": "yi4qi3",
+        "intermediate_2": "yìqǐ",
+        "native_1": "together; in the same place",
+        "primary_1": "一起",
+        "primary_2": "一起"
+    },
+    {
+        "intermediate_1": "yi2xia4",
+        "intermediate_2": "yíxià",
+        "native_1": "a little bit/while; one time; once",
+        "primary_1": "一下",
+        "primary_2": "一下"
+    },
+    {
+        "intermediate_1": "yi3jing5",
+        "intermediate_2": "yǐjing",
+        "native_1": "already",
+        "primary_1": "已经",
+        "primary_2": "已經"
+    },
+    {
+        "intermediate_1": "yi4si5",
+        "intermediate_2": "yìsi",
+        "native_1": "meaning; idea; opinion",
+        "primary_1": "意思",
+        "primary_2": "意思"
+    },
+    {
+        "intermediate_1": "yin1wei4",
+        "intermediate_2": "yīnwèi",
+        "native_1": "because",
+        "primary_1": "因为",
+        "primary_2": "因為"
+    },
+    {
+        "intermediate_1": "suo3yi3",
+        "intermediate_2": "suǒyǐ",
+        "native_1": "so; therefore; as a result",
+        "primary_1": "所以",
+        "primary_2": "所以"
+    },
+    {
+        "intermediate_1": "yin1",
+        "intermediate_2": "yīn",
+        "native_1": "cloudy (weather); yin (the negative principle of Yin and Yang); secret; the moon; negative; shade",
+        "primary_1": "阴",
+        "primary_2": "陰"
+    },
+    {
+        "intermediate_1": "you2yong3",
+        "intermediate_2": "yóuyǒng",
+        "native_1": "to swim",
+        "primary_1": "游泳",
+        "primary_2": "游泳"
+    },
+    {
+        "intermediate_1": "you4bian5",
+        "intermediate_2": "yòubian",
+        "native_1": "the right (as opposed to left) side",
+        "primary_1": "右边",
+        "primary_2": "右邊"
+    },
+    {
+        "intermediate_1": "yu2",
+        "intermediate_2": "yú",
+        "native_1": "fish (Kangxi radical 195)",
+        "primary_1": "鱼",
+        "primary_2": "魚"
+    },
+    {
+        "intermediate_1": "yuan3",
+        "intermediate_2": "yuǎn",
+        "native_1": "far; distant; remote",
+        "primary_1": "远",
+        "primary_2": "遠"
+    },
+    {
+        "intermediate_1": "yun4dong4",
+        "intermediate_2": "yùndòng",
+        "native_1": "(physical) exercise; movement; sports; campaign",
+        "primary_1": "运动",
+        "primary_2": "運動"
+    },
+    {
+        "intermediate_1": "zai4",
+        "intermediate_2": "zài",
+        "native_1": "again; once more",
+        "primary_1": "再",
+        "primary_2": "再"
+    },
+    {
+        "intermediate_1": "zao3shang5",
+        "intermediate_2": "zǎoshang",
+        "native_1": "(early) morning",
+        "primary_1": "早上",
+        "primary_2": "早上"
+    },
+    {
+        "intermediate_1": "zhang4fu5",
+        "intermediate_2": "zhàngfu",
+        "native_1": "husband; man",
+        "primary_1": "丈夫",
+        "primary_2": "丈夫"
+    },
+    {
+        "intermediate_1": "zhao3",
+        "intermediate_2": "zhǎo",
+        "native_1": "try to find; look for; seek; to give change",
+        "primary_1": "找",
+        "primary_2": "找"
+    },
+    {
+        "intermediate_1": "zhe5",
+        "intermediate_2": "zhe",
+        "native_1": "-ing (indicating action in progress)",
+        "primary_1": "着",
+        "primary_2": "著"
+    },
+    {
+        "intermediate_1": "zhen1",
+        "intermediate_2": "zhēn",
+        "native_1": "real; true; genuine",
+        "primary_1": "真",
+        "primary_2": "真"
+    },
+    {
+        "intermediate_1": "zheng4zai4",
+        "intermediate_2": "zhèngzài",
+        "native_1": "in the process of (doing something); currently",
+        "primary_1": "正在",
+        "primary_2": "正在"
+    },
+    {
+        "intermediate_1": "zhi1dao5",
+        "intermediate_2": "zhīdao",
+        "native_1": "know; be aware of",
+        "primary_1": "知道",
+        "primary_2": "知道"
+    },
+    {
+        "intermediate_1": "zhun3bei4",
+        "intermediate_2": "zhǔnbèi",
+        "native_1": "prepare; get ready",
+        "primary_1": "准备",
+        "primary_2": "准備"
+    },
+    {
+        "intermediate_1": "zou3",
+        "intermediate_2": "zǒu",
+        "native_1": "to walk; to go; to move (Kangxi radical 156)",
+        "primary_1": "走",
+        "primary_2": "走"
+    },
+    {
+        "intermediate_1": "zui4",
+        "intermediate_2": "zuì",
+        "native_1": "the most; -est; (indicator for superlative)",
+        "primary_1": "最",
+        "primary_2": "最"
+    },
+    {
+        "intermediate_1": "zuo3bian5",
+        "intermediate_2": "zuǒbian",
+        "native_1": "the left side; the left",
+        "primary_1": "左边",
+        "primary_2": "左邊"
+    }
+]

--- a/vocab/mandarin/hsk/3/vocab.csv
+++ b/vocab/mandarin/hsk/3/vocab.csv
@@ -1,0 +1,301 @@
+PRIMARY	PRIMARY	INTERMEDIATE	INTERMEDIATE	NATIVE
+阿姨	阿姨	a1yi2	āyí	auntie; step-mother; mother's younger sister	
+啊	啊	a5	a	ah; (particle showing elation, doubt, puzzled surprise, or approval)	
+矮	矮	ai3	ǎi	short; low	
+爱好	愛好	ai4hao4	àihào	hobby; fond of; to like; interest	
+安静	安靜	an1jing4	ānjìng	quiet; peaceful; calm	
+把	把	ba3	bǎ	(mw for things with handles); (pretransitive particle); to hold	
+班	班	ban1	bān	team; class; squad	
+搬	搬	ban1	bān	to move; to transport	
+办法	辦法	ban4fa3	bànfǎ	method; way (of doing something)	
+办公室	辦公室	ban4gong1shi4	bàngōngshì	office	
+半	半	ban4	bàn	half; semi-; incomplete	
+帮忙	幫忙	bang1mang2	bāngmáng	to help	
+包	包	bao1	bāo	to cover; to wrap; to hold; include; (mw for containers, packages, etc.)	
+饱	飽	bao3	bǎo	eat until full; satisfied	
+北方	北方	bei3fang1	běifāng	north; the northern part of the country	
+被	被	bei4	bèi	by (indicates passive voice sentences); a quilt/blanket	
+鼻子	鼻子	bi2zi5	bízi	nose	
+比较	比較	bi3jiao4	bǐjiào	compare; contrast; relatively	
+比赛	比賽	bi3sai4	bǐsài	(sports) match; competition	
+笔记本	筆記本	bi3ji4ben3	bǐjìběn	notebook	
+必须	必須	bi4xu1	bìxū	must; have to	
+变化	變化	bian4hua4	biànhuà	change	
+别人	別人	bie2ren5	biéren	other people; others	
+冰箱	冰箱	bing1xiang1	bīngxiāng	refrigerator	
+不但	不但	bu2dan4	búdàn	not only	
+而且	而且	er2qie3	érqiě	moreover; in addition; as well as	
+菜单	菜單	cai4dan1	càidān	menu	
+参加	參加	can1jia1	cānjiā	participate; join; take part in	
+草	草	cao3	cǎo	grass; straw; draft (of a document)	
+层	層	ceng2	céng	(mw for layers, floors of buildings)	
+差	差	cha4	chà	differ from; fall short of; poor; inferior
+超市	超市	chao1shi4	chāoshì	supermarket	
+衬衫	襯衫	chen4shan1	chènshān	shirt; blouse	
+成绩	成績	cheng2ji4	chéngjì	achievement; success; results (of work or study)	
+城市	城市	cheng2shi4	chéngshì	city or town	
+迟到	遲到	chi2dao4	chídào	arrive late	
+除了	除了	chu2le5	chúle	besides; except for; aside from; in addition to	
+船	船	chuan2	chuán	a boat; vessel; ship	
+春	春	chun1	chūn	spring (season); joyful	
+词典	詞典	ci2dian3	cídiǎn	dictionary	
+聪明	聰明	cong1ming5	cōngming	intelligent; clever; bright; smart	
+打扫	打掃	da3sao3	dǎsǎo	to clean; to sweep	
+打算	打算	da3suan4	dǎsuàn	to plan; intend	
+带	帶	dai4	dài	band; belt; ribbon; carry; bring; take along; bring up (kids)	
+担心	擔心	dan1xin1	dānxīn	to worry; feel anxious	
+蛋糕	蛋糕	dan4gao1	dàngāo	cake	
+当然	當然	dang1ran2	dāngrán	of course; naturally	
+地	地	di4, de5	dì, de	earth; ground | (adverbial particle)	
+灯	燈	deng1	dēng	lamp; light	
+地方	地方	di4fang5	dìfang	place; space; room; part, (fāng: local; regional)	
+地铁	地鐵	di4tie3	dìtiě	subway	
+地图	地圖	di4tu2	dìtú	map	
+电梯	電梯	dian4ti1	diàntī	elevator	
+电子邮件	電子郵件	dian4zi3 you2jian4	diànzǐ yóujiàn	email	
+东	東	dong1	dōng	East	
+冬	冬	dong1	dōng	winter	
+动物	動物	dong4wu4	dòngwù	animal	
+短	短	duan3	duǎn	short (in length, duration, or height); lack	
+段	段	duan4	duàn	paragraph; segment; section	
+锻炼	鍛煉	duan4lian4	duànliàn	to exercise; work out; toughen; to temper	
+多么	多麼	duo1me5	duōme	how (wonderful, etc.); what (a great idea)	
+饿	餓	e4	è	hungry	
+耳朵	耳朵	er3duo5	ěrduo	ear	
+发	發	fa1, fa4	fā, fà	send out; to issue; to show (one's feelings) | hair	
+发烧	發燒	fa1shao1	fāshāo	have a fever	
+发现	發現	fa1xian4	fāxiàn	discover; to find	
+方便	方便	fang1bian4	fāngbiàn	convenient	
+放	放	fang4	fàng	put; to place; to release; to free	
+放心	放心	fang4xin1	fàngxīn	relax; feel relieved; rest assured	
+分	分	fen1, fen4	fēn, fèn	divide; part; minute; cent | component; share; ingredient	
+附近	附近	fu4jin4	fùjìn	(in the) vicinity; nearby; neighboring	
+复习	復習	fu4xi2	fùxí	revise; to review	
+干净	干淨	gan1jing4	gānjìng	clean; neat and tidy	
+感冒	感冒	gan3mao4	gǎnmào	catch cold; (common) cold	
+感兴趣	感興趣	gan3 xing4qu4	gǎn xìngqù	be interested in	
+刚才	剛才	gang1cai2	gāngcái	just now; a moment ago	
+个子	個子	ge4zi5	gèzi	height; stature; build	
+根据	根據	gen1ju4	gēnjù	according to; based on; basis	
+跟	跟	gen1	gēn	to follow; go with; heel	
+更	更	geng4	gèng	more; even more
+公斤	公斤	gong1jin1	gōngjīn	kilogram	
+公园	公園	gong1yuan2	gōngyuán	public park	
+故事	故事	gu4shi5	gùshi	story; tale	
+刮风	刮風	gua1feng1	guāfēng	windy; to blow (wind)	
+关	關	guan1	guān	to close; shut; concern; relationship; turn off; mountain pass	
+关系	關系	guan1xi5	guānxi	relation; to concern	
+关心	關心	guan1xin1	guānxīn	concerned about/with	
+关于	關於	guan1yu2	guānyú	about; regarding; concerning	
+国家	國家	guo2jia1	guójiā	country; state; nation	
+过	過	guo4	guò	to pass; to cross; go over; (indicates a past experience)	
+过去	過去	guo4qu4	guòqù	in the past; formerly	
+还是	還是	hai2shi5	háishi	or; still; nevertheless; had better	
+害怕	害怕	hai4pa4	hàipà	afraid of; to fear	
+黑板	黑板	hei1ban3	hēibǎn	blackboard	
+后来	后來	hou4lai2	hòulái	afterwards; after; later	
+护照	護照	hu4zhao4	hùzhào	passport	
+花	花	hua1	huā	flower; blossom; spend money; cost	
+画	畫	hua4	huà	draw; picture; painting	
+坏	壞	huai4	huài	bad; broken	
+欢迎	歡迎	huan1ying2	huānyíng	to welcome; greet	
+还	還	hai2	hái	still; yet; in addition; even	
+环境	環境	huan2jing4	huánjìng	environment; surroundings	
+换	換	huan4	huàn	change; to exchange; to barter; to trade	
+黄河	黃河	huang2he2	huánghé	Yellow River	
+回答	回答	hui2da2	huídá	to reply; to answer	
+会议	會議	hui4yi4	huìyì	meeting; conference	
+或者	或者	huo4zhe3	huòzhě	or; possible; maybe; perhaps	
+几乎	幾乎	ji1hu1	jīhū	almost	
+机会	機會	ji1hui4	jīhuì	opportunity; chance; occasion	
+极	極	ji2	jí	an extreme; pole; very	
+记得	記得	ji4de5	jìde	remember	
+季节	季節	ji4jie2	jìjié	season; time; period	
+检查	檢查	jian3cha2	jiǎnchá	to check; examine; inspect	
+简单	簡單	jian3dan1	jiǎndān	simple; not complicated	
+见面	見面	jian4mian4	jiànmiàn	meet/see somebody; meeting	
+健康	健康	jian4kang1	jiànkāng	health; healthy	
+讲	講	jiang3	jiǎng	to talk; to lecture; to explain; a speech	
+教	教	jiao1, jiao4	jiāo, jiào	teach; instruct | religion; teaching	
+角	角	jiao3, jue2	jiǎo, jué	horn; angle; unit of money (1/10 yuan); corner (Kangxi radical 148) | role (theater)	
+脚	腳	jiao3	jiǎo	foot (body part)	
+接	接	jie1	jiē	connect; to meet; to pick up (somebody); to receive	
+街道	街道	jie1dao4	jiēdào	street	
+节目	節目	jie2mu4	jiémù	program; item (on a program)	
+节日	節日	jie2ri4	jiérì	holiday; festival	
+结婚	結婚	jie2hun1	jiéhūn	get married	
+结束	結束	jie2shu4	jiéshù	to end; to finish; conclude	
+解决	解決	jie3jue2	jiějué	settle (a dispute); resolve; solve	
+借	借	jie4	jiè	lend; borrow; excuse	
+经常	經常	jing1chang2	jīngcháng	often; frequently; daily	
+经过	經過	jing1guo4	jīngguò	to pass; go through; as a result of	
+经理	經理	jing1li3	jīnglǐ	manager; director	
+久	久	jiu3	jiǔ	long (time)	
+旧	舊	jiu4	jiù	old; past; used	
+句子	句子	ju4zi5	jùzi	sentence	
+决定	決定	jue2ding4	juédìng	decide; resolve	
+可爱	可愛	ke3'ai4	kě'ài	cute; lovely	
+渴	渴	ke3	kě	thirsty	
+刻	刻	ke4	kè	quarter (hour); (mw for short time intervals); carve; to cut	
+客人	客人	ke4ren2	kèrén	guest; customer	
+空调	空調	kong1tiao2	kōngtiáo	air conditioning	
+口	口	kou3	kǒu	mouth (Kangxi radical 30)	
+哭	哭	ku1	kū	cry; weep	
+裤子	褲子	ku4zi5	kùzi	pants; trousers	
+筷子	筷子	kuai4zi5	kuàizi	chopsticks	
+蓝	藍	lan2	lán	blue	
+老	老	lao3	lǎo	old; aged; tough; often (Kangxi radical 125)	
+离开	離開	li2kai1	líkāi	leave; depart	
+礼物	禮物	li3wu4	lǐwù	gift; present	
+历史	歷史	li4shi3	lìshǐ	history	
+脸	臉	lian3	liǎn	face	
+练习	練習	lian4xi2	liànxí	practice; exercise	
+辆	輛	liang4	liàng	(mw for vehicles)	
+聊天	聊天	liao2tian1	liáotiān	to chat	
+了解	了解	liao3jie3	liǎojiě	comprehend; understand; know; find out	
+邻居	鄰居	lin2ju1	línjū	neighbor	
+留学	留學	liu2xue2	liúxué	study abroad	
+楼	樓	lou2	lóu	story; floor; (multi-story) building	
+绿	綠	lv4	lǜ	green	
+马	馬	ma3	mǎ	horse (Kangxi radical 187)	
+马上	馬上	ma3shang4	mǎshàng	at once; immediately; right away	
+满意	滿意	man3yi4	mǎnyì	satisfied; pleased	
+帽子	帽子	mao4zi5	màozi	hat; cap	
+米	米	mi3	mǐ	rice; meter (Kangxi radical 119)	
+面包	面包	mian4bao1	miànbāo	bread	
+明白	明白	ming2bai5	míngbai	clear; obvious; understand; explicit	
+拿	拿	na2	ná	carry in your hand; seize; to catch	
+奶奶	奶奶	nai3nai5	nǎinai	grandma; (informal) paternal grandmother	
+南	南	nan2	nán	South	
+难	難	nan2	nán	difficult	
+难过	難過	nan2guo4	nánguò	be grieved; be sad; have a hard time	
+年级	年級	nian2ji2	niánjí	grade; year (in school)	
+年轻	年輕	nian2qing1	niánqīng	young	
+鸟	鳥	niao3	niǎo	bird (Kangxi radical 196)	
+努力	努力	nu3li4	nǔlì	to work hard; to strive	
+爬山	爬山	pa2shan1	páshān	mountain climbing	
+盘子	盤子	pan2zi5	pánzi	plate; dish; tray	
+胖	胖	pang4	pàng	fat; plump	
+皮鞋	皮鞋	pi2xie2	píxié	leather shoes	
+啤酒	啤酒	pi2jiu3	píjiǔ	beer	
+瓶子	瓶子	ping2zi5	píngzi	bottle	
+其实	其實	qi2shi2	qíshí	actually; in fact	
+其他	其他	qi2ta1	qítā	other; else	
+奇怪	奇怪	qi2guai4	qíguài	strange; odd	
+骑	騎	qi2	qí	to ride (an animal or bike); to sit astride	
+起飞	起飛	qi3fei1	qǐfēi	take off (in an airplane); liftoff	
+起来	起來	qi3lai5	qǐlai	(beginning or continuing an action); to rise; get up (from bed)	
+清楚	清楚	qing1chu5	qīngchu	clear; distinct; be clear about	
+请假	請假	qing3jia4	qǐngjià	to ask for time off	
+秋	秋	qiu1	qiū	autumn; fall; harvest time	
+裙子	裙子	qun2zi5	qúnzi	skirt	
+然后	然后	ran2hou4	ránhòu	then; afterwards	
+热情	熱情	re4qing2	rèqíng	cordial; warm; enthusiastic	
+认为	認為	ren4wei2	rènwéi	believe; think that	
+认真	認真	ren4zhen1	rènzhēn	serious; earnest; take seriously	
+容易	容易	rong2yi4	róngyì	easy; likely; liable (to)	
+如果	如果	ru2guo3	rúguǒ	if; in the event that	
+伞	傘	san3	sǎn	umbrella; parasol	
+上网	上網	shang4wang3	shàngwǎng	to surf the web; to go online	
+生气	生氣	sheng1qi4	shēngqì	angry; mad	
+声音	聲音	sheng1yin1	shēngyīn	sound; voice	
+世界	世界	shi4jie4	shìjiè	world	
+试	試	shi4	shì	to try; to test; examination	
+瘦	瘦	shou4	shòu	thin; tight; lean	
+叔叔	叔叔	shu1shu5	shūshu	(informal) father's younger brother; uncle	
+舒服	舒服	shu1fu5	shūfu	comfortable; feeling well	
+树	樹	shu4	shù	tree	
+数学	數學	shu4xue2	shùxué	mathematics	
+刷牙	刷牙	shua1ya2	shuāyá	brush one's teeth	
+双	雙	shuang1	shuāng	two; double; (mw for pairs)	
+水平	水平	shui3ping2	shuǐpíng	level; standard; horizontal	
+司机	司機	si1ji1	sījī	driver; chauffeur	
+太阳	太陽	tai4yang2	tàiyáng	the sun	
+特别	特別	te4bie2	tèbié	special; especially; particular	
+疼	疼	teng2	téng	ache; sore; (it) hurts; love fondly	
+提高	提高	ti2gao1	tígāo	to raise; heighten; improve	
+体育	體育	ti3yu4	tǐyù	physical training; sports	
+甜	甜	tian2	tián	sweet	
+条	條	tiao2	tiáo	strip; (mw for long thin objects); item	
+同事	同事	tong2shi4	tóngshì	colleague; co-worker	
+同意	同意	tong2yi4	tóngyì	agree; to consent; approve	
+头发	頭發	tou2fa5	tóufa	hair (on the head)	
+突然	突然	tu1ran2	tūrán	sudden; abrupt	
+图书馆	圖書館	tu2shu1guan3	túshūguǎn	library	
+腿	腿	tui3	tuǐ	leg	
+完成	完成	wan2cheng2	wánchéng	to complete; accomplish; to fulfill	
+碗	碗	wan3	wǎn	bowl; cup	
+万	萬	wan4	wàn	ten thousand	
+忘记	忘記	wang4ji4	wàngjì	forget	
+为	為	wei4	wèi	for; because of; to; for the sake of	
+为了	為了	wei4le5	wèile	in order to; for the sake of; for the purpose of	
+位	位	wei4	wèi	position; location; (polite mw for people)	
+文化	文化	wen2hua4	wénhuà	culture; civilization	
+西	西	xi1	xī	West (Kangxi radical 146)	
+习惯	習慣	xi2guan4	xíguàn	habit; be accustomed to; usual practice	
+洗手间	洗手間	xi3shou3jian1	xǐshǒujiān	toilet; lavatory; washroom	
+洗澡	洗澡	xi3zao3	xǐzǎo	bathe; take a bath or shower; bath or shower	
+夏	夏	xia4	xià	summer	
+先	先	xian1	xiān	first; early; before	
+相信	相信	xiang1xin4	xiāngxìn	believe (sb.); be convinced of	
+香蕉	香蕉	xiang1jiao1	xiāngjiāo	banana	
+向	向	xiang4	xiàng	direction; towards; to turn; to face	
+像	像	xiang4	xiàng	be like; resemble; appearance; appear	
+小心	小心	xiao3xin1	xiǎoxīn	be careful	
+校长	校長	xiao4zhang3	xiàozhǎng	principal (of school, college or university); president; headmaster	
+新闻	新聞	xin1wen2	xīnwén	news	
+新鲜	新鮮	xin1xian1	xīnxiān	fresh (experience, food, etc.); new; novel	
+信用卡	信用卡	xin4yong4ka3	xìnyòngkǎ	credit card	
+行李箱	行李箱	xing2li3xiang1	xínglǐxiāng	trunk; suitcase	
+熊猫	熊貓	xiong2mao1	xióngmāo	panda	
+需要	需要	xu1yao4	xūyào	to need; to want; to demand	
+选择	選擇	xuan3ze2	xuǎnzé	select; to pick; choose	
+要求	要求	yao1qiu2	yāoqiú	to request; to demand; requirement	
+爷爷	爺爺	ye2ye5	yéye	(informal) father's father; paternal grandfather	
+一般	一般	yi4ban1	yìbān	general; ordinary; common; same	
+一边	一邊	yi4bian1	yìbiān	one side; on the one hand; at the same time	
+一定	一定	yi2ding4	yídìng	surely; certainly; necessarily; definite	
+一共	一共	yi2gong4	yígòng	altogether; in total	
+一会儿	一會兒	yi2hui4r5	yíhuìr	a while; a moment	
+一样	一樣	yi2yang4	yíyàng	the same; alike; equal to	
+一直	一直	yi4zhi2	yìzhí	always; all along; straight (in a straight line)	
+以前	以前	yi3qian2	yǐqián	before; formerly; previous	
+音乐	音樂	yin1yue4	yīnyuè	music	
+银行	銀行	yin2hang2	yínháng	bank	
+饮料	飲料	yin3liao4	yǐnliào	beverage; drink	
+应该	應該	ying1gai1	yīnggāi	should; ought to; must	
+影响	影響	ying3xiang3	yǐngxiǎng	influence; affect; effect	
+用	用	yong4	yòng	to use (Kangxi radical 101)	
+游戏	游戲	you2xi4	yóuxì	game; play; recreation	
+有名	有名	you3ming2	yǒumíng	famous; well-known	
+又	又	you4	yòu	(once) again; also; both (Kangxi radical 29)	
+遇到	遇到	yu4dao4	yùdào	to meet; run into; come across	
+元	元	yuan2	yuán	Chinese monetary unit; dollar; first; principal	
+愿意	願意	yuan4yi4	yuànyì	be willing; want to; be ready	
+月亮	月亮	yue4liang5	yuèliang	the moon	
+越	越	yue4	yuè	even more; the more; exceed	
+站	站	zhan4	zhàn	stand; a station; be on one's feet; service center	
+张	張	zhang1	zhāng	(mw for flat objects); to spread out; (common surname)	
+长	長	chang2, zhang3	cháng, zhǎng	long; length | grow; chief (Kangxi radical 168)
+着急	著急	zhao2ji2	zháojí	to worry; feel anxious	
+照顾	照顧	zhao4gu5	zhàogu	take care of; look after; give consideration	
+照片	照片	zhao4pian4	zhàopiàn	picture; photograph	
+照相机	照相機	zhao4xiang4ji1	zhàoxiàngjī	camera	
+只	隻	zhi1, zhi3	zhī, zhǐ	but; only; merely; just | (mw for birds and certain animals)	
+只有	隻有	zhi3you3	zhǐyǒu	only	
+才	才	cai2	cái	ability; talent; just now; not until	
+中间	中間	zhong1jian1	zhōngjiān	center; middle; between; among	
+中文	中文	Zhong1wen2	Zhōngwén	Chinese (language)	
+终于	終於	zhong1yu2	zhōngyú	at last; in the end; finally	
+种	種	zhong3	zhǒng	type; breed; race; seed	
+重要	重要	zhong4yao4	zhòngyào	important; significant; major	
+周末	周末	zhou1mo4	zhōumò	weekend	
+主要	主要	zhu3yao4	zhǔyào	main; principal; major	
+注意	注意	zhu4yi4	zhùyì	pay attention to; take notice of; be careful	
+自己	自己	zi4ji3	zìjǐ	oneself; self	
+自行车	自行車	zi4xing2che1	zìxíngchē	bike; bicycle	
+总是	總是	zong3shi4	zǒngshì	always; eventually	
+嘴	嘴	zui3	zuǐ	mouth	
+最后	最后	zui4hou4	zuìhòu	last; final; ultimately	
+最近	最近	zui4jin4	zuìjìn	recently; lately; these days	
+作业	作業	zuo4ye4	zuòyè	school assignment; homework; task	

--- a/vocab/mandarin/hsk/3/vocab.json
+++ b/vocab/mandarin/hsk/3/vocab.json
@@ -1,0 +1,2102 @@
+[
+    {
+        "intermediate_1": "a1yi2",
+        "intermediate_2": "āyí",
+        "native_1": "auntie; step-mother; mother's younger sister",
+        "primary_1": "阿姨",
+        "primary_2": "阿姨"
+    },
+    {
+        "intermediate_1": "a5",
+        "intermediate_2": "a",
+        "native_1": "ah; (particle showing elation, doubt, puzzled surprise, or approval)",
+        "primary_1": "啊",
+        "primary_2": "啊"
+    },
+    {
+        "intermediate_1": "ai3",
+        "intermediate_2": "ǎi",
+        "native_1": "short; low",
+        "primary_1": "矮",
+        "primary_2": "矮"
+    },
+    {
+        "intermediate_1": "ai4hao4",
+        "intermediate_2": "àihào",
+        "native_1": "hobby; fond of; to like; interest",
+        "primary_1": "爱好",
+        "primary_2": "愛好"
+    },
+    {
+        "intermediate_1": "an1jing4",
+        "intermediate_2": "ānjìng",
+        "native_1": "quiet; peaceful; calm",
+        "primary_1": "安静",
+        "primary_2": "安靜"
+    },
+    {
+        "intermediate_1": "ba3",
+        "intermediate_2": "bǎ",
+        "native_1": "(mw for things with handles); (pretransitive particle); to hold",
+        "primary_1": "把",
+        "primary_2": "把"
+    },
+    {
+        "intermediate_1": "ban1",
+        "intermediate_2": "bān",
+        "native_1": "team; class; squad",
+        "primary_1": "班",
+        "primary_2": "班"
+    },
+    {
+        "intermediate_1": "ban1",
+        "intermediate_2": "bān",
+        "native_1": "to move; to transport",
+        "primary_1": "搬",
+        "primary_2": "搬"
+    },
+    {
+        "intermediate_1": "ban4fa3",
+        "intermediate_2": "bànfǎ",
+        "native_1": "method; way (of doing something)",
+        "primary_1": "办法",
+        "primary_2": "辦法"
+    },
+    {
+        "intermediate_1": "ban4gong1shi4",
+        "intermediate_2": "bàngōngshì",
+        "native_1": "office",
+        "primary_1": "办公室",
+        "primary_2": "辦公室"
+    },
+    {
+        "intermediate_1": "ban4",
+        "intermediate_2": "bàn",
+        "native_1": "half; semi-; incomplete",
+        "primary_1": "半",
+        "primary_2": "半"
+    },
+    {
+        "intermediate_1": "bang1mang2",
+        "intermediate_2": "bāngmáng",
+        "native_1": "to help",
+        "primary_1": "帮忙",
+        "primary_2": "幫忙"
+    },
+    {
+        "intermediate_1": "bao1",
+        "intermediate_2": "bāo",
+        "native_1": "to cover; to wrap; to hold; include; (mw for containers, packages, etc.)",
+        "primary_1": "包",
+        "primary_2": "包"
+    },
+    {
+        "intermediate_1": "bao3",
+        "intermediate_2": "bǎo",
+        "native_1": "eat until full; satisfied",
+        "primary_1": "饱",
+        "primary_2": "飽"
+    },
+    {
+        "intermediate_1": "bei3fang1",
+        "intermediate_2": "běifāng",
+        "native_1": "north; the northern part of the country",
+        "primary_1": "北方",
+        "primary_2": "北方"
+    },
+    {
+        "intermediate_1": "bei4",
+        "intermediate_2": "bèi",
+        "native_1": "by (indicates passive voice sentences); a quilt/blanket",
+        "primary_1": "被",
+        "primary_2": "被"
+    },
+    {
+        "intermediate_1": "bi2zi5",
+        "intermediate_2": "bízi",
+        "native_1": "nose",
+        "primary_1": "鼻子",
+        "primary_2": "鼻子"
+    },
+    {
+        "intermediate_1": "bi3jiao4",
+        "intermediate_2": "bǐjiào",
+        "native_1": "compare; contrast; relatively",
+        "primary_1": "比较",
+        "primary_2": "比較"
+    },
+    {
+        "intermediate_1": "bi3sai4",
+        "intermediate_2": "bǐsài",
+        "native_1": "(sports) match; competition",
+        "primary_1": "比赛",
+        "primary_2": "比賽"
+    },
+    {
+        "intermediate_1": "bi3ji4ben3",
+        "intermediate_2": "bǐjìběn",
+        "native_1": "notebook",
+        "primary_1": "笔记本",
+        "primary_2": "筆記本"
+    },
+    {
+        "intermediate_1": "bi4xu1",
+        "intermediate_2": "bìxū",
+        "native_1": "must; have to",
+        "primary_1": "必须",
+        "primary_2": "必須"
+    },
+    {
+        "intermediate_1": "bian4hua4",
+        "intermediate_2": "biànhuà",
+        "native_1": "change",
+        "primary_1": "变化",
+        "primary_2": "變化"
+    },
+    {
+        "intermediate_1": "bie2ren5",
+        "intermediate_2": "biéren",
+        "native_1": "other people; others",
+        "primary_1": "别人",
+        "primary_2": "別人"
+    },
+    {
+        "intermediate_1": "bing1xiang1",
+        "intermediate_2": "bīngxiāng",
+        "native_1": "refrigerator",
+        "primary_1": "冰箱",
+        "primary_2": "冰箱"
+    },
+    {
+        "intermediate_1": "bu2dan4",
+        "intermediate_2": "búdàn",
+        "native_1": "not only",
+        "primary_1": "不但",
+        "primary_2": "不但"
+    },
+    {
+        "intermediate_1": "er2qie3",
+        "intermediate_2": "érqiě",
+        "native_1": "moreover; in addition; as well as",
+        "primary_1": "而且",
+        "primary_2": "而且"
+    },
+    {
+        "intermediate_1": "cai4dan1",
+        "intermediate_2": "càidān",
+        "native_1": "menu",
+        "primary_1": "菜单",
+        "primary_2": "菜單"
+    },
+    {
+        "intermediate_1": "can1jia1",
+        "intermediate_2": "cānjiā",
+        "native_1": "participate; join; take part in",
+        "primary_1": "参加",
+        "primary_2": "參加"
+    },
+    {
+        "intermediate_1": "cao3",
+        "intermediate_2": "cǎo",
+        "native_1": "grass; straw; draft (of a document)",
+        "primary_1": "草",
+        "primary_2": "草"
+    },
+    {
+        "intermediate_1": "ceng2",
+        "intermediate_2": "céng",
+        "native_1": "(mw for layers, floors of buildings)",
+        "primary_1": "层",
+        "primary_2": "層"
+    },
+    {
+        "intermediate_1": "cha4",
+        "intermediate_2": "chà",
+        "native_1": "differ from; fall short of; poor; inferior",
+        "primary_1": "差",
+        "primary_2": "差"
+    },
+    {
+        "intermediate_1": "chao1shi4",
+        "intermediate_2": "chāoshì",
+        "native_1": "supermarket",
+        "primary_1": "超市",
+        "primary_2": "超市"
+    },
+    {
+        "intermediate_1": "chen4shan1",
+        "intermediate_2": "chènshān",
+        "native_1": "shirt; blouse",
+        "primary_1": "衬衫",
+        "primary_2": "襯衫"
+    },
+    {
+        "intermediate_1": "cheng2ji4",
+        "intermediate_2": "chéngjì",
+        "native_1": "achievement; success; results (of work or study)",
+        "primary_1": "成绩",
+        "primary_2": "成績"
+    },
+    {
+        "intermediate_1": "cheng2shi4",
+        "intermediate_2": "chéngshì",
+        "native_1": "city or town",
+        "primary_1": "城市",
+        "primary_2": "城市"
+    },
+    {
+        "intermediate_1": "chi2dao4",
+        "intermediate_2": "chídào",
+        "native_1": "arrive late",
+        "primary_1": "迟到",
+        "primary_2": "遲到"
+    },
+    {
+        "intermediate_1": "chu2le5",
+        "intermediate_2": "chúle",
+        "native_1": "besides; except for; aside from; in addition to",
+        "primary_1": "除了",
+        "primary_2": "除了"
+    },
+    {
+        "intermediate_1": "chuan2",
+        "intermediate_2": "chuán",
+        "native_1": "a boat; vessel; ship",
+        "primary_1": "船",
+        "primary_2": "船"
+    },
+    {
+        "intermediate_1": "chun1",
+        "intermediate_2": "chūn",
+        "native_1": "spring (season); joyful",
+        "primary_1": "春",
+        "primary_2": "春"
+    },
+    {
+        "intermediate_1": "ci2dian3",
+        "intermediate_2": "cídiǎn",
+        "native_1": "dictionary",
+        "primary_1": "词典",
+        "primary_2": "詞典"
+    },
+    {
+        "intermediate_1": "cong1ming5",
+        "intermediate_2": "cōngming",
+        "native_1": "intelligent; clever; bright; smart",
+        "primary_1": "聪明",
+        "primary_2": "聰明"
+    },
+    {
+        "intermediate_1": "da3sao3",
+        "intermediate_2": "dǎsǎo",
+        "native_1": "to clean; to sweep",
+        "primary_1": "打扫",
+        "primary_2": "打掃"
+    },
+    {
+        "intermediate_1": "da3suan4",
+        "intermediate_2": "dǎsuàn",
+        "native_1": "to plan; intend",
+        "primary_1": "打算",
+        "primary_2": "打算"
+    },
+    {
+        "intermediate_1": "dai4",
+        "intermediate_2": "dài",
+        "native_1": "band; belt; ribbon; carry; bring; take along; bring up (kids)",
+        "primary_1": "带",
+        "primary_2": "帶"
+    },
+    {
+        "intermediate_1": "dan1xin1",
+        "intermediate_2": "dānxīn",
+        "native_1": "to worry; feel anxious",
+        "primary_1": "担心",
+        "primary_2": "擔心"
+    },
+    {
+        "intermediate_1": "dan4gao1",
+        "intermediate_2": "dàngāo",
+        "native_1": "cake",
+        "primary_1": "蛋糕",
+        "primary_2": "蛋糕"
+    },
+    {
+        "intermediate_1": "dang1ran2",
+        "intermediate_2": "dāngrán",
+        "native_1": "of course; naturally",
+        "primary_1": "当然",
+        "primary_2": "當然"
+    },
+    {
+        "intermediate_1": "di4, de5",
+        "intermediate_2": "dì, de",
+        "native_1": "earth; ground | (adverbial particle)",
+        "primary_1": "地",
+        "primary_2": "地"
+    },
+    {
+        "intermediate_1": "deng1",
+        "intermediate_2": "dēng",
+        "native_1": "lamp; light",
+        "primary_1": "灯",
+        "primary_2": "燈"
+    },
+    {
+        "intermediate_1": "di4fang5",
+        "intermediate_2": "dìfang",
+        "native_1": "place; space; room; part, (fāng: local; regional)",
+        "primary_1": "地方",
+        "primary_2": "地方"
+    },
+    {
+        "intermediate_1": "di4tie3",
+        "intermediate_2": "dìtiě",
+        "native_1": "subway",
+        "primary_1": "地铁",
+        "primary_2": "地鐵"
+    },
+    {
+        "intermediate_1": "di4tu2",
+        "intermediate_2": "dìtú",
+        "native_1": "map",
+        "primary_1": "地图",
+        "primary_2": "地圖"
+    },
+    {
+        "intermediate_1": "dian4ti1",
+        "intermediate_2": "diàntī",
+        "native_1": "elevator",
+        "primary_1": "电梯",
+        "primary_2": "電梯"
+    },
+    {
+        "intermediate_1": "dian4zi3 you2jian4",
+        "intermediate_2": "diànzǐ yóujiàn",
+        "native_1": "email",
+        "primary_1": "电子邮件",
+        "primary_2": "電子郵件"
+    },
+    {
+        "intermediate_1": "dong1",
+        "intermediate_2": "dōng",
+        "native_1": "East",
+        "primary_1": "东",
+        "primary_2": "東"
+    },
+    {
+        "intermediate_1": "dong1",
+        "intermediate_2": "dōng",
+        "native_1": "winter",
+        "primary_1": "冬",
+        "primary_2": "冬"
+    },
+    {
+        "intermediate_1": "dong4wu4",
+        "intermediate_2": "dòngwù",
+        "native_1": "animal",
+        "primary_1": "动物",
+        "primary_2": "動物"
+    },
+    {
+        "intermediate_1": "duan3",
+        "intermediate_2": "duǎn",
+        "native_1": "short (in length, duration, or height); lack",
+        "primary_1": "短",
+        "primary_2": "短"
+    },
+    {
+        "intermediate_1": "duan4",
+        "intermediate_2": "duàn",
+        "native_1": "paragraph; segment; section",
+        "primary_1": "段",
+        "primary_2": "段"
+    },
+    {
+        "intermediate_1": "duan4lian4",
+        "intermediate_2": "duànliàn",
+        "native_1": "to exercise; work out; toughen; to temper",
+        "primary_1": "锻炼",
+        "primary_2": "鍛煉"
+    },
+    {
+        "intermediate_1": "duo1me5",
+        "intermediate_2": "duōme",
+        "native_1": "how (wonderful, etc.); what (a great idea)",
+        "primary_1": "多么",
+        "primary_2": "多麼"
+    },
+    {
+        "intermediate_1": "e4",
+        "intermediate_2": "è",
+        "native_1": "hungry",
+        "primary_1": "饿",
+        "primary_2": "餓"
+    },
+    {
+        "intermediate_1": "er3duo5",
+        "intermediate_2": "ěrduo",
+        "native_1": "ear",
+        "primary_1": "耳朵",
+        "primary_2": "耳朵"
+    },
+    {
+        "intermediate_1": "fa1, fa4",
+        "intermediate_2": "fā, fà",
+        "native_1": "send out; to issue; to show (one's feelings) | hair",
+        "primary_1": "发",
+        "primary_2": "發"
+    },
+    {
+        "intermediate_1": "fa1shao1",
+        "intermediate_2": "fāshāo",
+        "native_1": "have a fever",
+        "primary_1": "发烧",
+        "primary_2": "發燒"
+    },
+    {
+        "intermediate_1": "fa1xian4",
+        "intermediate_2": "fāxiàn",
+        "native_1": "discover; to find",
+        "primary_1": "发现",
+        "primary_2": "發現"
+    },
+    {
+        "intermediate_1": "fang1bian4",
+        "intermediate_2": "fāngbiàn",
+        "native_1": "convenient",
+        "primary_1": "方便",
+        "primary_2": "方便"
+    },
+    {
+        "intermediate_1": "fang4",
+        "intermediate_2": "fàng",
+        "native_1": "put; to place; to release; to free",
+        "primary_1": "放",
+        "primary_2": "放"
+    },
+    {
+        "intermediate_1": "fang4xin1",
+        "intermediate_2": "fàngxīn",
+        "native_1": "relax; feel relieved; rest assured",
+        "primary_1": "放心",
+        "primary_2": "放心"
+    },
+    {
+        "intermediate_1": "fen1, fen4",
+        "intermediate_2": "fēn, fèn",
+        "native_1": "divide; part; minute; cent | component; share; ingredient",
+        "primary_1": "分",
+        "primary_2": "分"
+    },
+    {
+        "intermediate_1": "fu4jin4",
+        "intermediate_2": "fùjìn",
+        "native_1": "(in the) vicinity; nearby; neighboring",
+        "primary_1": "附近",
+        "primary_2": "附近"
+    },
+    {
+        "intermediate_1": "fu4xi2",
+        "intermediate_2": "fùxí",
+        "native_1": "revise; to review",
+        "primary_1": "复习",
+        "primary_2": "復習"
+    },
+    {
+        "intermediate_1": "gan1jing4",
+        "intermediate_2": "gānjìng",
+        "native_1": "clean; neat and tidy",
+        "primary_1": "干净",
+        "primary_2": "干淨"
+    },
+    {
+        "intermediate_1": "gan3mao4",
+        "intermediate_2": "gǎnmào",
+        "native_1": "catch cold; (common) cold",
+        "primary_1": "感冒",
+        "primary_2": "感冒"
+    },
+    {
+        "intermediate_1": "gan3 xing4qu4",
+        "intermediate_2": "gǎn xìngqù",
+        "native_1": "be interested in",
+        "primary_1": "感兴趣",
+        "primary_2": "感興趣"
+    },
+    {
+        "intermediate_1": "gang1cai2",
+        "intermediate_2": "gāngcái",
+        "native_1": "just now; a moment ago",
+        "primary_1": "刚才",
+        "primary_2": "剛才"
+    },
+    {
+        "intermediate_1": "ge4zi5",
+        "intermediate_2": "gèzi",
+        "native_1": "height; stature; build",
+        "primary_1": "个子",
+        "primary_2": "個子"
+    },
+    {
+        "intermediate_1": "gen1ju4",
+        "intermediate_2": "gēnjù",
+        "native_1": "according to; based on; basis",
+        "primary_1": "根据",
+        "primary_2": "根據"
+    },
+    {
+        "intermediate_1": "gen1",
+        "intermediate_2": "gēn",
+        "native_1": "to follow; go with; heel",
+        "primary_1": "跟",
+        "primary_2": "跟"
+    },
+    {
+        "intermediate_1": "geng4",
+        "intermediate_2": "gèng",
+        "native_1": "more; even more",
+        "primary_1": "更",
+        "primary_2": "更"
+    },
+    {
+        "intermediate_1": "gong1jin1",
+        "intermediate_2": "gōngjīn",
+        "native_1": "kilogram",
+        "primary_1": "公斤",
+        "primary_2": "公斤"
+    },
+    {
+        "intermediate_1": "gong1yuan2",
+        "intermediate_2": "gōngyuán",
+        "native_1": "public park",
+        "primary_1": "公园",
+        "primary_2": "公園"
+    },
+    {
+        "intermediate_1": "gu4shi5",
+        "intermediate_2": "gùshi",
+        "native_1": "story; tale",
+        "primary_1": "故事",
+        "primary_2": "故事"
+    },
+    {
+        "intermediate_1": "gua1feng1",
+        "intermediate_2": "guāfēng",
+        "native_1": "windy; to blow (wind)",
+        "primary_1": "刮风",
+        "primary_2": "刮風"
+    },
+    {
+        "intermediate_1": "guan1",
+        "intermediate_2": "guān",
+        "native_1": "to close; shut; concern; relationship; turn off; mountain pass",
+        "primary_1": "关",
+        "primary_2": "關"
+    },
+    {
+        "intermediate_1": "guan1xi5",
+        "intermediate_2": "guānxi",
+        "native_1": "relation; to concern",
+        "primary_1": "关系",
+        "primary_2": "關系"
+    },
+    {
+        "intermediate_1": "guan1xin1",
+        "intermediate_2": "guānxīn",
+        "native_1": "concerned about/with",
+        "primary_1": "关心",
+        "primary_2": "關心"
+    },
+    {
+        "intermediate_1": "guan1yu2",
+        "intermediate_2": "guānyú",
+        "native_1": "about; regarding; concerning",
+        "primary_1": "关于",
+        "primary_2": "關於"
+    },
+    {
+        "intermediate_1": "guo2jia1",
+        "intermediate_2": "guójiā",
+        "native_1": "country; state; nation",
+        "primary_1": "国家",
+        "primary_2": "國家"
+    },
+    {
+        "intermediate_1": "guo4",
+        "intermediate_2": "guò",
+        "native_1": "to pass; to cross; go over; (indicates a past experience)",
+        "primary_1": "过",
+        "primary_2": "過"
+    },
+    {
+        "intermediate_1": "guo4qu4",
+        "intermediate_2": "guòqù",
+        "native_1": "in the past; formerly",
+        "primary_1": "过去",
+        "primary_2": "過去"
+    },
+    {
+        "intermediate_1": "hai2shi5",
+        "intermediate_2": "háishi",
+        "native_1": "or; still; nevertheless; had better",
+        "primary_1": "还是",
+        "primary_2": "還是"
+    },
+    {
+        "intermediate_1": "hai4pa4",
+        "intermediate_2": "hàipà",
+        "native_1": "afraid of; to fear",
+        "primary_1": "害怕",
+        "primary_2": "害怕"
+    },
+    {
+        "intermediate_1": "hei1ban3",
+        "intermediate_2": "hēibǎn",
+        "native_1": "blackboard",
+        "primary_1": "黑板",
+        "primary_2": "黑板"
+    },
+    {
+        "intermediate_1": "hou4lai2",
+        "intermediate_2": "hòulái",
+        "native_1": "afterwards; after; later",
+        "primary_1": "后来",
+        "primary_2": "后來"
+    },
+    {
+        "intermediate_1": "hu4zhao4",
+        "intermediate_2": "hùzhào",
+        "native_1": "passport",
+        "primary_1": "护照",
+        "primary_2": "護照"
+    },
+    {
+        "intermediate_1": "hua1",
+        "intermediate_2": "huā",
+        "native_1": "flower; blossom; spend money; cost",
+        "primary_1": "花",
+        "primary_2": "花"
+    },
+    {
+        "intermediate_1": "hua4",
+        "intermediate_2": "huà",
+        "native_1": "draw; picture; painting",
+        "primary_1": "画",
+        "primary_2": "畫"
+    },
+    {
+        "intermediate_1": "huai4",
+        "intermediate_2": "huài",
+        "native_1": "bad; broken",
+        "primary_1": "坏",
+        "primary_2": "壞"
+    },
+    {
+        "intermediate_1": "huan1ying2",
+        "intermediate_2": "huānyíng",
+        "native_1": "to welcome; greet",
+        "primary_1": "欢迎",
+        "primary_2": "歡迎"
+    },
+    {
+        "intermediate_1": "hai2",
+        "intermediate_2": "hái",
+        "native_1": "still; yet; in addition; even",
+        "primary_1": "还",
+        "primary_2": "還"
+    },
+    {
+        "intermediate_1": "huan2jing4",
+        "intermediate_2": "huánjìng",
+        "native_1": "environment; surroundings",
+        "primary_1": "环境",
+        "primary_2": "環境"
+    },
+    {
+        "intermediate_1": "huan4",
+        "intermediate_2": "huàn",
+        "native_1": "change; to exchange; to barter; to trade",
+        "primary_1": "换",
+        "primary_2": "換"
+    },
+    {
+        "intermediate_1": "huang2he2",
+        "intermediate_2": "huánghé",
+        "native_1": "Yellow River",
+        "primary_1": "黄河",
+        "primary_2": "黃河"
+    },
+    {
+        "intermediate_1": "hui2da2",
+        "intermediate_2": "huídá",
+        "native_1": "to reply; to answer",
+        "primary_1": "回答",
+        "primary_2": "回答"
+    },
+    {
+        "intermediate_1": "hui4yi4",
+        "intermediate_2": "huìyì",
+        "native_1": "meeting; conference",
+        "primary_1": "会议",
+        "primary_2": "會議"
+    },
+    {
+        "intermediate_1": "huo4zhe3",
+        "intermediate_2": "huòzhě",
+        "native_1": "or; possible; maybe; perhaps",
+        "primary_1": "或者",
+        "primary_2": "或者"
+    },
+    {
+        "intermediate_1": "ji1hu1",
+        "intermediate_2": "jīhū",
+        "native_1": "almost",
+        "primary_1": "几乎",
+        "primary_2": "幾乎"
+    },
+    {
+        "intermediate_1": "ji1hui4",
+        "intermediate_2": "jīhuì",
+        "native_1": "opportunity; chance; occasion",
+        "primary_1": "机会",
+        "primary_2": "機會"
+    },
+    {
+        "intermediate_1": "ji2",
+        "intermediate_2": "jí",
+        "native_1": "an extreme; pole; very",
+        "primary_1": "极",
+        "primary_2": "極"
+    },
+    {
+        "intermediate_1": "ji4de5",
+        "intermediate_2": "jìde",
+        "native_1": "remember",
+        "primary_1": "记得",
+        "primary_2": "記得"
+    },
+    {
+        "intermediate_1": "ji4jie2",
+        "intermediate_2": "jìjié",
+        "native_1": "season; time; period",
+        "primary_1": "季节",
+        "primary_2": "季節"
+    },
+    {
+        "intermediate_1": "jian3cha2",
+        "intermediate_2": "jiǎnchá",
+        "native_1": "to check; examine; inspect",
+        "primary_1": "检查",
+        "primary_2": "檢查"
+    },
+    {
+        "intermediate_1": "jian3dan1",
+        "intermediate_2": "jiǎndān",
+        "native_1": "simple; not complicated",
+        "primary_1": "简单",
+        "primary_2": "簡單"
+    },
+    {
+        "intermediate_1": "jian4mian4",
+        "intermediate_2": "jiànmiàn",
+        "native_1": "meet/see somebody; meeting",
+        "primary_1": "见面",
+        "primary_2": "見面"
+    },
+    {
+        "intermediate_1": "jian4kang1",
+        "intermediate_2": "jiànkāng",
+        "native_1": "health; healthy",
+        "primary_1": "健康",
+        "primary_2": "健康"
+    },
+    {
+        "intermediate_1": "jiang3",
+        "intermediate_2": "jiǎng",
+        "native_1": "to talk; to lecture; to explain; a speech",
+        "primary_1": "讲",
+        "primary_2": "講"
+    },
+    {
+        "intermediate_1": "jiao1, jiao4",
+        "intermediate_2": "jiāo, jiào",
+        "native_1": "teach; instruct | religion; teaching",
+        "primary_1": "教",
+        "primary_2": "教"
+    },
+    {
+        "intermediate_1": "jiao3, jue2",
+        "intermediate_2": "jiǎo, jué",
+        "native_1": "horn; angle; unit of money (1/10 yuan); corner (Kangxi radical 148) | role (theater)",
+        "primary_1": "角",
+        "primary_2": "角"
+    },
+    {
+        "intermediate_1": "jiao3",
+        "intermediate_2": "jiǎo",
+        "native_1": "foot (body part)",
+        "primary_1": "脚",
+        "primary_2": "腳"
+    },
+    {
+        "intermediate_1": "jie1",
+        "intermediate_2": "jiē",
+        "native_1": "connect; to meet; to pick up (somebody); to receive",
+        "primary_1": "接",
+        "primary_2": "接"
+    },
+    {
+        "intermediate_1": "jie1dao4",
+        "intermediate_2": "jiēdào",
+        "native_1": "street",
+        "primary_1": "街道",
+        "primary_2": "街道"
+    },
+    {
+        "intermediate_1": "jie2mu4",
+        "intermediate_2": "jiémù",
+        "native_1": "program; item (on a program)",
+        "primary_1": "节目",
+        "primary_2": "節目"
+    },
+    {
+        "intermediate_1": "jie2ri4",
+        "intermediate_2": "jiérì",
+        "native_1": "holiday; festival",
+        "primary_1": "节日",
+        "primary_2": "節日"
+    },
+    {
+        "intermediate_1": "jie2hun1",
+        "intermediate_2": "jiéhūn",
+        "native_1": "get married",
+        "primary_1": "结婚",
+        "primary_2": "結婚"
+    },
+    {
+        "intermediate_1": "jie2shu4",
+        "intermediate_2": "jiéshù",
+        "native_1": "to end; to finish; conclude",
+        "primary_1": "结束",
+        "primary_2": "結束"
+    },
+    {
+        "intermediate_1": "jie3jue2",
+        "intermediate_2": "jiějué",
+        "native_1": "settle (a dispute); resolve; solve",
+        "primary_1": "解决",
+        "primary_2": "解決"
+    },
+    {
+        "intermediate_1": "jie4",
+        "intermediate_2": "jiè",
+        "native_1": "lend; borrow; excuse",
+        "primary_1": "借",
+        "primary_2": "借"
+    },
+    {
+        "intermediate_1": "jing1chang2",
+        "intermediate_2": "jīngcháng",
+        "native_1": "often; frequently; daily",
+        "primary_1": "经常",
+        "primary_2": "經常"
+    },
+    {
+        "intermediate_1": "jing1guo4",
+        "intermediate_2": "jīngguò",
+        "native_1": "to pass; go through; as a result of",
+        "primary_1": "经过",
+        "primary_2": "經過"
+    },
+    {
+        "intermediate_1": "jing1li3",
+        "intermediate_2": "jīnglǐ",
+        "native_1": "manager; director",
+        "primary_1": "经理",
+        "primary_2": "經理"
+    },
+    {
+        "intermediate_1": "jiu3",
+        "intermediate_2": "jiǔ",
+        "native_1": "long (time)",
+        "primary_1": "久",
+        "primary_2": "久"
+    },
+    {
+        "intermediate_1": "jiu4",
+        "intermediate_2": "jiù",
+        "native_1": "old; past; used",
+        "primary_1": "旧",
+        "primary_2": "舊"
+    },
+    {
+        "intermediate_1": "ju4zi5",
+        "intermediate_2": "jùzi",
+        "native_1": "sentence",
+        "primary_1": "句子",
+        "primary_2": "句子"
+    },
+    {
+        "intermediate_1": "jue2ding4",
+        "intermediate_2": "juédìng",
+        "native_1": "decide; resolve",
+        "primary_1": "决定",
+        "primary_2": "決定"
+    },
+    {
+        "intermediate_1": "ke3'ai4",
+        "intermediate_2": "kě'ài",
+        "native_1": "cute; lovely",
+        "primary_1": "可爱",
+        "primary_2": "可愛"
+    },
+    {
+        "intermediate_1": "ke3",
+        "intermediate_2": "kě",
+        "native_1": "thirsty",
+        "primary_1": "渴",
+        "primary_2": "渴"
+    },
+    {
+        "intermediate_1": "ke4",
+        "intermediate_2": "kè",
+        "native_1": "quarter (hour); (mw for short time intervals); carve; to cut",
+        "primary_1": "刻",
+        "primary_2": "刻"
+    },
+    {
+        "intermediate_1": "ke4ren2",
+        "intermediate_2": "kèrén",
+        "native_1": "guest; customer",
+        "primary_1": "客人",
+        "primary_2": "客人"
+    },
+    {
+        "intermediate_1": "kong1tiao2",
+        "intermediate_2": "kōngtiáo",
+        "native_1": "air conditioning",
+        "primary_1": "空调",
+        "primary_2": "空調"
+    },
+    {
+        "intermediate_1": "kou3",
+        "intermediate_2": "kǒu",
+        "native_1": "mouth (Kangxi radical 30)",
+        "primary_1": "口",
+        "primary_2": "口"
+    },
+    {
+        "intermediate_1": "ku1",
+        "intermediate_2": "kū",
+        "native_1": "cry; weep",
+        "primary_1": "哭",
+        "primary_2": "哭"
+    },
+    {
+        "intermediate_1": "ku4zi5",
+        "intermediate_2": "kùzi",
+        "native_1": "pants; trousers",
+        "primary_1": "裤子",
+        "primary_2": "褲子"
+    },
+    {
+        "intermediate_1": "kuai4zi5",
+        "intermediate_2": "kuàizi",
+        "native_1": "chopsticks",
+        "primary_1": "筷子",
+        "primary_2": "筷子"
+    },
+    {
+        "intermediate_1": "lan2",
+        "intermediate_2": "lán",
+        "native_1": "blue",
+        "primary_1": "蓝",
+        "primary_2": "藍"
+    },
+    {
+        "intermediate_1": "lao3",
+        "intermediate_2": "lǎo",
+        "native_1": "old; aged; tough; often (Kangxi radical 125)",
+        "primary_1": "老",
+        "primary_2": "老"
+    },
+    {
+        "intermediate_1": "li2kai1",
+        "intermediate_2": "líkāi",
+        "native_1": "leave; depart",
+        "primary_1": "离开",
+        "primary_2": "離開"
+    },
+    {
+        "intermediate_1": "li3wu4",
+        "intermediate_2": "lǐwù",
+        "native_1": "gift; present",
+        "primary_1": "礼物",
+        "primary_2": "禮物"
+    },
+    {
+        "intermediate_1": "li4shi3",
+        "intermediate_2": "lìshǐ",
+        "native_1": "history",
+        "primary_1": "历史",
+        "primary_2": "歷史"
+    },
+    {
+        "intermediate_1": "lian3",
+        "intermediate_2": "liǎn",
+        "native_1": "face",
+        "primary_1": "脸",
+        "primary_2": "臉"
+    },
+    {
+        "intermediate_1": "lian4xi2",
+        "intermediate_2": "liànxí",
+        "native_1": "practice; exercise",
+        "primary_1": "练习",
+        "primary_2": "練習"
+    },
+    {
+        "intermediate_1": "liang4",
+        "intermediate_2": "liàng",
+        "native_1": "(mw for vehicles)",
+        "primary_1": "辆",
+        "primary_2": "輛"
+    },
+    {
+        "intermediate_1": "liao2tian1",
+        "intermediate_2": "liáotiān",
+        "native_1": "to chat",
+        "primary_1": "聊天",
+        "primary_2": "聊天"
+    },
+    {
+        "intermediate_1": "liao3jie3",
+        "intermediate_2": "liǎojiě",
+        "native_1": "comprehend; understand; know; find out",
+        "primary_1": "了解",
+        "primary_2": "了解"
+    },
+    {
+        "intermediate_1": "lin2ju1",
+        "intermediate_2": "línjū",
+        "native_1": "neighbor",
+        "primary_1": "邻居",
+        "primary_2": "鄰居"
+    },
+    {
+        "intermediate_1": "liu2xue2",
+        "intermediate_2": "liúxué",
+        "native_1": "study abroad",
+        "primary_1": "留学",
+        "primary_2": "留學"
+    },
+    {
+        "intermediate_1": "lou2",
+        "intermediate_2": "lóu",
+        "native_1": "story; floor; (multi-story) building",
+        "primary_1": "楼",
+        "primary_2": "樓"
+    },
+    {
+        "intermediate_1": "lv4",
+        "intermediate_2": "lǜ",
+        "native_1": "green",
+        "primary_1": "绿",
+        "primary_2": "綠"
+    },
+    {
+        "intermediate_1": "ma3",
+        "intermediate_2": "mǎ",
+        "native_1": "horse (Kangxi radical 187)",
+        "primary_1": "马",
+        "primary_2": "馬"
+    },
+    {
+        "intermediate_1": "ma3shang4",
+        "intermediate_2": "mǎshàng",
+        "native_1": "at once; immediately; right away",
+        "primary_1": "马上",
+        "primary_2": "馬上"
+    },
+    {
+        "intermediate_1": "man3yi4",
+        "intermediate_2": "mǎnyì",
+        "native_1": "satisfied; pleased",
+        "primary_1": "满意",
+        "primary_2": "滿意"
+    },
+    {
+        "intermediate_1": "mao4zi5",
+        "intermediate_2": "màozi",
+        "native_1": "hat; cap",
+        "primary_1": "帽子",
+        "primary_2": "帽子"
+    },
+    {
+        "intermediate_1": "mi3",
+        "intermediate_2": "mǐ",
+        "native_1": "rice; meter (Kangxi radical 119)",
+        "primary_1": "米",
+        "primary_2": "米"
+    },
+    {
+        "intermediate_1": "mian4bao1",
+        "intermediate_2": "miànbāo",
+        "native_1": "bread",
+        "primary_1": "面包",
+        "primary_2": "面包"
+    },
+    {
+        "intermediate_1": "ming2bai5",
+        "intermediate_2": "míngbai",
+        "native_1": "clear; obvious; understand; explicit",
+        "primary_1": "明白",
+        "primary_2": "明白"
+    },
+    {
+        "intermediate_1": "na2",
+        "intermediate_2": "ná",
+        "native_1": "carry in your hand; seize; to catch",
+        "primary_1": "拿",
+        "primary_2": "拿"
+    },
+    {
+        "intermediate_1": "nai3nai5",
+        "intermediate_2": "nǎinai",
+        "native_1": "grandma; (informal) paternal grandmother",
+        "primary_1": "奶奶",
+        "primary_2": "奶奶"
+    },
+    {
+        "intermediate_1": "nan2",
+        "intermediate_2": "nán",
+        "native_1": "South",
+        "primary_1": "南",
+        "primary_2": "南"
+    },
+    {
+        "intermediate_1": "nan2",
+        "intermediate_2": "nán",
+        "native_1": "difficult",
+        "primary_1": "难",
+        "primary_2": "難"
+    },
+    {
+        "intermediate_1": "nan2guo4",
+        "intermediate_2": "nánguò",
+        "native_1": "be grieved; be sad; have a hard time",
+        "primary_1": "难过",
+        "primary_2": "難過"
+    },
+    {
+        "intermediate_1": "nian2ji2",
+        "intermediate_2": "niánjí",
+        "native_1": "grade; year (in school)",
+        "primary_1": "年级",
+        "primary_2": "年級"
+    },
+    {
+        "intermediate_1": "nian2qing1",
+        "intermediate_2": "niánqīng",
+        "native_1": "young",
+        "primary_1": "年轻",
+        "primary_2": "年輕"
+    },
+    {
+        "intermediate_1": "niao3",
+        "intermediate_2": "niǎo",
+        "native_1": "bird (Kangxi radical 196)",
+        "primary_1": "鸟",
+        "primary_2": "鳥"
+    },
+    {
+        "intermediate_1": "nu3li4",
+        "intermediate_2": "nǔlì",
+        "native_1": "to work hard; to strive",
+        "primary_1": "努力",
+        "primary_2": "努力"
+    },
+    {
+        "intermediate_1": "pa2shan1",
+        "intermediate_2": "páshān",
+        "native_1": "mountain climbing",
+        "primary_1": "爬山",
+        "primary_2": "爬山"
+    },
+    {
+        "intermediate_1": "pan2zi5",
+        "intermediate_2": "pánzi",
+        "native_1": "plate; dish; tray",
+        "primary_1": "盘子",
+        "primary_2": "盤子"
+    },
+    {
+        "intermediate_1": "pang4",
+        "intermediate_2": "pàng",
+        "native_1": "fat; plump",
+        "primary_1": "胖",
+        "primary_2": "胖"
+    },
+    {
+        "intermediate_1": "pi2xie2",
+        "intermediate_2": "píxié",
+        "native_1": "leather shoes",
+        "primary_1": "皮鞋",
+        "primary_2": "皮鞋"
+    },
+    {
+        "intermediate_1": "pi2jiu3",
+        "intermediate_2": "píjiǔ",
+        "native_1": "beer",
+        "primary_1": "啤酒",
+        "primary_2": "啤酒"
+    },
+    {
+        "intermediate_1": "ping2zi5",
+        "intermediate_2": "píngzi",
+        "native_1": "bottle",
+        "primary_1": "瓶子",
+        "primary_2": "瓶子"
+    },
+    {
+        "intermediate_1": "qi2shi2",
+        "intermediate_2": "qíshí",
+        "native_1": "actually; in fact",
+        "primary_1": "其实",
+        "primary_2": "其實"
+    },
+    {
+        "intermediate_1": "qi2ta1",
+        "intermediate_2": "qítā",
+        "native_1": "other; else",
+        "primary_1": "其他",
+        "primary_2": "其他"
+    },
+    {
+        "intermediate_1": "qi2guai4",
+        "intermediate_2": "qíguài",
+        "native_1": "strange; odd",
+        "primary_1": "奇怪",
+        "primary_2": "奇怪"
+    },
+    {
+        "intermediate_1": "qi2",
+        "intermediate_2": "qí",
+        "native_1": "to ride (an animal or bike); to sit astride",
+        "primary_1": "骑",
+        "primary_2": "騎"
+    },
+    {
+        "intermediate_1": "qi3fei1",
+        "intermediate_2": "qǐfēi",
+        "native_1": "take off (in an airplane); liftoff",
+        "primary_1": "起飞",
+        "primary_2": "起飛"
+    },
+    {
+        "intermediate_1": "qi3lai5",
+        "intermediate_2": "qǐlai",
+        "native_1": "(beginning or continuing an action); to rise; get up (from bed)",
+        "primary_1": "起来",
+        "primary_2": "起來"
+    },
+    {
+        "intermediate_1": "qing1chu5",
+        "intermediate_2": "qīngchu",
+        "native_1": "clear; distinct; be clear about",
+        "primary_1": "清楚",
+        "primary_2": "清楚"
+    },
+    {
+        "intermediate_1": "qing3jia4",
+        "intermediate_2": "qǐngjià",
+        "native_1": "to ask for time off",
+        "primary_1": "请假",
+        "primary_2": "請假"
+    },
+    {
+        "intermediate_1": "qiu1",
+        "intermediate_2": "qiū",
+        "native_1": "autumn; fall; harvest time",
+        "primary_1": "秋",
+        "primary_2": "秋"
+    },
+    {
+        "intermediate_1": "qun2zi5",
+        "intermediate_2": "qúnzi",
+        "native_1": "skirt",
+        "primary_1": "裙子",
+        "primary_2": "裙子"
+    },
+    {
+        "intermediate_1": "ran2hou4",
+        "intermediate_2": "ránhòu",
+        "native_1": "then; afterwards",
+        "primary_1": "然后",
+        "primary_2": "然后"
+    },
+    {
+        "intermediate_1": "re4qing2",
+        "intermediate_2": "rèqíng",
+        "native_1": "cordial; warm; enthusiastic",
+        "primary_1": "热情",
+        "primary_2": "熱情"
+    },
+    {
+        "intermediate_1": "ren4wei2",
+        "intermediate_2": "rènwéi",
+        "native_1": "believe; think that",
+        "primary_1": "认为",
+        "primary_2": "認為"
+    },
+    {
+        "intermediate_1": "ren4zhen1",
+        "intermediate_2": "rènzhēn",
+        "native_1": "serious; earnest; take seriously",
+        "primary_1": "认真",
+        "primary_2": "認真"
+    },
+    {
+        "intermediate_1": "rong2yi4",
+        "intermediate_2": "róngyì",
+        "native_1": "easy; likely; liable (to)",
+        "primary_1": "容易",
+        "primary_2": "容易"
+    },
+    {
+        "intermediate_1": "ru2guo3",
+        "intermediate_2": "rúguǒ",
+        "native_1": "if; in the event that",
+        "primary_1": "如果",
+        "primary_2": "如果"
+    },
+    {
+        "intermediate_1": "san3",
+        "intermediate_2": "sǎn",
+        "native_1": "umbrella; parasol",
+        "primary_1": "伞",
+        "primary_2": "傘"
+    },
+    {
+        "intermediate_1": "shang4wang3",
+        "intermediate_2": "shàngwǎng",
+        "native_1": "to surf the web; to go online",
+        "primary_1": "上网",
+        "primary_2": "上網"
+    },
+    {
+        "intermediate_1": "sheng1qi4",
+        "intermediate_2": "shēngqì",
+        "native_1": "angry; mad",
+        "primary_1": "生气",
+        "primary_2": "生氣"
+    },
+    {
+        "intermediate_1": "sheng1yin1",
+        "intermediate_2": "shēngyīn",
+        "native_1": "sound; voice",
+        "primary_1": "声音",
+        "primary_2": "聲音"
+    },
+    {
+        "intermediate_1": "shi4jie4",
+        "intermediate_2": "shìjiè",
+        "native_1": "world",
+        "primary_1": "世界",
+        "primary_2": "世界"
+    },
+    {
+        "intermediate_1": "shi4",
+        "intermediate_2": "shì",
+        "native_1": "to try; to test; examination",
+        "primary_1": "试",
+        "primary_2": "試"
+    },
+    {
+        "intermediate_1": "shou4",
+        "intermediate_2": "shòu",
+        "native_1": "thin; tight; lean",
+        "primary_1": "瘦",
+        "primary_2": "瘦"
+    },
+    {
+        "intermediate_1": "shu1shu5",
+        "intermediate_2": "shūshu",
+        "native_1": "(informal) father's younger brother; uncle",
+        "primary_1": "叔叔",
+        "primary_2": "叔叔"
+    },
+    {
+        "intermediate_1": "shu1fu5",
+        "intermediate_2": "shūfu",
+        "native_1": "comfortable; feeling well",
+        "primary_1": "舒服",
+        "primary_2": "舒服"
+    },
+    {
+        "intermediate_1": "shu4",
+        "intermediate_2": "shù",
+        "native_1": "tree",
+        "primary_1": "树",
+        "primary_2": "樹"
+    },
+    {
+        "intermediate_1": "shu4xue2",
+        "intermediate_2": "shùxué",
+        "native_1": "mathematics",
+        "primary_1": "数学",
+        "primary_2": "數學"
+    },
+    {
+        "intermediate_1": "shua1ya2",
+        "intermediate_2": "shuāyá",
+        "native_1": "brush one's teeth",
+        "primary_1": "刷牙",
+        "primary_2": "刷牙"
+    },
+    {
+        "intermediate_1": "shuang1",
+        "intermediate_2": "shuāng",
+        "native_1": "two; double; (mw for pairs)",
+        "primary_1": "双",
+        "primary_2": "雙"
+    },
+    {
+        "intermediate_1": "shui3ping2",
+        "intermediate_2": "shuǐpíng",
+        "native_1": "level; standard; horizontal",
+        "primary_1": "水平",
+        "primary_2": "水平"
+    },
+    {
+        "intermediate_1": "si1ji1",
+        "intermediate_2": "sījī",
+        "native_1": "driver; chauffeur",
+        "primary_1": "司机",
+        "primary_2": "司機"
+    },
+    {
+        "intermediate_1": "tai4yang2",
+        "intermediate_2": "tàiyáng",
+        "native_1": "the sun",
+        "primary_1": "太阳",
+        "primary_2": "太陽"
+    },
+    {
+        "intermediate_1": "te4bie2",
+        "intermediate_2": "tèbié",
+        "native_1": "special; especially; particular",
+        "primary_1": "特别",
+        "primary_2": "特別"
+    },
+    {
+        "intermediate_1": "teng2",
+        "intermediate_2": "téng",
+        "native_1": "ache; sore; (it) hurts; love fondly",
+        "primary_1": "疼",
+        "primary_2": "疼"
+    },
+    {
+        "intermediate_1": "ti2gao1",
+        "intermediate_2": "tígāo",
+        "native_1": "to raise; heighten; improve",
+        "primary_1": "提高",
+        "primary_2": "提高"
+    },
+    {
+        "intermediate_1": "ti3yu4",
+        "intermediate_2": "tǐyù",
+        "native_1": "physical training; sports",
+        "primary_1": "体育",
+        "primary_2": "體育"
+    },
+    {
+        "intermediate_1": "tian2",
+        "intermediate_2": "tián",
+        "native_1": "sweet",
+        "primary_1": "甜",
+        "primary_2": "甜"
+    },
+    {
+        "intermediate_1": "tiao2",
+        "intermediate_2": "tiáo",
+        "native_1": "strip; (mw for long thin objects); item",
+        "primary_1": "条",
+        "primary_2": "條"
+    },
+    {
+        "intermediate_1": "tong2shi4",
+        "intermediate_2": "tóngshì",
+        "native_1": "colleague; co-worker",
+        "primary_1": "同事",
+        "primary_2": "同事"
+    },
+    {
+        "intermediate_1": "tong2yi4",
+        "intermediate_2": "tóngyì",
+        "native_1": "agree; to consent; approve",
+        "primary_1": "同意",
+        "primary_2": "同意"
+    },
+    {
+        "intermediate_1": "tou2fa5",
+        "intermediate_2": "tóufa",
+        "native_1": "hair (on the head)",
+        "primary_1": "头发",
+        "primary_2": "頭發"
+    },
+    {
+        "intermediate_1": "tu1ran2",
+        "intermediate_2": "tūrán",
+        "native_1": "sudden; abrupt",
+        "primary_1": "突然",
+        "primary_2": "突然"
+    },
+    {
+        "intermediate_1": "tu2shu1guan3",
+        "intermediate_2": "túshūguǎn",
+        "native_1": "library",
+        "primary_1": "图书馆",
+        "primary_2": "圖書館"
+    },
+    {
+        "intermediate_1": "tui3",
+        "intermediate_2": "tuǐ",
+        "native_1": "leg",
+        "primary_1": "腿",
+        "primary_2": "腿"
+    },
+    {
+        "intermediate_1": "wan2cheng2",
+        "intermediate_2": "wánchéng",
+        "native_1": "to complete; accomplish; to fulfill",
+        "primary_1": "完成",
+        "primary_2": "完成"
+    },
+    {
+        "intermediate_1": "wan3",
+        "intermediate_2": "wǎn",
+        "native_1": "bowl; cup",
+        "primary_1": "碗",
+        "primary_2": "碗"
+    },
+    {
+        "intermediate_1": "wan4",
+        "intermediate_2": "wàn",
+        "native_1": "ten thousand",
+        "primary_1": "万",
+        "primary_2": "萬"
+    },
+    {
+        "intermediate_1": "wang4ji4",
+        "intermediate_2": "wàngjì",
+        "native_1": "forget",
+        "primary_1": "忘记",
+        "primary_2": "忘記"
+    },
+    {
+        "intermediate_1": "wei4",
+        "intermediate_2": "wèi",
+        "native_1": "for; because of; to; for the sake of",
+        "primary_1": "为",
+        "primary_2": "為"
+    },
+    {
+        "intermediate_1": "wei4le5",
+        "intermediate_2": "wèile",
+        "native_1": "in order to; for the sake of; for the purpose of",
+        "primary_1": "为了",
+        "primary_2": "為了"
+    },
+    {
+        "intermediate_1": "wei4",
+        "intermediate_2": "wèi",
+        "native_1": "position; location; (polite mw for people)",
+        "primary_1": "位",
+        "primary_2": "位"
+    },
+    {
+        "intermediate_1": "wen2hua4",
+        "intermediate_2": "wénhuà",
+        "native_1": "culture; civilization",
+        "primary_1": "文化",
+        "primary_2": "文化"
+    },
+    {
+        "intermediate_1": "xi1",
+        "intermediate_2": "xī",
+        "native_1": "West (Kangxi radical 146)",
+        "primary_1": "西",
+        "primary_2": "西"
+    },
+    {
+        "intermediate_1": "xi2guan4",
+        "intermediate_2": "xíguàn",
+        "native_1": "habit; be accustomed to; usual practice",
+        "primary_1": "习惯",
+        "primary_2": "習慣"
+    },
+    {
+        "intermediate_1": "xi3shou3jian1",
+        "intermediate_2": "xǐshǒujiān",
+        "native_1": "toilet; lavatory; washroom",
+        "primary_1": "洗手间",
+        "primary_2": "洗手間"
+    },
+    {
+        "intermediate_1": "xi3zao3",
+        "intermediate_2": "xǐzǎo",
+        "native_1": "bathe; take a bath or shower; bath or shower",
+        "primary_1": "洗澡",
+        "primary_2": "洗澡"
+    },
+    {
+        "intermediate_1": "xia4",
+        "intermediate_2": "xià",
+        "native_1": "summer",
+        "primary_1": "夏",
+        "primary_2": "夏"
+    },
+    {
+        "intermediate_1": "xian1",
+        "intermediate_2": "xiān",
+        "native_1": "first; early; before",
+        "primary_1": "先",
+        "primary_2": "先"
+    },
+    {
+        "intermediate_1": "xiang1xin4",
+        "intermediate_2": "xiāngxìn",
+        "native_1": "believe (sb.); be convinced of",
+        "primary_1": "相信",
+        "primary_2": "相信"
+    },
+    {
+        "intermediate_1": "xiang1jiao1",
+        "intermediate_2": "xiāngjiāo",
+        "native_1": "banana",
+        "primary_1": "香蕉",
+        "primary_2": "香蕉"
+    },
+    {
+        "intermediate_1": "xiang4",
+        "intermediate_2": "xiàng",
+        "native_1": "direction; towards; to turn; to face",
+        "primary_1": "向",
+        "primary_2": "向"
+    },
+    {
+        "intermediate_1": "xiang4",
+        "intermediate_2": "xiàng",
+        "native_1": "be like; resemble; appearance; appear",
+        "primary_1": "像",
+        "primary_2": "像"
+    },
+    {
+        "intermediate_1": "xiao3xin1",
+        "intermediate_2": "xiǎoxīn",
+        "native_1": "be careful",
+        "primary_1": "小心",
+        "primary_2": "小心"
+    },
+    {
+        "intermediate_1": "xiao4zhang3",
+        "intermediate_2": "xiàozhǎng",
+        "native_1": "principal (of school, college or university); president; headmaster",
+        "primary_1": "校长",
+        "primary_2": "校長"
+    },
+    {
+        "intermediate_1": "xin1wen2",
+        "intermediate_2": "xīnwén",
+        "native_1": "news",
+        "primary_1": "新闻",
+        "primary_2": "新聞"
+    },
+    {
+        "intermediate_1": "xin1xian1",
+        "intermediate_2": "xīnxiān",
+        "native_1": "fresh (experience, food, etc.); new; novel",
+        "primary_1": "新鲜",
+        "primary_2": "新鮮"
+    },
+    {
+        "intermediate_1": "xin4yong4ka3",
+        "intermediate_2": "xìnyòngkǎ",
+        "native_1": "credit card",
+        "primary_1": "信用卡",
+        "primary_2": "信用卡"
+    },
+    {
+        "intermediate_1": "xing2li3xiang1",
+        "intermediate_2": "xínglǐxiāng",
+        "native_1": "trunk; suitcase",
+        "primary_1": "行李箱",
+        "primary_2": "行李箱"
+    },
+    {
+        "intermediate_1": "xiong2mao1",
+        "intermediate_2": "xióngmāo",
+        "native_1": "panda",
+        "primary_1": "熊猫",
+        "primary_2": "熊貓"
+    },
+    {
+        "intermediate_1": "xu1yao4",
+        "intermediate_2": "xūyào",
+        "native_1": "to need; to want; to demand",
+        "primary_1": "需要",
+        "primary_2": "需要"
+    },
+    {
+        "intermediate_1": "xuan3ze2",
+        "intermediate_2": "xuǎnzé",
+        "native_1": "select; to pick; choose",
+        "primary_1": "选择",
+        "primary_2": "選擇"
+    },
+    {
+        "intermediate_1": "yao1qiu2",
+        "intermediate_2": "yāoqiú",
+        "native_1": "to request; to demand; requirement",
+        "primary_1": "要求",
+        "primary_2": "要求"
+    },
+    {
+        "intermediate_1": "ye2ye5",
+        "intermediate_2": "yéye",
+        "native_1": "(informal) father's father; paternal grandfather",
+        "primary_1": "爷爷",
+        "primary_2": "爺爺"
+    },
+    {
+        "intermediate_1": "yi4ban1",
+        "intermediate_2": "yìbān",
+        "native_1": "general; ordinary; common; same",
+        "primary_1": "一般",
+        "primary_2": "一般"
+    },
+    {
+        "intermediate_1": "yi4bian1",
+        "intermediate_2": "yìbiān",
+        "native_1": "one side; on the one hand; at the same time",
+        "primary_1": "一边",
+        "primary_2": "一邊"
+    },
+    {
+        "intermediate_1": "yi2ding4",
+        "intermediate_2": "yídìng",
+        "native_1": "surely; certainly; necessarily; definite",
+        "primary_1": "一定",
+        "primary_2": "一定"
+    },
+    {
+        "intermediate_1": "yi2gong4",
+        "intermediate_2": "yígòng",
+        "native_1": "altogether; in total",
+        "primary_1": "一共",
+        "primary_2": "一共"
+    },
+    {
+        "intermediate_1": "yi2hui4r5",
+        "intermediate_2": "yíhuìr",
+        "native_1": "a while; a moment",
+        "primary_1": "一会儿",
+        "primary_2": "一會兒"
+    },
+    {
+        "intermediate_1": "yi2yang4",
+        "intermediate_2": "yíyàng",
+        "native_1": "the same; alike; equal to",
+        "primary_1": "一样",
+        "primary_2": "一樣"
+    },
+    {
+        "intermediate_1": "yi4zhi2",
+        "intermediate_2": "yìzhí",
+        "native_1": "always; all along; straight (in a straight line)",
+        "primary_1": "一直",
+        "primary_2": "一直"
+    },
+    {
+        "intermediate_1": "yi3qian2",
+        "intermediate_2": "yǐqián",
+        "native_1": "before; formerly; previous",
+        "primary_1": "以前",
+        "primary_2": "以前"
+    },
+    {
+        "intermediate_1": "yin1yue4",
+        "intermediate_2": "yīnyuè",
+        "native_1": "music",
+        "primary_1": "音乐",
+        "primary_2": "音樂"
+    },
+    {
+        "intermediate_1": "yin2hang2",
+        "intermediate_2": "yínháng",
+        "native_1": "bank",
+        "primary_1": "银行",
+        "primary_2": "銀行"
+    },
+    {
+        "intermediate_1": "yin3liao4",
+        "intermediate_2": "yǐnliào",
+        "native_1": "beverage; drink",
+        "primary_1": "饮料",
+        "primary_2": "飲料"
+    },
+    {
+        "intermediate_1": "ying1gai1",
+        "intermediate_2": "yīnggāi",
+        "native_1": "should; ought to; must",
+        "primary_1": "应该",
+        "primary_2": "應該"
+    },
+    {
+        "intermediate_1": "ying3xiang3",
+        "intermediate_2": "yǐngxiǎng",
+        "native_1": "influence; affect; effect",
+        "primary_1": "影响",
+        "primary_2": "影響"
+    },
+    {
+        "intermediate_1": "yong4",
+        "intermediate_2": "yòng",
+        "native_1": "to use (Kangxi radical 101)",
+        "primary_1": "用",
+        "primary_2": "用"
+    },
+    {
+        "intermediate_1": "you2xi4",
+        "intermediate_2": "yóuxì",
+        "native_1": "game; play; recreation",
+        "primary_1": "游戏",
+        "primary_2": "游戲"
+    },
+    {
+        "intermediate_1": "you3ming2",
+        "intermediate_2": "yǒumíng",
+        "native_1": "famous; well-known",
+        "primary_1": "有名",
+        "primary_2": "有名"
+    },
+    {
+        "intermediate_1": "you4",
+        "intermediate_2": "yòu",
+        "native_1": "(once) again; also; both (Kangxi radical 29)",
+        "primary_1": "又",
+        "primary_2": "又"
+    },
+    {
+        "intermediate_1": "yu4dao4",
+        "intermediate_2": "yùdào",
+        "native_1": "to meet; run into; come across",
+        "primary_1": "遇到",
+        "primary_2": "遇到"
+    },
+    {
+        "intermediate_1": "yuan2",
+        "intermediate_2": "yuán",
+        "native_1": "Chinese monetary unit; dollar; first; principal",
+        "primary_1": "元",
+        "primary_2": "元"
+    },
+    {
+        "intermediate_1": "yuan4yi4",
+        "intermediate_2": "yuànyì",
+        "native_1": "be willing; want to; be ready",
+        "primary_1": "愿意",
+        "primary_2": "願意"
+    },
+    {
+        "intermediate_1": "yue4liang5",
+        "intermediate_2": "yuèliang",
+        "native_1": "the moon",
+        "primary_1": "月亮",
+        "primary_2": "月亮"
+    },
+    {
+        "intermediate_1": "yue4",
+        "intermediate_2": "yuè",
+        "native_1": "even more; the more; exceed",
+        "primary_1": "越",
+        "primary_2": "越"
+    },
+    {
+        "intermediate_1": "zhan4",
+        "intermediate_2": "zhàn",
+        "native_1": "stand; a station; be on one's feet; service center",
+        "primary_1": "站",
+        "primary_2": "站"
+    },
+    {
+        "intermediate_1": "zhang1",
+        "intermediate_2": "zhāng",
+        "native_1": "(mw for flat objects); to spread out; (common surname)",
+        "primary_1": "张",
+        "primary_2": "張"
+    },
+    {
+        "intermediate_1": "chang2, zhang3",
+        "intermediate_2": "cháng, zhǎng",
+        "native_1": "long; length | grow; chief (Kangxi radical 168)",
+        "primary_1": "长",
+        "primary_2": "長"
+    },
+    {
+        "intermediate_1": "zhao2ji2",
+        "intermediate_2": "zháojí",
+        "native_1": "to worry; feel anxious",
+        "primary_1": "着急",
+        "primary_2": "著急"
+    },
+    {
+        "intermediate_1": "zhao4gu5",
+        "intermediate_2": "zhàogu",
+        "native_1": "take care of; look after; give consideration",
+        "primary_1": "照顾",
+        "primary_2": "照顧"
+    },
+    {
+        "intermediate_1": "zhao4pian4",
+        "intermediate_2": "zhàopiàn",
+        "native_1": "picture; photograph",
+        "primary_1": "照片",
+        "primary_2": "照片"
+    },
+    {
+        "intermediate_1": "zhao4xiang4ji1",
+        "intermediate_2": "zhàoxiàngjī",
+        "native_1": "camera",
+        "primary_1": "照相机",
+        "primary_2": "照相機"
+    },
+    {
+        "intermediate_1": "zhi1, zhi3",
+        "intermediate_2": "zhī, zhǐ",
+        "native_1": "but; only; merely; just | (mw for birds and certain animals)",
+        "primary_1": "只",
+        "primary_2": "隻"
+    },
+    {
+        "intermediate_1": "zhi3you3",
+        "intermediate_2": "zhǐyǒu",
+        "native_1": "only",
+        "primary_1": "只有",
+        "primary_2": "隻有"
+    },
+    {
+        "intermediate_1": "cai2",
+        "intermediate_2": "cái",
+        "native_1": "ability; talent; just now; not until",
+        "primary_1": "才",
+        "primary_2": "才"
+    },
+    {
+        "intermediate_1": "zhong1jian1",
+        "intermediate_2": "zhōngjiān",
+        "native_1": "center; middle; between; among",
+        "primary_1": "中间",
+        "primary_2": "中間"
+    },
+    {
+        "intermediate_1": "Zhong1wen2",
+        "intermediate_2": "Zhōngwén",
+        "native_1": "Chinese (language)",
+        "primary_1": "中文",
+        "primary_2": "中文"
+    },
+    {
+        "intermediate_1": "zhong1yu2",
+        "intermediate_2": "zhōngyú",
+        "native_1": "at last; in the end; finally",
+        "primary_1": "终于",
+        "primary_2": "終於"
+    },
+    {
+        "intermediate_1": "zhong3",
+        "intermediate_2": "zhǒng",
+        "native_1": "type; breed; race; seed",
+        "primary_1": "种",
+        "primary_2": "種"
+    },
+    {
+        "intermediate_1": "zhong4yao4",
+        "intermediate_2": "zhòngyào",
+        "native_1": "important; significant; major",
+        "primary_1": "重要",
+        "primary_2": "重要"
+    },
+    {
+        "intermediate_1": "zhou1mo4",
+        "intermediate_2": "zhōumò",
+        "native_1": "weekend",
+        "primary_1": "周末",
+        "primary_2": "周末"
+    },
+    {
+        "intermediate_1": "zhu3yao4",
+        "intermediate_2": "zhǔyào",
+        "native_1": "main; principal; major",
+        "primary_1": "主要",
+        "primary_2": "主要"
+    },
+    {
+        "intermediate_1": "zhu4yi4",
+        "intermediate_2": "zhùyì",
+        "native_1": "pay attention to; take notice of; be careful",
+        "primary_1": "注意",
+        "primary_2": "注意"
+    },
+    {
+        "intermediate_1": "zi4ji3",
+        "intermediate_2": "zìjǐ",
+        "native_1": "oneself; self",
+        "primary_1": "自己",
+        "primary_2": "自己"
+    },
+    {
+        "intermediate_1": "zi4xing2che1",
+        "intermediate_2": "zìxíngchē",
+        "native_1": "bike; bicycle",
+        "primary_1": "自行车",
+        "primary_2": "自行車"
+    },
+    {
+        "intermediate_1": "zong3shi4",
+        "intermediate_2": "zǒngshì",
+        "native_1": "always; eventually",
+        "primary_1": "总是",
+        "primary_2": "總是"
+    },
+    {
+        "intermediate_1": "zui3",
+        "intermediate_2": "zuǐ",
+        "native_1": "mouth",
+        "primary_1": "嘴",
+        "primary_2": "嘴"
+    },
+    {
+        "intermediate_1": "zui4hou4",
+        "intermediate_2": "zuìhòu",
+        "native_1": "last; final; ultimately",
+        "primary_1": "最后",
+        "primary_2": "最后"
+    },
+    {
+        "intermediate_1": "zui4jin4",
+        "intermediate_2": "zuìjìn",
+        "native_1": "recently; lately; these days",
+        "primary_1": "最近",
+        "primary_2": "最近"
+    },
+    {
+        "intermediate_1": "zuo4ye4",
+        "intermediate_2": "zuòyè",
+        "native_1": "school assignment; homework; task",
+        "primary_1": "作业",
+        "primary_2": "作業"
+    }
+]

--- a/vocab/mandarin/hsk/4/vocab.csv
+++ b/vocab/mandarin/hsk/4/vocab.csv
@@ -1,0 +1,601 @@
+PRIMARY	PRIMARY	INTERMEDIATE	INTERMEDIATE	NATIVE
+爱情	愛情	ai4qing2	àiqíng	(romantic) love
+安排	安排	an1pai2	ānpái	arrange; to plan
+安全	安全	an1quan2	ānquán	safe; safety; secure; security
+按时	按時	an4shi2	ànshí	on time; on schedule
+按照	按照	an4zhao4	ànzhào	according to; in accordance with; in light of
+百分之	百分之	bai3fen1zhi1	bǎifēnzhī	percent
+棒	棒	bang4	bàng	stick; club; good; excellent
+包子	包子	bao1zi	bāozi	steamed stuffed bun
+保护	保護	bao3hu4	bǎohù	to protect; to defend
+保证	保證	bao3zheng4	bǎozhèng	to guarantee; ensure
+报名	報名	bao4 ming2	bào míng	sign up; apply
+抱	抱	bao4	bào	to hold; to hug; carry in one's arms; to cradle
+抱歉	抱歉	bao4qian4	bàoqiàn	be sorry; feel apologetic; to regret
+倍	倍	bei4	bèi	(two, three, etc)-fold; times (multiplier)
+本来	本來	ben3lai2	běnlái	originally; at first
+笨	笨	ben4	bèn	stupid; foolish; silly; dumb; clumsy
+比如	比如	bi3ru2	bǐrú	for example; for instance; such as
+毕业	畢業	bi4 ye4	bì yè	to graduate; to finish school
+遍	遍	bian4	biàn	a time; everywhere; turn; (mw for times or turns)
+标准	標准	biao1zhun3	biāozhǔn	(an official) standard; norm; criterion
+表格	表格	biao3ge2	biǎogé	form (document)
+表示	表示	biao3shi4	biǎoshì	express; show; indicate
+表演	表演	biao3yan3	biǎoyǎn	perform; to play
+表扬	表揚	biao3yang2	biǎoyáng	to praise; commend
+饼干	餅幹	bing3gan1	bǐnggān	biscuit; cracker; cookie
+并且	並且	bing4qie3	bìngqiě	and; besides; moreover
+博士	博士	bo2shi4	bóshì	doctor; PhD
+不得不	不得不	bu4 de2 bu4	bù dé bù	have to; have no choice but to; cannot but
+不管	不管	bu4guan3	bùguǎn	no matter (what, how, etc.); regardless of
+不过	不過	bu2guo4	búguò	only; merely; but; however
+不仅	不僅	bu4jin3	bùjǐn	not only; not just
+部分	部分	bu4fen	bùfen	part; share; section
+擦	擦	ca1	cā	to wipe; to rub; to polish
+猜	猜	cai1	cāi	to guess
+材料	材料	cai2liao4	cáiliào	material
+参观	參觀	cang1uan1	cānguān	to visit (a place, such as a tourist spot); inspect
+餐厅	餐廳	can1ting1	cāntīng	dining hall; cafeteria; restaurant
+厕所	廁所	ce4suo3	cèsuǒ	bathroom; toilet; lavatory
+差不多	差不多	cha4buduo1	chàbuduō	almost; about the same
+长城	長城	chang2cheng2	chángchéng	the Great Wall
+长江	長江	Chang2jiang1	Chángjiāng	the Yangtze River; the Changjiang River
+尝	嘗	chang2	cháng	to taste; flavor; (past tense marker)
+场	場	chang3	chǎng	courtyard; place; field; (mw for games, performances, etc.)
+超过	超過	chao1guo4	chāoguò	surpass; exceed; outstrip
+成功	成功	cheng2gong1	chénggōng	success; to succeed
+成为	成爲	cheng2wei2	chéngwéi	become; turn into
+诚实	誠實	cheng2shi2	chéngshí	honest; honorable
+乘坐	乘坐	cheng2zuo4	chéngzuò	ride; get into (a vehicle)
+吃惊	吃驚	chi1 jing1	chī jīng	be startled; be shocked; be amazed
+重新	重新	chong2xin1	chóngxīn	again; anew; once more
+抽烟	抽煙	chou1yan1	chōuyān	to smoke (a cigarette, pipe, etc.)
+出差	出差	chu1 chai1	chū chāi	go on a business trip
+出发	出發	chu1fa1	chūfā	start out; set off
+出生	出生	chu1sheng1	chūshēng	be born
+出现	出現	chu1xian4	chūxiàn	appear; arise; emerge
+厨房	廚房	chu2fang2	chúfáng	kitchen
+传真	傳真	chuan2zhen1	chuánzhēn	fax; facsimile
+窗户	窗戶	chuang1hu	chuānghu	window
+词语	詞語	ci2yu3	cíyǔ	words and expressions; terms
+从来	從來	cong2lai2	cónglái	always; at all times
+粗心	粗心	cu1xin1	cūxīn	careless; inadvertent; negligent
+存	存	cun2	cún	exist; to deposit; to store
+错误	錯誤	cuo4wu4	cuòwù	error; mistake; mistaken
+答案	答案	da2'an4	dá'àn	answer; solution
+打扮	打扮	da3ban	dǎban	dress up; put on make up
+打扰	打擾	da3rao3	dǎrǎo	disturb
+打印	打印	da3yin4	dǎyìn	to print
+打招呼	打招呼	da3zhao1hu	dǎzhāohu	notify; greet; inform
+打折	打折	da3zhe2	dǎzhé	sell at a discount
+打针	打針	da3zhen1	dǎzhēn	inject; get a shot
+大概	大概	da4gai4	dàgài	probably; roughly; approximate
+大使馆	大使館	da4shi3guan3	dàshǐguǎn	embassy
+大约	大約	da4yue1	dàyuē	approximately; about
+大夫	大夫	dai4fu	dàifu	doctor; physician
+戴	戴	dai4	dài	put on; to wear; to respect
+当	當	dang1	dāng	should; act as; work as; manage; match; (sound of bells)
+当时	當時	dang1shi2	dāngshí	then; at that time; while
+刀	刀	dao1	dāo	knife; blade (Kangxi radical 18)
+导游	導遊	dao3you2	dǎoyóu	tour guide
+到处	到處	dao4chu4	dàochù	everywhere; in all places; all over
+到底	到底	dao4 di3	dào dǐ	after all; in the end (used in a question)
+倒	倒	dao3, dao4	dǎo, dào	to collapse; to fall; fail; to exchange | to pour; contrary to expectations
+道歉	道歉	dao4qian4	dàoqiàn	apologize; make an apology
+得意	得意	de2yi4	déyì	proud of oneself; complacent
+得	得	de	de	(complement particle)
+登机牌	登機牌	deng1ji1pai2	dēngjīpái	boarding pass
+等	等	deng3	děng	to wait; rank; equal; etc.
+低	低	di1	dī	low; to lower (one's head); droop
+底	底	di3	dǐ	bottom; background; base
+地点	地點	di4dian3	dìdiǎn	place; site; location
+地球	地球	di4qiu2	dìqiú	the Earth; planet
+地址	地址	di4zhi3	dìzhǐ	address
+调查	調查	diao4cha2	diàochá	investigate; survey; inquiry
+掉	掉	diao4	diào	to drop; to fall
+丢	丟	diu1	diū	lose (something); throw; put aside
+动作	動作	dong4zuo4	dòngzuò	movement; motion; action
+堵车	堵車	du3che1	dǔchē	traffic jam
+肚子	肚子	du4zi	dùzi	belly; abdomen; stomach
+短信	短信	duan3xin4	duǎnxìn	text message; SMS
+对话	對話	dui4hua4	duìhuà	dialogue; conversation
+对面	對面	dui4mian4	duìmiàn	opposite; across from; the other side
+对于	對于	dui4yu2	duìyú	regarding; as far as sth. is concerned; with regards to; for
+儿童	兒童	er2tong2	értóng	child; children
+而	而	er2	ér	and; but; yet; while (Kangxi radical 126)
+发生	發生	fa1sheng1	fāshēng	happen; occur; take place
+发展	發展	fa1zhan3	fāzhǎn	develop; development; growth
+法律	法律	fa3lü4	fǎlǜ	law; statute
+翻译	翻譯	fan1yi4	fānyì	translate; translation; interpret
+烦恼	煩惱	fan2nao3	fánnǎo	worried; vexed
+反对	反對	fan3dui4	fǎnduì	oppose; fight against
+方法	方法	fang1fa3	fāngfǎ	method; way; means
+方面	方面	fang1mian4	fāngmiàn	aspect; field; side
+方向	方向	fang1xiang4	fāngxiàng	direction; orientation
+房东	房東	fang2dong1	fángdōng	landlord
+放弃	放棄	fang4qi4	fàngqì	abandon; renounce; give up
+放暑假	放暑假	fang4 shu3jia4	fàng shǔjià	have summer vacation
+放松	放松	fang4song1	fàngsōng	relax; loosen; slacken
+份	份	fen4	fèn	part; portion; (mw for documents, papers, jobs, etc.)
+丰富	豐富	feng1fu4	fēngfù	rich; enrich; abundant; plentiful
+否则	否則	fou3ze2	fǒuzé	if not; otherwise; or else
+符合	符合	fu2he2	fúhé	in keeping with; in accordance with; conform
+父亲	父親	fu4qin	fùqin	father
+付款	付款	fu4 kuan3	fù kuǎn	to pay
+负责	負責	fu4ze2	fùzé	responsible for (something); in charge of
+复印	複印	fu4yin4	fùyìn	photocopy; duplicate
+复杂	複雜	fu4za2	fùzá	complicated; complex
+富	富	fu4	fù	wealthy
+改变	改變	gai3bian4	gǎibiàn	to change; alter; to transform
+干杯	幹杯	gan1 bei1	gān bēi	to drink a toast; cheers!; bottoms up!
+赶	趕	gan3	gǎn	catch up; overtake; drive away
+敢	敢	gan3	gǎn	to dare
+感动	感動	gan3dong4	gǎndòng	be moved; to touch emotionally
+感觉	感覺	gan3jue2	gǎnjué	to feel; become aware of; feeling
+感情	感情	gan3qing2	gǎnqíng	feeling; emotion; sensation
+感谢	感謝	gan3xie4	gǎnxiè	thank; be grateful
+干	幹	gan1	gān	to concern; shield; dry; clean (Kangxi radical 51)
+刚	剛	gang1	gāng	just (indicating the immediate past); recently; firm
+高速公路	高速公路	gao1su4 gong1lu4	gāosù gōnglù	highway
+胳膊	胳膊	ge1bo	gēbo	arm
+各	各	ge4	gè	each; every
+工资	工資	gong1zi1	gōngzī	wages; pay; earnings; salary
+公里	公裏	gong1li3	gōnglǐ	kilometer
+功夫	功夫	gong1fu	gōngfu	kung fu; skill; art; labor
+共同	共同	gong4tong2	gòngtóng	together; common; joint
+购物	購物	gou4wu4	gòuwù	go shopping; buy goods
+够	夠	gou4	gòu	enough; to reach
+估计	估計	gu1ji4	gūjì	appraise; estimate
+鼓励	鼓勵	gu3li4	gǔlì	encourage; inspire
+故意	故意	gu4yi4	gùyì	deliberately; intentional; on purpose
+顾客	顧客	gu4ke4	gùkè	customer; client
+挂	挂	gua4	guà	hang; put up; suspend
+关键	關鍵	guan1jian4	guānjiàn	crucial; key; pivotal
+观众	觀衆	guan1zhong4	guānzhòng	spectator; audience
+管理	管理	guan3li3	guǎnlǐ	supervise; manage
+光	光	guang1	guāng	light; ray; bright; only; merely; used up
+广播	廣播	guang3bo1	guǎngbō	broadcast; on the air
+广告	廣告	guang3gao4	guǎnggào	advertisement; a commercial
+逛	逛	guang4	guàng	to stroll; to visit; go window shopping
+规定	規定	gui1ding4	guīdìng	regulation; stipulate; fix; set
+国籍	國籍	guo2ji2	guójí	nationality
+国际	國際	guo2ji4	guójì	international
+果汁	果汁	guo3zhi1	guǒzhī	fruit juice
+过程	過程	guo4cheng2	guòchéng	course of events; process
+海洋	海洋	hai3yang2	hǎiyáng	ocean
+害羞	害羞	hai4 xiu1	hài xiū	blush; shy
+寒假	寒假	han2jia4	hánjià	winter vacation
+汗	汗	han4	hàn	sweat; perspiration; Khan
+航班	航班	hang2ban1	hángbān	scheduled flight; flight number
+好处	好處	hao3chu	hǎochu	benefit; advantage
+好像	好像	hao3xiang4	hǎoxiàng	as if; seem to be
+号码	號碼	hao4ma3	hàomǎ	number
+合格	合格	he2ge2	hégé	qualified; up to standard
+合适	合適	he2shi4	héshì	suitable; proper; appropriate
+盒子	盒子	he2zi	hézi	box
+后悔	後悔	hou4hui3	hòuhuǐ	to regret; repent
+厚	厚	hou4	hòu	thick (for flat things); generous
+互联网	互聯網	Hu4lian2wang3	Hùliánwǎng	Internet
+互相	互相	hu4xiang1	hùxiāng	mutually; with each other
+护士	護士	hu4shi	hùshi	nurse
+怀疑	懷疑	huai2yi2	huáiyí	doubt; to suspect; be skeptical
+回忆	回憶	hui2yi4	huíyì	to recall; recollect
+活动	活動	huo2dong4	huódòng	activity; exercise; move about
+活泼	活潑	huo2po	huópo	lively; vivacious
+火	火	huo3	huǒ	fire (Kangxi radical 86)
+获得	獲得	huo4de2	huòdé	obtain; acquire; to gain
+积极	積極	ji1ji2	jījí	active; positive; energetic
+积累	積累	ji1lei3	jīlěi	accumulate; accumulation
+基础	基礎	ji1chu3	jīchǔ	base; foundation
+激动	激動	ji1dong4	jīdòng	excite; agitate
+及时	及時	ji2shi2	jíshí	timely; in time; promptly; without delay
+即使	即使	ji2shi3	jíshǐ	even if; even though
+计划	計劃	ji4hua4	jìhuà	plan; project
+记者	記者	ji4zhe3	jìzhě	reporter; journalist
+技术	技術	ji4shu4	jìshù	technology; technique; skill
+既然	既然	ji4ran2	jìrán	since; given that; now that
+继续	繼續	ji4xu4	jìxù	to continue; to go on; to proceed
+寄	寄	ji4	jì	send by mail
+加班	加班	jia1 ban1	jiā bān	work overtime
+加油站	加油站	jia1you2zhan4	jiāyóuzhàn	gas station
+家具	家具	jia1ju4	jiājù	furniture
+假	假	jia3, jia4	jiǎ, jià	fake; if; borrow | vacation; holiday
+价格	價格	jia4ge2	jiàgé	price
+坚持	堅持	jian1chi2	jiānchí	persist in; persevere
+减肥	減肥	jian3fei2	jiǎnféi	go on a diet; lose weight
+减少	減少	jian3shao3	jiǎnshǎo	reduce; to decrease
+建议	建議	jian4yi4	jiànyì	to propose; to suggest; recommend
+将来	將來	jiang1lai2	jiānglái	the future
+奖金	獎金	jiang3jin1	jiǎngjīn	bonus
+降低	降低	jiang4di1	jiàngdī	reduce; to lower; to drop
+降落	降落	jiang4luo4	jiàngluò	descend; to land; put down
+交	交	jiao1	jiāo	deliver; turn over; intersect; to pay (money); friendship
+交流	交流	jiao1liu2	jiāoliú	communicate; exchange; give and take; interaction; to alternate
+交通	交通	jiao1tong1	jiāotōng	traffic; transportation
+郊区	郊區	jiao1qu1	jiāoqū	suburbs; outskirts
+骄傲	驕傲	jiao1'ao4	jiāo'ào	proud; arrogant; conceited; take pride in
+饺子	餃子	jiao3zi	jiǎozi	dumpling; potsticker
+教授	教授	jiao4shou4	jiàoshòu	professor; instruct; to lecture
+教育	教育	jiao4yu4	jiàoyù	education
+接受	接受	jie1shou4	jiēshòu	accept; receive (honors, etc.)
+接着	接著	jie1zhe	jiēzhe	continue; carry on; to catch; follow
+节	節	jie2	jié	section; part; festival; moral integrity; save; (mw for class periods)
+节约	節約	jie2yue1	jiéyuē	frugal; to save
+结果	結果	jie2guo3	jiéguǒ	result; outcome; finally
+解释	解釋	jie3shi4	jiěshì	to explain
+尽管	盡管	jing3uan3	jǐnguǎn	despite; although; even though | freely; without hesitation
+紧张	緊張	jin3zhang1	jǐnzhāng	nervous; tension; strain
+进行	進行	jin4xing2	jìnxíng	carry on; carry out; undertake
+禁止	禁止	jin4zhi3	jìnzhǐ	to ban; prohibit
+京剧	京劇	jing1ju4	jīngjù	Beijing Opera
+经济	經濟	jing1ji4	jīngjì	economy; economic
+经历	經曆	jing1li4	jīnglì	undergo; to experience
+经验	經驗	jing1yan4	jīngyàn	experience
+精彩	精彩	jing1cai3	jīngcǎi	brilliant; spectacular; wonderful
+景色	景色	jing3se4	jǐngsè	scenery; landscape; scene; view
+警察	警察	jing3cha2	jǐngchá	police
+竞争	競爭	jing4zheng1	jìngzhēng	compete
+竟然	竟然	jing4ran2	jìngrán	unexpectedly; to one's surprise; go so far as to
+镜子	鏡子	jing4zi	jìngzi	mirror
+究竟	究竟	jiu1jing4	jiūjìng	after all; when all is said and done; actually
+举	舉	ju3	jǔ	lift; raise; cite
+举办	舉辦	ju3ban4	jǔbàn	to conduct; to hold
+举行	舉行	ju3xing2	jǔxíng	convene; to hold (a meeting, ceremony, etc.)
+拒绝	拒絕	ju4jue2	jùjué	to refuse; to decline; to reject
+距离	距離	ju4li2	jùlí	distance; be apart; away from
+聚会	聚會	ju4hui4	jùhuì	hold a meeting; get together; a party
+开玩笑	開玩笑	kai1 wan2xiao4	kāi wánxiào	joke; play a joke; make fun of
+开心	開心	kai1xin1	kāixīn	feel happy; have a great time; make fun of somebody
+看法	看法	kan4fa3	kànfǎ	point of view; opinion
+考虑	考慮	kao3lü4	kǎolǜ	think over; consider
+烤鸭	烤鴨	kao3ya1	kǎoyā	roast duck
+科学	科學	ke1xue2	kēxué	science; scientific knowledge
+棵	棵	ke1	kē	(mw for plants)
+咳嗽	咳嗽	ke2sou	késou	to cough
+可怜	可憐	ke3lian2	kělián	pitiful; poor; pathetic
+可是	可是	ke3shi4	kěshì	but; however
+可惜	可惜	ke3xi1	kěxī	it's a pity; regrettable; too bad
+客厅	客廳	ke4ting1	kètīng	living room; parlor
+肯定	肯定	ken3ding4	kěndìng	sure; definite; affirm; approve
+空	空	kong1, kong4	kōng, kòng	empty; sky | leave blank; leisure
+空气	空氣	kong1qi4	kōngqì	air
+恐怕	恐怕	kong3pa4	kǒngpà	be afraid; to fear; I'm afraid that...
+苦	苦	ku3	kǔ	bitter; miserable
+矿泉水	礦泉水	kuang4quan2shui3	kuàngquánshuǐ	mineral water
+困	困	kun4	kùn	sleepy; surround; hard-pressed
+困难	困難	kun4nan	kùnnan	difficulty; difficult; problem
+垃圾桶	垃圾桶	la1ji1tong3	lājītǒng	garbage can
+拉	拉	la1	lā	to pull; to play (string instruments); to drag
+辣	辣	la4	là	hot (spicy)
+来不及	來不及	lai2 bu ji2	lái bu jí	there's not enough time (to do something); it's too late
+来得及	來得及	lai2 de ji2	lái de jí	there's still time
+来自	來自	lai2zi4	láizì	come from (a place)
+懒	懶	lan3	lǎn	lazy
+浪费	浪費	lang4fei4	làngfèi	to waste; squander
+浪漫	浪漫	lang4man4	làngmàn	romantic
+老虎	老虎	lao3hu3	lǎohǔ	tiger
+冷静	冷靜	leng3jing4	lěngjìng	calm; cool-headed; sober
+礼拜天	禮拜天	li3bai4tian1	lǐbàitiān	Sunday
+礼貌	禮貌	li3mao4	lǐmào	courtesy; politeness; manners
+理发	理發	li3fa4	lǐfà	a barber, hairdressing; haircut
+理解	理解	li3jie3	lǐjiě	comprehend; understand
+理想	理想	li3xiang3	lǐxiǎng	ideal
+力气	力氣	li4qi	lìqi	physical strength; effort
+厉害	厲害	li4hai	lìhai	terrible; formidable; fierce; cool; awesome
+例如	例如	li4ru2	lìrú	for example; for instance
+俩	倆	liang3	liǎng	(colloquial) two (people)
+连	連	lian2	lián	even; including; join
+联系	聯系	lian2xi4	liánxì	integrate; link; connection; contact
+凉快	涼快	liang2kuai	liángkuai	nice and cool; pleasantly cool
+零钱	零錢	ling2qian2	língqián	small change (of money)
+另外	另外	ling4wai4	lìngwài	another; in addition; besides
+留	留	liu2	liú	to leave (behind, a message); to retain; to stay
+流利	流利	liu2li4	liúlì	fluent
+流行	流行	liu2xing2	liúxíng	spread; prevalent; be popular
+旅行	旅行	lü3xing2	lǚxíng	travel
+律师	律師	lü4shi1	lǜshī	lawyer
+乱	亂	luan4	luàn	disorder; confusion; arbitrarily
+麻烦	麻煩	ma2fan	máfan	trouble (someone); troubling; bothersome
+马虎	馬虎	ma3hu	mǎhu	careless; sloppy; casual
+满	滿	man3	mǎn	full; abbreviation for Manchurian
+毛	毛	mao2	máo	hair; fur; feather; dime (Kangxi radical 82)
+毛巾	毛巾	mao2jin1	máojīn	towel; washcloth
+美丽	美麗	mei3li4	měilì	beautiful
+梦	夢	meng4	mèng	to dream
+迷路	迷路	mi2lu4	mílù	to get lost
+密码	密碼	mi4ma3	mìmǎ	password; secret code
+免费	免費	mian3 fei4	miǎn fèi	free (of charge); no cost
+秒	秒	miao3	miǎo	second (unit of time or angle)
+民族	民族	min2zu2	mínzú	nationality; ethnic group
+母亲	母親	mu3qin	mǔqin	mother
+目的	目的	mu4di4	mùdì	purpose; aim; goal
+耐心	耐心	nai4xin1	nàixīn	to be patient
+难道	難道	nan2dao4	nándào	could it be that ...?; don't tell me ...
+难受	難受	nan2shou4	nánshòu	feel unwell; to suffer pain
+内	內	nei4	nèi	inside; inner; internal; within
+内容	內容	nei4rong2	nèiróng	content; substance; details
+能力	能力	neng2li4	nénglì	capability; capable; ability
+年龄	年齡	nian2ling2	niánlíng	(a person's) age
+弄	弄	nong4	nòng	do; manage; to handle; make
+暖和	暖和	nuan3huo	nuǎnhuo	warm; nice and warm
+偶尔	偶爾	ou3'er3	ǒu'ěr	occasionally; once in a while; sometimes
+排队	排隊	pai2 dui4	pái duì	queue; stand in line
+排列	排列	pai2lie4	páiliè	arrange; align; permutation
+判断	判斷	pan4duan4	pànduàn	to judge; judgment; to decide
+陪	陪	pei2	péi	accompany; keep company
+批评	批評	pi1ping2	pīpíng	criticize
+皮肤	皮膚	pi2fu1	pífū	skin
+脾气	脾氣	pi2qi	píqi	temperament; disposition; temper
+篇	篇	pian1	piān	sheet; (mw for articles); piece of writing
+骗	騙	pian4	piàn	to cheat; to swindle; deceive
+乒乓球	乒乓球	ping1pang1qiu2	pīngpāngqiú	ping pong; table tennis
+平时	平時	ping2shi2	píngshí	ordinarily; in normal times; in peacetime
+破	破	po4	pò	broken; damaged; to split
+葡萄	葡萄	pu2tao	pútao	grape
+普遍	普遍	pu3bian4	pǔbiàn	common; universal; general; widespread
+普通话	普通話	pu3tong1hua4	pǔtōnghuà	Mandarin (common language)
+其次	其次	qi2ci4	qícì	next; secondly
+其中	其中	qi2zhong1	qízhōng	among; in; included among these
+气候	氣候	qi4hou4	qìhòu	climate; atmosphere; weather
+千万	千萬	qian1wan4	qiānwàn	ten million; be sure to; must
+签证	簽證	qian1zheng4	qiānzhèng	visa
+敲	敲	qiao1	qiāo	knock; blackmail
+桥	橋	qiao2	qiáo	bridge
+巧克力	巧克力	qiao3ke4li4	qiǎokèlì	chocolate
+亲戚	親戚	qin1qi	qīnqi	a relative (i.e. family relation)
+轻	輕	qing1	qīng	light; easy; gentle; soft
+轻松	輕松	qing1song1	qīngsōng	relaxed; gentle; easygoing
+情况	情況	qing2kuang4	qíngkuàng	circumstance; state of affairs; situation
+穷	窮	qiong2	qióng	poor; exhausted
+区别	區別	qu1bie2	qūbié	difference; distinguish
+取	取	qu3	qǔ	to take; get; choose
+全部	全部	quan2bu4	quánbù	whole; entire; complete
+缺点	缺點	que1dian3	quēdiǎn	weak point; defect; fault; shortcoming
+缺少	缺少	que1shao3	quēshǎo	to lack; be short of; be deficient in
+却	卻	que4	què	but; yet; however
+确实	確實	que4shi2	quèshí	indeed; in truth; reliable
+然而	然而	ran2'er2	rán'ér	however; yet; but
+热闹	熱鬧	ren4ao	rènao	bustling; lively; busy
+任何	任何	ren4he2	rènhé	any; whatever; whichever
+任务	任務	ren4wu	rènwu	a mission; an assignment; a task
+扔	扔	reng1	rēng	to throw; throw away
+仍然	仍然	reng2ran2	réngrán	still; yet
+日记	日記	ri4ji4	rìjì	diary
+入口	入口	ru4kou3	rùkǒu	entrance
+散步	散步	san4 bu4	sàn bù	to go for a walk
+森林	森林	sen1lin2	sēnlín	forest
+沙发	沙發	sha1fa1	shāfā	sofa
+伤心	傷心	shang1xin1	shāngxīn	sad; grieve; brokenhearted
+商量	商量	shang1liang	shāngliang	consult; talk over; discuss
+稍微	稍微	shao1wei1	shāowēi	a little bit; slightly
+勺子	勺子	shao2zi	sháozi	spoon; scoop; ladle
+社会	社會	she4hui4	shèhuì	society
+申请	申請	shen1qing3	shēnqǐng	apply for; application
+深	深	shen1	shēn	deep; profound; dark (of colors)
+甚至	甚至	shen4zhi4	shènzhì	even (to the point of); so much so that
+生活	生活	sheng1huo2	shēnghuó	life; livelihood; to live
+生命	生命	sheng1ming4	shēngmìng	life
+生意	生意	sheng1yi	shēngyi	business; trade
+省	省	sheng3	shěng	to save; economize; omit; province
+剩	剩	sheng4	shèng	have as remainder; be left over; surplus
+失败	失敗	shi1bai4	shībài	be defeated; fail; lose
+失望	失望	shi1wang4	shīwàng	disappointed; lose hope
+师傅	師傅	shi1fu	shīfu	master; qualified worker; teacher
+十分	十分	shi2fen1	shífēn	very; fully; 100%
+实际	實際	shi2ji4	shíjì	actual; reality; practice
+实在	實在	shi2zai4	shízài	honest; in reality; honestly; indeed; certainly
+使	使	shi3	shǐ	to use; to make; to cause; enable; envoy; messenger
+使用	使用	shi3yong4	shǐyòng	to use; employ; apply; administer; manipulate
+世纪	世紀	shi4ji4	shìjì	century
+是否	是否	shi4fou3	shìfǒu	whether (or not); if
+适合	適合	shi4he2	shìhé	to suit; to fit
+适应	適應	shi4ying4	shìyìng	to suit; to fit; adapt
+收	收	shou1	shōu	receive; accept; collect; to harvest
+收入	收入	shou1ru4	shōurù	take in; income; revenue
+收拾	收拾	shou1shi	shōushi	to tidy; put in order; to repair; to settle with; punish
+首都	首都	shou3du1	shǒudū	capital (city)
+首先	首先	shou3xian1	shǒuxiān	first (of all); in the first place; firstly
+受不了	受不了	shou4 bu liao3	shòu bu liǎo	cannot endure; unbearable; can't stand
+受到	受到	shou4dao4	shòudào	receive (influence, restriction, etc.); be subjected to
+售货员	售貨員	shou4huo4yuan2	shòuhuòyuán	salesclerk; shop assistant
+输	輸	shu1	shū	to transport; to lose (a game, etc.)
+熟悉	熟悉	shu2xi1	shúxī	familiar with; know well
+数量	數量	shu4liang4	shùliàng	amount; quantity; number
+数字	數字	shu4zi4	shùzì	number; numeral; figure; digit
+帅	帥	shuai4	shuài	handsome; graceful; commander-in-chief
+顺便	順便	shun4bian4	shùnbiàn	conveniently; in passing; on the way
+顺利	順利	shun4li4	shùnlì	go smoothly; without a hitch; successful
+顺序	順序	shun4xu4	shùnxù	sequence; order
+说明	說明	shuo1ming2	shuōmíng	explain; explanation; illustrate; to show
+硕士	碩士	shuo4shi4	shuòshì	Master's degree (M.A.)
+死	死	si3	sǐ	to die; dead; fixed; impassible; extremely
+速度	速度	su4du4	sùdù	speed; rate; velocity
+塑料袋	塑料袋	su4liao4dai4	sùliàodài	plastic bag
+酸	酸	suan1	suān	sour; sore; ache
+随便	隨便	sui2bian4	suíbiàn	as one pleases; informal; random; casual
+随着	隨著	sui2zhe	suízhe	along with; in the wake of
+孙子	孫子	sun1zi	sūnzi	grandson; son's son
+所有	所有	suo3you3	suǒyǒu	all; to have; to possess
+台	台	tai2	tái	platform; Taiwan (abbr.); desk; stage; typhoon; (mw for machines); (classical) you (in letters)
+抬	擡	tai2	tái	to lift; to raise (with both palms up); carry (together)
+态度	態度	tai4du	tàidu	manner; bearing; attitude
+谈	談	tan2	tán	to talk; to chat; discuss
+弹钢琴	彈鋼琴	tan2 gang1qin2	tán gāngqín	play the piano
+汤	湯	tang1	tāng	soup; broth
+糖	糖	tang2	táng	sugar; candy; sweets
+躺	躺	tang3	tǎng	recline; lie down (on back or side)
+趟	趟	tang4, tang1	tàng, tāng	(mw for trips times) | to wade
+讨论	討論	tao3lun4	tǎolùn	to discuss; discussion; to talk over
+讨厌	討厭	tao3yan4	tǎoyàn	to hate; loathe; disgusting; troublesome
+特点	特點	te4dian3	tèdiǎn	a characteristic; trait; feature
+提	提	ti2	tí	to carry; to lift; to raise (an issue)
+提供	提供	ti2gong1	tígōng	to supply; provide; furnish
+提前	提前	ti2qian2	tíqián	shift to an earlier date; bring forward; to advance
+提醒	提醒	ti2xing3	tíxǐng	remind; call attention to; warn of
+填空	填空	tian2kong4	tiánkòng	fill in the blanks; fill a vacancy
+条件	條件	tiao2jian4	tiáojiàn	condition; circumstances; prerequisite
+停	停	ting2	tíng	to stop; to halt; to park (a car)
+挺	挺	ting3	tǐng	straighten up; stick out; rather (good); very
+通过	通過	tong1guo4	tōngguò	by means of; through (a method); pass through; via
+通知	通知	tong1zhi1	tōngzhī	notify; to inform; notice
+同情	同情	tong2qing2	tóngqíng	compassion; sympathy
+同时	同時	tong2shi2	tóngshí	at the same time; simultaneously
+推	推	tui1	tuī	to push; to scrape; to decline; postpone; elect
+推迟	推遲	tui1chi2	tuīchí	postpone; defer
+脱	脫	tuo1	tuō	to shed; take off; to escape
+袜子	襪子	wa4zi	wàzi	socks; stockings
+完全	完全	wan2quan2	wánquán	complete; whole; totally
+网球	網球	wang3qiu2	wǎngqiú	tennis; tennis ball
+网站	網站	wang3zhan4	wǎngzhàn	website
+往往	往往	wang3wang3	wǎngwǎng	often; frequently; more often than not
+危险	危險	wei1xian3	wēixiǎn	danger; dangerous; perilous
+卫生间	衛生間	wei4sheng1jian1	wèishēngjiān	restroom; bathroom; water closet (WC)
+味道	味道	wei4dao	wèidao	flavor; taste
+温度	溫度	wen1du4	wēndù	temperature
+文章	文章	wen2zhang1	wénzhāng	article; essay
+污染	汙染	wu1ran3	wūrǎn	pollution; contamination
+无	無	wu2	wú	have not; without; not (Kangxi radical 71)
+无聊	無聊	wu2liao2	wúliáo	nonsense; bored; silly; stupid
+无论	無論	wu2lun4	wúlùn	no matter what; regardless of whether...
+误会	誤會	wu4hui4	wùhuì	to misunderstand; to mistake
+西红柿	西紅柿	xi1hong2shi4	xīhóngshì	tomato
+吸引	吸引	xi1yin3	xīyǐn	attract (interest, investment, etc.)
+咸	鹹	xian2	xián	salty; salted; all
+现金	現金	xian4jin1	xiànjīn	cash
+羡慕	羨慕	xian4mu4	xiànmù	to envy; admire
+相反	相反	xiang1fan3	xiāngfǎn	opposite; contrary
+相同	相同	xiang1tong2	xiāngtóng	identical; same; alike
+香	香	xiang1	xiāng	fragrant; savory (Kangxi radical 186)
+详细	詳細	xiang2xi4	xiángxì	detailed; in detail; minute
+响	響	xiang3	xiǎng	make a sound; to ring; echo
+橡皮	橡皮	xiang4pi2	xiàngpí	rubber; an eraser
+消息	消息	xiao1xi	xiāoxi	news; information
+小吃	小吃	xiao3chi1	xiǎochī	snack; refreshments
+小伙子	小夥子	xiao3huo3zi	xiǎohuǒzi	young man; lad; youngster
+小说	小說	xiao3shuo1	xiǎoshuō	novel; fiction
+笑话	笑話	xiao4hua	xiàohua	joke; laugh at
+效果	效果	xiao4guo3	xiàoguǒ	effect; result
+心情	心情	xin1qing2	xīnqíng	mood; state of mind
+辛苦	辛苦	xin1ku3	xīnkǔ	hard; exhausting; toilsome; laborious
+信封	信封	xin4feng1	xìnfēng	envelope
+信息	信息	xin4xi1	xìnxī	information; news; message
+信心	信心	xin4xin1	xìnxīn	confidence; faith (in sb. or sth.)
+兴奋	興奮	xing1fen4	xīngfèn	excitement； be excited
+行	行	xing2	xíng	walk; be current; do; will do; okay
+醒	醒	xing3	xǐng	wake up
+幸福	幸福	xing4fu2	xìngfú	happy; blessed; fortunate
+性别	性別	xing4bie2	xìngbié	gender; sex; sexual distinction
+性格	性格	xing4ge2	xìnggé	nature; personality; temperament
+修理	修理	xiu1li3	xiūlǐ	to repair; perform maintenance; to overhaul
+许多	許多	xu3duo1	xǔduō	many; a lot; much
+学期	學期	xue2qi1	xuéqī	semester; school term
+压力	壓力	ya1li4	yālì	pressure; stress
+呀	呀	ya	ya	ah; oh; (used for 啊 after words ending with a, e, i, o, or ü)
+牙膏	牙膏	ya2gao1	yágāo	toothpaste
+亚洲	亞洲	Ya4zhou1	Yàzhōu	Asia
+严格	嚴格	yang2e2	yángé	strict; stringent; tight
+严重	嚴重	yan2zhong4	yánzhòng	grave; serious; critical
+研究	研究	yan2jiu1	yánjiū	to study; to research
+盐	鹽	yan2	yán	salt
+眼镜	眼鏡	yan3jing4	yǎnjìng	glasses; spectacles
+演出	演出	yan3chu1	yǎnchū	to act (in a play); to perform; to put on a show; performance
+演员	演員	yan3yuan2	yǎnyuán	actor or actress; performer
+阳光	陽光	yang2guang1	yángguāng	sunshine; sunlight
+养成	養成	yang3cheng2	yǎngchéng	cultivate; acquire; to form
+样子	樣子	yang4zi	yàngzi	manner; air; appearance; looks
+邀请	邀請	yao1qing3	yāoqǐng	to invite
+要是	要是	yao4shi	yàoshi	if; suppose; in case
+钥匙	鑰匙	yao4shi	yàoshi	key
+也许	也許	ye3xu3	yěxǔ	perhaps; probably; maybe
+叶子	葉子	ye4zi	yèzi	leaves
+页	頁	ye4	yè	page; leaf (Kangxi radical 181)
+一切	一切	yi2qie4	yíqiè	all; every; everything
+以	以	yi3	yǐ	to use; according to; so as to; for; by
+以为	以爲	yi3wei2	yǐwéi	think (mistakenly); consider (that); believe
+艺术	藝術	yi4shu4	yìshù	art
+意见	意見	yi4jian4	yìjiàn	opinion; view; suggestion; complaint
+因此	因此	yin1ci3	yīncǐ	therefore; thus; that is why; because of this
+引起	引起	yin3qi3	yǐnqǐ	give rise to; lead to; to cause; arouse
+印象	印象	yin4xiang4	yìnxiàng	impression
+赢	贏	ying2	yíng	to win; to beat; to profit
+应聘	應聘	ying4pin4	yìngpìn	accept a job offer; to apply for a job
+永远	永遠	yong3yuan3	yǒngyuǎn	forever; eternal; always
+勇敢	勇敢	yong3gan3	yǒnggǎn	brave; courageous
+优点	優點	you1dian3	yōudiǎn	merit; good point; a strength; a benefit
+优秀	優秀	you1xiu4	yōuxiù	outstanding; excellent
+幽默	幽默	you1mo4	yōumò	humorous
+尤其	尤其	you2qi2	yóuqí	especially; particularly
+由	由	you2	yóu	follow; from; by; through
+由于	由于	you2yu2	yóuyú	due to; owing to; as a result of; thanks to
+邮局	郵局	you2ju2	yóujú	post office
+友好	友好	you3hao3	yǒuhǎo	friendly (relations); close friends
+友谊	友誼	you3yi4	yǒuyì	friendship; companionship
+有趣	有趣	you3qu4	yǒuqù	interesting; fascinating; amusing
+于是	于是	yu2shi4	yúshì	as a result; thus; therefore
+愉快	愉快	yu2kuai4	yúkuài	happy; cheerful; delightful
+与	與	yu3	yǔ	(formal) and; to give; together with; participate; final particle expressing doubt or surprise
+羽毛球	羽毛球	yu3mao2qiu2	yǔmáoqiú	badminton
+语法	語法	yu3fa3	yǔfǎ	grammar
+语言	語言	yu3yan2	yǔyán	language
+预习	預習	yu4xi2	yùxí	(of students) prepare a lesson before class; preview
+原来	原來	yuan2lai2	yuánlái	original; former; as it turns out
+原谅	原諒	yuan2liang4	yuánliàng	to excuse; forgive; to pardon
+原因	原因	yuan2yin1	yuányīn	cause; reason
+约会	約會	yue1hui4	yuēhuì	appointment; engagement; date
+阅读	閱讀	yue4du2	yuèdú	read; reading
+云	雲	yun2	yún	cloud; Yunnan province | say; speak
+允许	允許	yun3xu3	yǔnxǔ	to permit; allow
+杂志	雜志	za2zhi4	zázhì	magazine
+咱们	咱們	zan2men	zánmen	we (including the listener); us; our
+暂时	暫時	zan4shi2	zànshí	temporary; transient; for the moment
+脏	髒	zang1	zāng	filthy; dirty
+责任	責任	zer2en4	zérèn	responsibility; blame; duty
+增加	增加	zeng1jia1	zēngjiā	to increase; to raise; add
+占线	占線	zhan4xian4	zhànxiàn	the (phone) line is busy
+招聘	招聘	zhao1pin4	zhāopìn	recruitment; take job applications for a job
+照	照	zhao4	zhào	to shine; illuminate; according to
+真正	真正	zhen1zheng4	zhēnzhèng	genuine; real; true
+整理	整理	zheng3li3	zhěnglǐ	put in order; arrange; straighten up; to tidy; to pack (luggage)
+正常	正常	zheng4chang2	zhèngcháng	normal; regular; ordinary
+正好	正好	zheng4hao3	zhènghǎo	just (in time); just right; just enough; happen to; by chance
+正确	正確	zheng4que4	zhèngquè	correct; proper
+正式	正式	zheng4shi4	zhèngshì	formal; official
+证明	證明	zheng4ming2	zhèngmíng	proof; testify; confirm; certificate
+之	之	zhi1	zhī	(literary equivalent to 的); (pronoun); of
+支持	支持	zhi1chi2	zhīchí	sustain; hold out; | support; stand by (e.g. international support)
+知识	知識	zhi1shi	zhīshi	knowledge; intellectual
+直接	直接	zhi2jie1	zhíjiē	direct; immediate
+值得	值得	zhi2de	zhíde	be worth; deserve
+职业	職業	zhi2ye4	zhíyè	profession; occupation
+植物	植物	zhi2wu4	zhíwù	plant; botanical; vegetation
+只好	只好	zhi3hao3	zhǐhǎo	have to; be forced to
+只要	只要	zhi3yao4	zhǐyào	so long as; if only; provided that
+指	指	zhi3	zhǐ	finger; to point (at, to, out); refer to
+至少	至少	zhi4shao3	zhìshǎo	at least; (to say the) least
+质量	質量	zhi4liang4	zhìliàng	quality; mass (physics)
+重	重	zhong4	zhòng	heavy; serious; important
+重点	重點	zhong4dian3	zhòngdiǎn	emphasis; main point
+重视	重視	zhong4shi4	zhòngshì	to value; take seriously
+周围	周圍	zhou1wei2	zhōuwéi	surroundings; vicinity; environment
+主意	主意	zhu3yi	zhǔyi	plan; idea; decision
+祝贺	祝賀	zhu4he4	zhùhè	congratulate
+著名	著名	zhu4ming2	zhùmíng	famous; well-known; celebration
+专门	專門	zhuan1men2	zhuānmén	specialized
+专业	專業	zhuan1ye4	zhuānyè	profession; specialized field of study; major
+转	轉	zhuan3, zhuan4	zhuǎn, zhuàn	to turn; to change; pass on | revolve; rotate
+赚	賺	zhuan4	zhuàn	earn; make a profit
+准确	准確	zhun3que4	zhǔnquè	accurate; precise
+准时	准時	zhun3shi2	zhǔnshí	punctually; on time
+仔细	仔細	zi3xi4	zǐxì	careful; attentive; cautious
+自然	自然	zi4ran2	zìrán	nature; natural
+自信	自信	zi4xin4	zìxìn	self-confidence
+总结	總結	zong3jie2	zǒngjié	summarize; conclude
+租	租	zu1	zū	to rent
+最好	最好	zui4hao3	zuìhǎo	the best; had better ...; it would be best
+尊重	尊重	zun1zhong4	zūnzhòng	esteem; to respect; to value; to honor
+左右	左右	zuo3you4	zuǒyòu	about; approximate; around | left and right
+作家	作家	zuo4jia1	zuòjiā	author; writer
+作用	作用	zuo4yong4	zuòyòng	action; activity; effect
+作者	作者	zuo4zhe3	zuòzhě	author; writer
+座	座	zuo4	zuò	(mw for mountains, bridges, tall buildings, etc.); | seat; base; stand; constellation
+座位	座位	zuo4wei4	zuòwèi	seat; place

--- a/vocab/mandarin/hsk/4/vocab.json
+++ b/vocab/mandarin/hsk/4/vocab.json
@@ -1,0 +1,4202 @@
+[
+    {
+        "intermediate_1": "ai4qing2",
+        "intermediate_2": "àiqíng",
+        "native_1": "(romantic) love",
+        "primary_1": "爱情",
+        "primary_2": "愛情"
+    },
+    {
+        "intermediate_1": "an1pai2",
+        "intermediate_2": "ānpái",
+        "native_1": "arrange; to plan",
+        "primary_1": "安排",
+        "primary_2": "安排"
+    },
+    {
+        "intermediate_1": "an1quan2",
+        "intermediate_2": "ānquán",
+        "native_1": "safe; safety; secure; security",
+        "primary_1": "安全",
+        "primary_2": "安全"
+    },
+    {
+        "intermediate_1": "an4shi2",
+        "intermediate_2": "ànshí",
+        "native_1": "on time; on schedule",
+        "primary_1": "按时",
+        "primary_2": "按時"
+    },
+    {
+        "intermediate_1": "an4zhao4",
+        "intermediate_2": "ànzhào",
+        "native_1": "according to; in accordance with; in light of",
+        "primary_1": "按照",
+        "primary_2": "按照"
+    },
+    {
+        "intermediate_1": "bai3fen1zhi1",
+        "intermediate_2": "bǎifēnzhī",
+        "native_1": "percent",
+        "primary_1": "百分之",
+        "primary_2": "百分之"
+    },
+    {
+        "intermediate_1": "bang4",
+        "intermediate_2": "bàng",
+        "native_1": "stick; club; good; excellent",
+        "primary_1": "棒",
+        "primary_2": "棒"
+    },
+    {
+        "intermediate_1": "bao1zi",
+        "intermediate_2": "bāozi",
+        "native_1": "steamed stuffed bun",
+        "primary_1": "包子",
+        "primary_2": "包子"
+    },
+    {
+        "intermediate_1": "bao3hu4",
+        "intermediate_2": "bǎohù",
+        "native_1": "to protect; to defend",
+        "primary_1": "保护",
+        "primary_2": "保護"
+    },
+    {
+        "intermediate_1": "bao3zheng4",
+        "intermediate_2": "bǎozhèng",
+        "native_1": "to guarantee; ensure",
+        "primary_1": "保证",
+        "primary_2": "保證"
+    },
+    {
+        "intermediate_1": "bao4 ming2",
+        "intermediate_2": "bào míng",
+        "native_1": "sign up; apply",
+        "primary_1": "报名",
+        "primary_2": "報名"
+    },
+    {
+        "intermediate_1": "bao4",
+        "intermediate_2": "bào",
+        "native_1": "to hold; to hug; carry in one's arms; to cradle",
+        "primary_1": "抱",
+        "primary_2": "抱"
+    },
+    {
+        "intermediate_1": "bao4qian4",
+        "intermediate_2": "bàoqiàn",
+        "native_1": "be sorry; feel apologetic; to regret",
+        "primary_1": "抱歉",
+        "primary_2": "抱歉"
+    },
+    {
+        "intermediate_1": "bei4",
+        "intermediate_2": "bèi",
+        "native_1": "(two, three, etc)-fold; times (multiplier)",
+        "primary_1": "倍",
+        "primary_2": "倍"
+    },
+    {
+        "intermediate_1": "ben3lai2",
+        "intermediate_2": "běnlái",
+        "native_1": "originally; at first",
+        "primary_1": "本来",
+        "primary_2": "本來"
+    },
+    {
+        "intermediate_1": "ben4",
+        "intermediate_2": "bèn",
+        "native_1": "stupid; foolish; silly; dumb; clumsy",
+        "primary_1": "笨",
+        "primary_2": "笨"
+    },
+    {
+        "intermediate_1": "bi3ru2",
+        "intermediate_2": "bǐrú",
+        "native_1": "for example; for instance; such as",
+        "primary_1": "比如",
+        "primary_2": "比如"
+    },
+    {
+        "intermediate_1": "bi4 ye4",
+        "intermediate_2": "bì yè",
+        "native_1": "to graduate; to finish school",
+        "primary_1": "毕业",
+        "primary_2": "畢業"
+    },
+    {
+        "intermediate_1": "bian4",
+        "intermediate_2": "biàn",
+        "native_1": "a time; everywhere; turn; (mw for times or turns)",
+        "primary_1": "遍",
+        "primary_2": "遍"
+    },
+    {
+        "intermediate_1": "biao1zhun3",
+        "intermediate_2": "biāozhǔn",
+        "native_1": "(an official) standard; norm; criterion",
+        "primary_1": "标准",
+        "primary_2": "標准"
+    },
+    {
+        "intermediate_1": "biao3ge2",
+        "intermediate_2": "biǎogé",
+        "native_1": "form (document)",
+        "primary_1": "表格",
+        "primary_2": "表格"
+    },
+    {
+        "intermediate_1": "biao3shi4",
+        "intermediate_2": "biǎoshì",
+        "native_1": "express; show; indicate",
+        "primary_1": "表示",
+        "primary_2": "表示"
+    },
+    {
+        "intermediate_1": "biao3yan3",
+        "intermediate_2": "biǎoyǎn",
+        "native_1": "perform; to play",
+        "primary_1": "表演",
+        "primary_2": "表演"
+    },
+    {
+        "intermediate_1": "biao3yang2",
+        "intermediate_2": "biǎoyáng",
+        "native_1": "to praise; commend",
+        "primary_1": "表扬",
+        "primary_2": "表揚"
+    },
+    {
+        "intermediate_1": "bing3gan1",
+        "intermediate_2": "bǐnggān",
+        "native_1": "biscuit; cracker; cookie",
+        "primary_1": "饼干",
+        "primary_2": "餅幹"
+    },
+    {
+        "intermediate_1": "bing4qie3",
+        "intermediate_2": "bìngqiě",
+        "native_1": "and; besides; moreover",
+        "primary_1": "并且",
+        "primary_2": "並且"
+    },
+    {
+        "intermediate_1": "bo2shi4",
+        "intermediate_2": "bóshì",
+        "native_1": "doctor; PhD",
+        "primary_1": "博士",
+        "primary_2": "博士"
+    },
+    {
+        "intermediate_1": "bu4 de2 bu4",
+        "intermediate_2": "bù dé bù",
+        "native_1": "have to; have no choice but to; cannot but",
+        "primary_1": "不得不",
+        "primary_2": "不得不"
+    },
+    {
+        "intermediate_1": "bu4guan3",
+        "intermediate_2": "bùguǎn",
+        "native_1": "no matter (what, how, etc.); regardless of",
+        "primary_1": "不管",
+        "primary_2": "不管"
+    },
+    {
+        "intermediate_1": "bu2guo4",
+        "intermediate_2": "búguò",
+        "native_1": "only; merely; but; however",
+        "primary_1": "不过",
+        "primary_2": "不過"
+    },
+    {
+        "intermediate_1": "bu4jin3",
+        "intermediate_2": "bùjǐn",
+        "native_1": "not only; not just",
+        "primary_1": "不仅",
+        "primary_2": "不僅"
+    },
+    {
+        "intermediate_1": "bu4fen",
+        "intermediate_2": "bùfen",
+        "native_1": "part; share; section",
+        "primary_1": "部分",
+        "primary_2": "部分"
+    },
+    {
+        "intermediate_1": "ca1",
+        "intermediate_2": "cā",
+        "native_1": "to wipe; to rub; to polish",
+        "primary_1": "擦",
+        "primary_2": "擦"
+    },
+    {
+        "intermediate_1": "cai1",
+        "intermediate_2": "cāi",
+        "native_1": "to guess",
+        "primary_1": "猜",
+        "primary_2": "猜"
+    },
+    {
+        "intermediate_1": "cai2liao4",
+        "intermediate_2": "cáiliào",
+        "native_1": "material",
+        "primary_1": "材料",
+        "primary_2": "材料"
+    },
+    {
+        "intermediate_1": "cang1uan1",
+        "intermediate_2": "cānguān",
+        "native_1": "to visit (a place, such as a tourist spot); inspect",
+        "primary_1": "参观",
+        "primary_2": "參觀"
+    },
+    {
+        "intermediate_1": "can1ting1",
+        "intermediate_2": "cāntīng",
+        "native_1": "dining hall; cafeteria; restaurant",
+        "primary_1": "餐厅",
+        "primary_2": "餐廳"
+    },
+    {
+        "intermediate_1": "ce4suo3",
+        "intermediate_2": "cèsuǒ",
+        "native_1": "bathroom; toilet; lavatory",
+        "primary_1": "厕所",
+        "primary_2": "廁所"
+    },
+    {
+        "intermediate_1": "cha4buduo1",
+        "intermediate_2": "chàbuduō",
+        "native_1": "almost; about the same",
+        "primary_1": "差不多",
+        "primary_2": "差不多"
+    },
+    {
+        "intermediate_1": "chang2cheng2",
+        "intermediate_2": "chángchéng",
+        "native_1": "the Great Wall",
+        "primary_1": "长城",
+        "primary_2": "長城"
+    },
+    {
+        "intermediate_1": "Chang2jiang1",
+        "intermediate_2": "Chángjiāng",
+        "native_1": "the Yangtze River; the Changjiang River",
+        "primary_1": "长江",
+        "primary_2": "長江"
+    },
+    {
+        "intermediate_1": "chang2",
+        "intermediate_2": "cháng",
+        "native_1": "to taste; flavor; (past tense marker)",
+        "primary_1": "尝",
+        "primary_2": "嘗"
+    },
+    {
+        "intermediate_1": "chang3",
+        "intermediate_2": "chǎng",
+        "native_1": "courtyard; place; field; (mw for games, performances, etc.)",
+        "primary_1": "场",
+        "primary_2": "場"
+    },
+    {
+        "intermediate_1": "chao1guo4",
+        "intermediate_2": "chāoguò",
+        "native_1": "surpass; exceed; outstrip",
+        "primary_1": "超过",
+        "primary_2": "超過"
+    },
+    {
+        "intermediate_1": "cheng2gong1",
+        "intermediate_2": "chénggōng",
+        "native_1": "success; to succeed",
+        "primary_1": "成功",
+        "primary_2": "成功"
+    },
+    {
+        "intermediate_1": "cheng2wei2",
+        "intermediate_2": "chéngwéi",
+        "native_1": "become; turn into",
+        "primary_1": "成为",
+        "primary_2": "成爲"
+    },
+    {
+        "intermediate_1": "cheng2shi2",
+        "intermediate_2": "chéngshí",
+        "native_1": "honest; honorable",
+        "primary_1": "诚实",
+        "primary_2": "誠實"
+    },
+    {
+        "intermediate_1": "cheng2zuo4",
+        "intermediate_2": "chéngzuò",
+        "native_1": "ride; get into (a vehicle)",
+        "primary_1": "乘坐",
+        "primary_2": "乘坐"
+    },
+    {
+        "intermediate_1": "chi1 jing1",
+        "intermediate_2": "chī jīng",
+        "native_1": "be startled; be shocked; be amazed",
+        "primary_1": "吃惊",
+        "primary_2": "吃驚"
+    },
+    {
+        "intermediate_1": "chong2xin1",
+        "intermediate_2": "chóngxīn",
+        "native_1": "again; anew; once more",
+        "primary_1": "重新",
+        "primary_2": "重新"
+    },
+    {
+        "intermediate_1": "chou1yan1",
+        "intermediate_2": "chōuyān",
+        "native_1": "to smoke (a cigarette, pipe, etc.)",
+        "primary_1": "抽烟",
+        "primary_2": "抽煙"
+    },
+    {
+        "intermediate_1": "chu1 chai1",
+        "intermediate_2": "chū chāi",
+        "native_1": "go on a business trip",
+        "primary_1": "出差",
+        "primary_2": "出差"
+    },
+    {
+        "intermediate_1": "chu1fa1",
+        "intermediate_2": "chūfā",
+        "native_1": "start out; set off",
+        "primary_1": "出发",
+        "primary_2": "出發"
+    },
+    {
+        "intermediate_1": "chu1sheng1",
+        "intermediate_2": "chūshēng",
+        "native_1": "be born",
+        "primary_1": "出生",
+        "primary_2": "出生"
+    },
+    {
+        "intermediate_1": "chu1xian4",
+        "intermediate_2": "chūxiàn",
+        "native_1": "appear; arise; emerge",
+        "primary_1": "出现",
+        "primary_2": "出現"
+    },
+    {
+        "intermediate_1": "chu2fang2",
+        "intermediate_2": "chúfáng",
+        "native_1": "kitchen",
+        "primary_1": "厨房",
+        "primary_2": "廚房"
+    },
+    {
+        "intermediate_1": "chuan2zhen1",
+        "intermediate_2": "chuánzhēn",
+        "native_1": "fax; facsimile",
+        "primary_1": "传真",
+        "primary_2": "傳真"
+    },
+    {
+        "intermediate_1": "chuang1hu",
+        "intermediate_2": "chuānghu",
+        "native_1": "window",
+        "primary_1": "窗户",
+        "primary_2": "窗戶"
+    },
+    {
+        "intermediate_1": "ci2yu3",
+        "intermediate_2": "cíyǔ",
+        "native_1": "words and expressions; terms",
+        "primary_1": "词语",
+        "primary_2": "詞語"
+    },
+    {
+        "intermediate_1": "cong2lai2",
+        "intermediate_2": "cónglái",
+        "native_1": "always; at all times",
+        "primary_1": "从来",
+        "primary_2": "從來"
+    },
+    {
+        "intermediate_1": "cu1xin1",
+        "intermediate_2": "cūxīn",
+        "native_1": "careless; inadvertent; negligent",
+        "primary_1": "粗心",
+        "primary_2": "粗心"
+    },
+    {
+        "intermediate_1": "cun2",
+        "intermediate_2": "cún",
+        "native_1": "exist; to deposit; to store",
+        "primary_1": "存",
+        "primary_2": "存"
+    },
+    {
+        "intermediate_1": "cuo4wu4",
+        "intermediate_2": "cuòwù",
+        "native_1": "error; mistake; mistaken",
+        "primary_1": "错误",
+        "primary_2": "錯誤"
+    },
+    {
+        "intermediate_1": "da2'an4",
+        "intermediate_2": "dá'àn",
+        "native_1": "answer; solution",
+        "primary_1": "答案",
+        "primary_2": "答案"
+    },
+    {
+        "intermediate_1": "da3ban",
+        "intermediate_2": "dǎban",
+        "native_1": "dress up; put on make up",
+        "primary_1": "打扮",
+        "primary_2": "打扮"
+    },
+    {
+        "intermediate_1": "da3rao3",
+        "intermediate_2": "dǎrǎo",
+        "native_1": "disturb",
+        "primary_1": "打扰",
+        "primary_2": "打擾"
+    },
+    {
+        "intermediate_1": "da3yin4",
+        "intermediate_2": "dǎyìn",
+        "native_1": "to print",
+        "primary_1": "打印",
+        "primary_2": "打印"
+    },
+    {
+        "intermediate_1": "da3zhao1hu",
+        "intermediate_2": "dǎzhāohu",
+        "native_1": "notify; greet; inform",
+        "primary_1": "打招呼",
+        "primary_2": "打招呼"
+    },
+    {
+        "intermediate_1": "da3zhe2",
+        "intermediate_2": "dǎzhé",
+        "native_1": "sell at a discount",
+        "primary_1": "打折",
+        "primary_2": "打折"
+    },
+    {
+        "intermediate_1": "da3zhen1",
+        "intermediate_2": "dǎzhēn",
+        "native_1": "inject; get a shot",
+        "primary_1": "打针",
+        "primary_2": "打針"
+    },
+    {
+        "intermediate_1": "da4gai4",
+        "intermediate_2": "dàgài",
+        "native_1": "probably; roughly; approximate",
+        "primary_1": "大概",
+        "primary_2": "大概"
+    },
+    {
+        "intermediate_1": "da4shi3guan3",
+        "intermediate_2": "dàshǐguǎn",
+        "native_1": "embassy",
+        "primary_1": "大使馆",
+        "primary_2": "大使館"
+    },
+    {
+        "intermediate_1": "da4yue1",
+        "intermediate_2": "dàyuē",
+        "native_1": "approximately; about",
+        "primary_1": "大约",
+        "primary_2": "大約"
+    },
+    {
+        "intermediate_1": "dai4fu",
+        "intermediate_2": "dàifu",
+        "native_1": "doctor; physician",
+        "primary_1": "大夫",
+        "primary_2": "大夫"
+    },
+    {
+        "intermediate_1": "dai4",
+        "intermediate_2": "dài",
+        "native_1": "put on; to wear; to respect",
+        "primary_1": "戴",
+        "primary_2": "戴"
+    },
+    {
+        "intermediate_1": "dang1",
+        "intermediate_2": "dāng",
+        "native_1": "should; act as; work as; manage; match; (sound of bells)",
+        "primary_1": "当",
+        "primary_2": "當"
+    },
+    {
+        "intermediate_1": "dang1shi2",
+        "intermediate_2": "dāngshí",
+        "native_1": "then; at that time; while",
+        "primary_1": "当时",
+        "primary_2": "當時"
+    },
+    {
+        "intermediate_1": "dao1",
+        "intermediate_2": "dāo",
+        "native_1": "knife; blade (Kangxi radical 18)",
+        "primary_1": "刀",
+        "primary_2": "刀"
+    },
+    {
+        "intermediate_1": "dao3you2",
+        "intermediate_2": "dǎoyóu",
+        "native_1": "tour guide",
+        "primary_1": "导游",
+        "primary_2": "導遊"
+    },
+    {
+        "intermediate_1": "dao4chu4",
+        "intermediate_2": "dàochù",
+        "native_1": "everywhere; in all places; all over",
+        "primary_1": "到处",
+        "primary_2": "到處"
+    },
+    {
+        "intermediate_1": "dao4 di3",
+        "intermediate_2": "dào dǐ",
+        "native_1": "after all; in the end (used in a question)",
+        "primary_1": "到底",
+        "primary_2": "到底"
+    },
+    {
+        "intermediate_1": "dao3, dao4",
+        "intermediate_2": "dǎo, dào",
+        "native_1": "to collapse; to fall; fail; to exchange | to pour; contrary to expectations",
+        "primary_1": "倒",
+        "primary_2": "倒"
+    },
+    {
+        "intermediate_1": "dao4qian4",
+        "intermediate_2": "dàoqiàn",
+        "native_1": "apologize; make an apology",
+        "primary_1": "道歉",
+        "primary_2": "道歉"
+    },
+    {
+        "intermediate_1": "de2yi4",
+        "intermediate_2": "déyì",
+        "native_1": "proud of oneself; complacent",
+        "primary_1": "得意",
+        "primary_2": "得意"
+    },
+    {
+        "intermediate_1": "de",
+        "intermediate_2": "de",
+        "native_1": "(complement particle)",
+        "primary_1": "得",
+        "primary_2": "得"
+    },
+    {
+        "intermediate_1": "deng1ji1pai2",
+        "intermediate_2": "dēngjīpái",
+        "native_1": "boarding pass",
+        "primary_1": "登机牌",
+        "primary_2": "登機牌"
+    },
+    {
+        "intermediate_1": "deng3",
+        "intermediate_2": "děng",
+        "native_1": "to wait; rank; equal; etc.",
+        "primary_1": "等",
+        "primary_2": "等"
+    },
+    {
+        "intermediate_1": "di1",
+        "intermediate_2": "dī",
+        "native_1": "low; to lower (one's head); droop",
+        "primary_1": "低",
+        "primary_2": "低"
+    },
+    {
+        "intermediate_1": "di3",
+        "intermediate_2": "dǐ",
+        "native_1": "bottom; background; base",
+        "primary_1": "底",
+        "primary_2": "底"
+    },
+    {
+        "intermediate_1": "di4dian3",
+        "intermediate_2": "dìdiǎn",
+        "native_1": "place; site; location",
+        "primary_1": "地点",
+        "primary_2": "地點"
+    },
+    {
+        "intermediate_1": "di4qiu2",
+        "intermediate_2": "dìqiú",
+        "native_1": "the Earth; planet",
+        "primary_1": "地球",
+        "primary_2": "地球"
+    },
+    {
+        "intermediate_1": "di4zhi3",
+        "intermediate_2": "dìzhǐ",
+        "native_1": "address",
+        "primary_1": "地址",
+        "primary_2": "地址"
+    },
+    {
+        "intermediate_1": "diao4cha2",
+        "intermediate_2": "diàochá",
+        "native_1": "investigate; survey; inquiry",
+        "primary_1": "调查",
+        "primary_2": "調查"
+    },
+    {
+        "intermediate_1": "diao4",
+        "intermediate_2": "diào",
+        "native_1": "to drop; to fall",
+        "primary_1": "掉",
+        "primary_2": "掉"
+    },
+    {
+        "intermediate_1": "diu1",
+        "intermediate_2": "diū",
+        "native_1": "lose (something); throw; put aside",
+        "primary_1": "丢",
+        "primary_2": "丟"
+    },
+    {
+        "intermediate_1": "dong4zuo4",
+        "intermediate_2": "dòngzuò",
+        "native_1": "movement; motion; action",
+        "primary_1": "动作",
+        "primary_2": "動作"
+    },
+    {
+        "intermediate_1": "du3che1",
+        "intermediate_2": "dǔchē",
+        "native_1": "traffic jam",
+        "primary_1": "堵车",
+        "primary_2": "堵車"
+    },
+    {
+        "intermediate_1": "du4zi",
+        "intermediate_2": "dùzi",
+        "native_1": "belly; abdomen; stomach",
+        "primary_1": "肚子",
+        "primary_2": "肚子"
+    },
+    {
+        "intermediate_1": "duan3xin4",
+        "intermediate_2": "duǎnxìn",
+        "native_1": "text message; SMS",
+        "primary_1": "短信",
+        "primary_2": "短信"
+    },
+    {
+        "intermediate_1": "dui4hua4",
+        "intermediate_2": "duìhuà",
+        "native_1": "dialogue; conversation",
+        "primary_1": "对话",
+        "primary_2": "對話"
+    },
+    {
+        "intermediate_1": "dui4mian4",
+        "intermediate_2": "duìmiàn",
+        "native_1": "opposite; across from; the other side",
+        "primary_1": "对面",
+        "primary_2": "對面"
+    },
+    {
+        "intermediate_1": "dui4yu2",
+        "intermediate_2": "duìyú",
+        "native_1": "regarding; as far as sth. is concerned; with regards to; for",
+        "primary_1": "对于",
+        "primary_2": "對于"
+    },
+    {
+        "intermediate_1": "er2tong2",
+        "intermediate_2": "értóng",
+        "native_1": "child; children",
+        "primary_1": "儿童",
+        "primary_2": "兒童"
+    },
+    {
+        "intermediate_1": "er2",
+        "intermediate_2": "ér",
+        "native_1": "and; but; yet; while (Kangxi radical 126)",
+        "primary_1": "而",
+        "primary_2": "而"
+    },
+    {
+        "intermediate_1": "fa1sheng1",
+        "intermediate_2": "fāshēng",
+        "native_1": "happen; occur; take place",
+        "primary_1": "发生",
+        "primary_2": "發生"
+    },
+    {
+        "intermediate_1": "fa1zhan3",
+        "intermediate_2": "fāzhǎn",
+        "native_1": "develop; development; growth",
+        "primary_1": "发展",
+        "primary_2": "發展"
+    },
+    {
+        "intermediate_1": "fa3lü4",
+        "intermediate_2": "fǎlǜ",
+        "native_1": "law; statute",
+        "primary_1": "法律",
+        "primary_2": "法律"
+    },
+    {
+        "intermediate_1": "fan1yi4",
+        "intermediate_2": "fānyì",
+        "native_1": "translate; translation; interpret",
+        "primary_1": "翻译",
+        "primary_2": "翻譯"
+    },
+    {
+        "intermediate_1": "fan2nao3",
+        "intermediate_2": "fánnǎo",
+        "native_1": "worried; vexed",
+        "primary_1": "烦恼",
+        "primary_2": "煩惱"
+    },
+    {
+        "intermediate_1": "fan3dui4",
+        "intermediate_2": "fǎnduì",
+        "native_1": "oppose; fight against",
+        "primary_1": "反对",
+        "primary_2": "反對"
+    },
+    {
+        "intermediate_1": "fang1fa3",
+        "intermediate_2": "fāngfǎ",
+        "native_1": "method; way; means",
+        "primary_1": "方法",
+        "primary_2": "方法"
+    },
+    {
+        "intermediate_1": "fang1mian4",
+        "intermediate_2": "fāngmiàn",
+        "native_1": "aspect; field; side",
+        "primary_1": "方面",
+        "primary_2": "方面"
+    },
+    {
+        "intermediate_1": "fang1xiang4",
+        "intermediate_2": "fāngxiàng",
+        "native_1": "direction; orientation",
+        "primary_1": "方向",
+        "primary_2": "方向"
+    },
+    {
+        "intermediate_1": "fang2dong1",
+        "intermediate_2": "fángdōng",
+        "native_1": "landlord",
+        "primary_1": "房东",
+        "primary_2": "房東"
+    },
+    {
+        "intermediate_1": "fang4qi4",
+        "intermediate_2": "fàngqì",
+        "native_1": "abandon; renounce; give up",
+        "primary_1": "放弃",
+        "primary_2": "放棄"
+    },
+    {
+        "intermediate_1": "fang4 shu3jia4",
+        "intermediate_2": "fàng shǔjià",
+        "native_1": "have summer vacation",
+        "primary_1": "放暑假",
+        "primary_2": "放暑假"
+    },
+    {
+        "intermediate_1": "fang4song1",
+        "intermediate_2": "fàngsōng",
+        "native_1": "relax; loosen; slacken",
+        "primary_1": "放松",
+        "primary_2": "放松"
+    },
+    {
+        "intermediate_1": "fen4",
+        "intermediate_2": "fèn",
+        "native_1": "part; portion; (mw for documents, papers, jobs, etc.)",
+        "primary_1": "份",
+        "primary_2": "份"
+    },
+    {
+        "intermediate_1": "feng1fu4",
+        "intermediate_2": "fēngfù",
+        "native_1": "rich; enrich; abundant; plentiful",
+        "primary_1": "丰富",
+        "primary_2": "豐富"
+    },
+    {
+        "intermediate_1": "fou3ze2",
+        "intermediate_2": "fǒuzé",
+        "native_1": "if not; otherwise; or else",
+        "primary_1": "否则",
+        "primary_2": "否則"
+    },
+    {
+        "intermediate_1": "fu2he2",
+        "intermediate_2": "fúhé",
+        "native_1": "in keeping with; in accordance with; conform",
+        "primary_1": "符合",
+        "primary_2": "符合"
+    },
+    {
+        "intermediate_1": "fu4qin",
+        "intermediate_2": "fùqin",
+        "native_1": "father",
+        "primary_1": "父亲",
+        "primary_2": "父親"
+    },
+    {
+        "intermediate_1": "fu4 kuan3",
+        "intermediate_2": "fù kuǎn",
+        "native_1": "to pay",
+        "primary_1": "付款",
+        "primary_2": "付款"
+    },
+    {
+        "intermediate_1": "fu4ze2",
+        "intermediate_2": "fùzé",
+        "native_1": "responsible for (something); in charge of",
+        "primary_1": "负责",
+        "primary_2": "負責"
+    },
+    {
+        "intermediate_1": "fu4yin4",
+        "intermediate_2": "fùyìn",
+        "native_1": "photocopy; duplicate",
+        "primary_1": "复印",
+        "primary_2": "複印"
+    },
+    {
+        "intermediate_1": "fu4za2",
+        "intermediate_2": "fùzá",
+        "native_1": "complicated; complex",
+        "primary_1": "复杂",
+        "primary_2": "複雜"
+    },
+    {
+        "intermediate_1": "fu4",
+        "intermediate_2": "fù",
+        "native_1": "wealthy",
+        "primary_1": "富",
+        "primary_2": "富"
+    },
+    {
+        "intermediate_1": "gai3bian4",
+        "intermediate_2": "gǎibiàn",
+        "native_1": "to change; alter; to transform",
+        "primary_1": "改变",
+        "primary_2": "改變"
+    },
+    {
+        "intermediate_1": "gan1 bei1",
+        "intermediate_2": "gān bēi",
+        "native_1": "to drink a toast; cheers!; bottoms up!",
+        "primary_1": "干杯",
+        "primary_2": "幹杯"
+    },
+    {
+        "intermediate_1": "gan3",
+        "intermediate_2": "gǎn",
+        "native_1": "catch up; overtake; drive away",
+        "primary_1": "赶",
+        "primary_2": "趕"
+    },
+    {
+        "intermediate_1": "gan3",
+        "intermediate_2": "gǎn",
+        "native_1": "to dare",
+        "primary_1": "敢",
+        "primary_2": "敢"
+    },
+    {
+        "intermediate_1": "gan3dong4",
+        "intermediate_2": "gǎndòng",
+        "native_1": "be moved; to touch emotionally",
+        "primary_1": "感动",
+        "primary_2": "感動"
+    },
+    {
+        "intermediate_1": "gan3jue2",
+        "intermediate_2": "gǎnjué",
+        "native_1": "to feel; become aware of; feeling",
+        "primary_1": "感觉",
+        "primary_2": "感覺"
+    },
+    {
+        "intermediate_1": "gan3qing2",
+        "intermediate_2": "gǎnqíng",
+        "native_1": "feeling; emotion; sensation",
+        "primary_1": "感情",
+        "primary_2": "感情"
+    },
+    {
+        "intermediate_1": "gan3xie4",
+        "intermediate_2": "gǎnxiè",
+        "native_1": "thank; be grateful",
+        "primary_1": "感谢",
+        "primary_2": "感謝"
+    },
+    {
+        "intermediate_1": "gan1",
+        "intermediate_2": "gān",
+        "native_1": "to concern; shield; dry; clean (Kangxi radical 51)",
+        "primary_1": "干",
+        "primary_2": "幹"
+    },
+    {
+        "intermediate_1": "gang1",
+        "intermediate_2": "gāng",
+        "native_1": "just (indicating the immediate past); recently; firm",
+        "primary_1": "刚",
+        "primary_2": "剛"
+    },
+    {
+        "intermediate_1": "gao1su4 gong1lu4",
+        "intermediate_2": "gāosù gōnglù",
+        "native_1": "highway",
+        "primary_1": "高速公路",
+        "primary_2": "高速公路"
+    },
+    {
+        "intermediate_1": "ge1bo",
+        "intermediate_2": "gēbo",
+        "native_1": "arm",
+        "primary_1": "胳膊",
+        "primary_2": "胳膊"
+    },
+    {
+        "intermediate_1": "ge4",
+        "intermediate_2": "gè",
+        "native_1": "each; every",
+        "primary_1": "各",
+        "primary_2": "各"
+    },
+    {
+        "intermediate_1": "gong1zi1",
+        "intermediate_2": "gōngzī",
+        "native_1": "wages; pay; earnings; salary",
+        "primary_1": "工资",
+        "primary_2": "工資"
+    },
+    {
+        "intermediate_1": "gong1li3",
+        "intermediate_2": "gōnglǐ",
+        "native_1": "kilometer",
+        "primary_1": "公里",
+        "primary_2": "公裏"
+    },
+    {
+        "intermediate_1": "gong1fu",
+        "intermediate_2": "gōngfu",
+        "native_1": "kung fu; skill; art; labor",
+        "primary_1": "功夫",
+        "primary_2": "功夫"
+    },
+    {
+        "intermediate_1": "gong4tong2",
+        "intermediate_2": "gòngtóng",
+        "native_1": "together; common; joint",
+        "primary_1": "共同",
+        "primary_2": "共同"
+    },
+    {
+        "intermediate_1": "gou4wu4",
+        "intermediate_2": "gòuwù",
+        "native_1": "go shopping; buy goods",
+        "primary_1": "购物",
+        "primary_2": "購物"
+    },
+    {
+        "intermediate_1": "gou4",
+        "intermediate_2": "gòu",
+        "native_1": "enough; to reach",
+        "primary_1": "够",
+        "primary_2": "夠"
+    },
+    {
+        "intermediate_1": "gu1ji4",
+        "intermediate_2": "gūjì",
+        "native_1": "appraise; estimate",
+        "primary_1": "估计",
+        "primary_2": "估計"
+    },
+    {
+        "intermediate_1": "gu3li4",
+        "intermediate_2": "gǔlì",
+        "native_1": "encourage; inspire",
+        "primary_1": "鼓励",
+        "primary_2": "鼓勵"
+    },
+    {
+        "intermediate_1": "gu4yi4",
+        "intermediate_2": "gùyì",
+        "native_1": "deliberately; intentional; on purpose",
+        "primary_1": "故意",
+        "primary_2": "故意"
+    },
+    {
+        "intermediate_1": "gu4ke4",
+        "intermediate_2": "gùkè",
+        "native_1": "customer; client",
+        "primary_1": "顾客",
+        "primary_2": "顧客"
+    },
+    {
+        "intermediate_1": "gua4",
+        "intermediate_2": "guà",
+        "native_1": "hang; put up; suspend",
+        "primary_1": "挂",
+        "primary_2": "挂"
+    },
+    {
+        "intermediate_1": "guan1jian4",
+        "intermediate_2": "guānjiàn",
+        "native_1": "crucial; key; pivotal",
+        "primary_1": "关键",
+        "primary_2": "關鍵"
+    },
+    {
+        "intermediate_1": "guan1zhong4",
+        "intermediate_2": "guānzhòng",
+        "native_1": "spectator; audience",
+        "primary_1": "观众",
+        "primary_2": "觀衆"
+    },
+    {
+        "intermediate_1": "guan3li3",
+        "intermediate_2": "guǎnlǐ",
+        "native_1": "supervise; manage",
+        "primary_1": "管理",
+        "primary_2": "管理"
+    },
+    {
+        "intermediate_1": "guang1",
+        "intermediate_2": "guāng",
+        "native_1": "light; ray; bright; only; merely; used up",
+        "primary_1": "光",
+        "primary_2": "光"
+    },
+    {
+        "intermediate_1": "guang3bo1",
+        "intermediate_2": "guǎngbō",
+        "native_1": "broadcast; on the air",
+        "primary_1": "广播",
+        "primary_2": "廣播"
+    },
+    {
+        "intermediate_1": "guang3gao4",
+        "intermediate_2": "guǎnggào",
+        "native_1": "advertisement; a commercial",
+        "primary_1": "广告",
+        "primary_2": "廣告"
+    },
+    {
+        "intermediate_1": "guang4",
+        "intermediate_2": "guàng",
+        "native_1": "to stroll; to visit; go window shopping",
+        "primary_1": "逛",
+        "primary_2": "逛"
+    },
+    {
+        "intermediate_1": "gui1ding4",
+        "intermediate_2": "guīdìng",
+        "native_1": "regulation; stipulate; fix; set",
+        "primary_1": "规定",
+        "primary_2": "規定"
+    },
+    {
+        "intermediate_1": "guo2ji2",
+        "intermediate_2": "guójí",
+        "native_1": "nationality",
+        "primary_1": "国籍",
+        "primary_2": "國籍"
+    },
+    {
+        "intermediate_1": "guo2ji4",
+        "intermediate_2": "guójì",
+        "native_1": "international",
+        "primary_1": "国际",
+        "primary_2": "國際"
+    },
+    {
+        "intermediate_1": "guo3zhi1",
+        "intermediate_2": "guǒzhī",
+        "native_1": "fruit juice",
+        "primary_1": "果汁",
+        "primary_2": "果汁"
+    },
+    {
+        "intermediate_1": "guo4cheng2",
+        "intermediate_2": "guòchéng",
+        "native_1": "course of events; process",
+        "primary_1": "过程",
+        "primary_2": "過程"
+    },
+    {
+        "intermediate_1": "hai3yang2",
+        "intermediate_2": "hǎiyáng",
+        "native_1": "ocean",
+        "primary_1": "海洋",
+        "primary_2": "海洋"
+    },
+    {
+        "intermediate_1": "hai4 xiu1",
+        "intermediate_2": "hài xiū",
+        "native_1": "blush; shy",
+        "primary_1": "害羞",
+        "primary_2": "害羞"
+    },
+    {
+        "intermediate_1": "han2jia4",
+        "intermediate_2": "hánjià",
+        "native_1": "winter vacation",
+        "primary_1": "寒假",
+        "primary_2": "寒假"
+    },
+    {
+        "intermediate_1": "han4",
+        "intermediate_2": "hàn",
+        "native_1": "sweat; perspiration; Khan",
+        "primary_1": "汗",
+        "primary_2": "汗"
+    },
+    {
+        "intermediate_1": "hang2ban1",
+        "intermediate_2": "hángbān",
+        "native_1": "scheduled flight; flight number",
+        "primary_1": "航班",
+        "primary_2": "航班"
+    },
+    {
+        "intermediate_1": "hao3chu",
+        "intermediate_2": "hǎochu",
+        "native_1": "benefit; advantage",
+        "primary_1": "好处",
+        "primary_2": "好處"
+    },
+    {
+        "intermediate_1": "hao3xiang4",
+        "intermediate_2": "hǎoxiàng",
+        "native_1": "as if; seem to be",
+        "primary_1": "好像",
+        "primary_2": "好像"
+    },
+    {
+        "intermediate_1": "hao4ma3",
+        "intermediate_2": "hàomǎ",
+        "native_1": "number",
+        "primary_1": "号码",
+        "primary_2": "號碼"
+    },
+    {
+        "intermediate_1": "he2ge2",
+        "intermediate_2": "hégé",
+        "native_1": "qualified; up to standard",
+        "primary_1": "合格",
+        "primary_2": "合格"
+    },
+    {
+        "intermediate_1": "he2shi4",
+        "intermediate_2": "héshì",
+        "native_1": "suitable; proper; appropriate",
+        "primary_1": "合适",
+        "primary_2": "合適"
+    },
+    {
+        "intermediate_1": "he2zi",
+        "intermediate_2": "hézi",
+        "native_1": "box",
+        "primary_1": "盒子",
+        "primary_2": "盒子"
+    },
+    {
+        "intermediate_1": "hou4hui3",
+        "intermediate_2": "hòuhuǐ",
+        "native_1": "to regret; repent",
+        "primary_1": "后悔",
+        "primary_2": "後悔"
+    },
+    {
+        "intermediate_1": "hou4",
+        "intermediate_2": "hòu",
+        "native_1": "thick (for flat things); generous",
+        "primary_1": "厚",
+        "primary_2": "厚"
+    },
+    {
+        "intermediate_1": "Hu4lian2wang3",
+        "intermediate_2": "Hùliánwǎng",
+        "native_1": "Internet",
+        "primary_1": "互联网",
+        "primary_2": "互聯網"
+    },
+    {
+        "intermediate_1": "hu4xiang1",
+        "intermediate_2": "hùxiāng",
+        "native_1": "mutually; with each other",
+        "primary_1": "互相",
+        "primary_2": "互相"
+    },
+    {
+        "intermediate_1": "hu4shi",
+        "intermediate_2": "hùshi",
+        "native_1": "nurse",
+        "primary_1": "护士",
+        "primary_2": "護士"
+    },
+    {
+        "intermediate_1": "huai2yi2",
+        "intermediate_2": "huáiyí",
+        "native_1": "doubt; to suspect; be skeptical",
+        "primary_1": "怀疑",
+        "primary_2": "懷疑"
+    },
+    {
+        "intermediate_1": "hui2yi4",
+        "intermediate_2": "huíyì",
+        "native_1": "to recall; recollect",
+        "primary_1": "回忆",
+        "primary_2": "回憶"
+    },
+    {
+        "intermediate_1": "huo2dong4",
+        "intermediate_2": "huódòng",
+        "native_1": "activity; exercise; move about",
+        "primary_1": "活动",
+        "primary_2": "活動"
+    },
+    {
+        "intermediate_1": "huo2po",
+        "intermediate_2": "huópo",
+        "native_1": "lively; vivacious",
+        "primary_1": "活泼",
+        "primary_2": "活潑"
+    },
+    {
+        "intermediate_1": "huo3",
+        "intermediate_2": "huǒ",
+        "native_1": "fire (Kangxi radical 86)",
+        "primary_1": "火",
+        "primary_2": "火"
+    },
+    {
+        "intermediate_1": "huo4de2",
+        "intermediate_2": "huòdé",
+        "native_1": "obtain; acquire; to gain",
+        "primary_1": "获得",
+        "primary_2": "獲得"
+    },
+    {
+        "intermediate_1": "ji1ji2",
+        "intermediate_2": "jījí",
+        "native_1": "active; positive; energetic",
+        "primary_1": "积极",
+        "primary_2": "積極"
+    },
+    {
+        "intermediate_1": "ji1lei3",
+        "intermediate_2": "jīlěi",
+        "native_1": "accumulate; accumulation",
+        "primary_1": "积累",
+        "primary_2": "積累"
+    },
+    {
+        "intermediate_1": "ji1chu3",
+        "intermediate_2": "jīchǔ",
+        "native_1": "base; foundation",
+        "primary_1": "基础",
+        "primary_2": "基礎"
+    },
+    {
+        "intermediate_1": "ji1dong4",
+        "intermediate_2": "jīdòng",
+        "native_1": "excite; agitate",
+        "primary_1": "激动",
+        "primary_2": "激動"
+    },
+    {
+        "intermediate_1": "ji2shi2",
+        "intermediate_2": "jíshí",
+        "native_1": "timely; in time; promptly; without delay",
+        "primary_1": "及时",
+        "primary_2": "及時"
+    },
+    {
+        "intermediate_1": "ji2shi3",
+        "intermediate_2": "jíshǐ",
+        "native_1": "even if; even though",
+        "primary_1": "即使",
+        "primary_2": "即使"
+    },
+    {
+        "intermediate_1": "ji4hua4",
+        "intermediate_2": "jìhuà",
+        "native_1": "plan; project",
+        "primary_1": "计划",
+        "primary_2": "計劃"
+    },
+    {
+        "intermediate_1": "ji4zhe3",
+        "intermediate_2": "jìzhě",
+        "native_1": "reporter; journalist",
+        "primary_1": "记者",
+        "primary_2": "記者"
+    },
+    {
+        "intermediate_1": "ji4shu4",
+        "intermediate_2": "jìshù",
+        "native_1": "technology; technique; skill",
+        "primary_1": "技术",
+        "primary_2": "技術"
+    },
+    {
+        "intermediate_1": "ji4ran2",
+        "intermediate_2": "jìrán",
+        "native_1": "since; given that; now that",
+        "primary_1": "既然",
+        "primary_2": "既然"
+    },
+    {
+        "intermediate_1": "ji4xu4",
+        "intermediate_2": "jìxù",
+        "native_1": "to continue; to go on; to proceed",
+        "primary_1": "继续",
+        "primary_2": "繼續"
+    },
+    {
+        "intermediate_1": "ji4",
+        "intermediate_2": "jì",
+        "native_1": "send by mail",
+        "primary_1": "寄",
+        "primary_2": "寄"
+    },
+    {
+        "intermediate_1": "jia1 ban1",
+        "intermediate_2": "jiā bān",
+        "native_1": "work overtime",
+        "primary_1": "加班",
+        "primary_2": "加班"
+    },
+    {
+        "intermediate_1": "jia1you2zhan4",
+        "intermediate_2": "jiāyóuzhàn",
+        "native_1": "gas station",
+        "primary_1": "加油站",
+        "primary_2": "加油站"
+    },
+    {
+        "intermediate_1": "jia1ju4",
+        "intermediate_2": "jiājù",
+        "native_1": "furniture",
+        "primary_1": "家具",
+        "primary_2": "家具"
+    },
+    {
+        "intermediate_1": "jia3, jia4",
+        "intermediate_2": "jiǎ, jià",
+        "native_1": "fake; if; borrow | vacation; holiday",
+        "primary_1": "假",
+        "primary_2": "假"
+    },
+    {
+        "intermediate_1": "jia4ge2",
+        "intermediate_2": "jiàgé",
+        "native_1": "price",
+        "primary_1": "价格",
+        "primary_2": "價格"
+    },
+    {
+        "intermediate_1": "jian1chi2",
+        "intermediate_2": "jiānchí",
+        "native_1": "persist in; persevere",
+        "primary_1": "坚持",
+        "primary_2": "堅持"
+    },
+    {
+        "intermediate_1": "jian3fei2",
+        "intermediate_2": "jiǎnféi",
+        "native_1": "go on a diet; lose weight",
+        "primary_1": "减肥",
+        "primary_2": "減肥"
+    },
+    {
+        "intermediate_1": "jian3shao3",
+        "intermediate_2": "jiǎnshǎo",
+        "native_1": "reduce; to decrease",
+        "primary_1": "减少",
+        "primary_2": "減少"
+    },
+    {
+        "intermediate_1": "jian4yi4",
+        "intermediate_2": "jiànyì",
+        "native_1": "to propose; to suggest; recommend",
+        "primary_1": "建议",
+        "primary_2": "建議"
+    },
+    {
+        "intermediate_1": "jiang1lai2",
+        "intermediate_2": "jiānglái",
+        "native_1": "the future",
+        "primary_1": "将来",
+        "primary_2": "將來"
+    },
+    {
+        "intermediate_1": "jiang3jin1",
+        "intermediate_2": "jiǎngjīn",
+        "native_1": "bonus",
+        "primary_1": "奖金",
+        "primary_2": "獎金"
+    },
+    {
+        "intermediate_1": "jiang4di1",
+        "intermediate_2": "jiàngdī",
+        "native_1": "reduce; to lower; to drop",
+        "primary_1": "降低",
+        "primary_2": "降低"
+    },
+    {
+        "intermediate_1": "jiang4luo4",
+        "intermediate_2": "jiàngluò",
+        "native_1": "descend; to land; put down",
+        "primary_1": "降落",
+        "primary_2": "降落"
+    },
+    {
+        "intermediate_1": "jiao1",
+        "intermediate_2": "jiāo",
+        "native_1": "deliver; turn over; intersect; to pay (money); friendship",
+        "primary_1": "交",
+        "primary_2": "交"
+    },
+    {
+        "intermediate_1": "jiao1liu2",
+        "intermediate_2": "jiāoliú",
+        "native_1": "communicate; exchange; give and take; interaction; to alternate",
+        "primary_1": "交流",
+        "primary_2": "交流"
+    },
+    {
+        "intermediate_1": "jiao1tong1",
+        "intermediate_2": "jiāotōng",
+        "native_1": "traffic; transportation",
+        "primary_1": "交通",
+        "primary_2": "交通"
+    },
+    {
+        "intermediate_1": "jiao1qu1",
+        "intermediate_2": "jiāoqū",
+        "native_1": "suburbs; outskirts",
+        "primary_1": "郊区",
+        "primary_2": "郊區"
+    },
+    {
+        "intermediate_1": "jiao1'ao4",
+        "intermediate_2": "jiāo'ào",
+        "native_1": "proud; arrogant; conceited; take pride in",
+        "primary_1": "骄傲",
+        "primary_2": "驕傲"
+    },
+    {
+        "intermediate_1": "jiao3zi",
+        "intermediate_2": "jiǎozi",
+        "native_1": "dumpling; potsticker",
+        "primary_1": "饺子",
+        "primary_2": "餃子"
+    },
+    {
+        "intermediate_1": "jiao4shou4",
+        "intermediate_2": "jiàoshòu",
+        "native_1": "professor; instruct; to lecture",
+        "primary_1": "教授",
+        "primary_2": "教授"
+    },
+    {
+        "intermediate_1": "jiao4yu4",
+        "intermediate_2": "jiàoyù",
+        "native_1": "education",
+        "primary_1": "教育",
+        "primary_2": "教育"
+    },
+    {
+        "intermediate_1": "jie1shou4",
+        "intermediate_2": "jiēshòu",
+        "native_1": "accept; receive (honors, etc.)",
+        "primary_1": "接受",
+        "primary_2": "接受"
+    },
+    {
+        "intermediate_1": "jie1zhe",
+        "intermediate_2": "jiēzhe",
+        "native_1": "continue; carry on; to catch; follow",
+        "primary_1": "接着",
+        "primary_2": "接著"
+    },
+    {
+        "intermediate_1": "jie2",
+        "intermediate_2": "jié",
+        "native_1": "section; part; festival; moral integrity; save; (mw for class periods)",
+        "primary_1": "节",
+        "primary_2": "節"
+    },
+    {
+        "intermediate_1": "jie2yue1",
+        "intermediate_2": "jiéyuē",
+        "native_1": "frugal; to save",
+        "primary_1": "节约",
+        "primary_2": "節約"
+    },
+    {
+        "intermediate_1": "jie2guo3",
+        "intermediate_2": "jiéguǒ",
+        "native_1": "result; outcome; finally",
+        "primary_1": "结果",
+        "primary_2": "結果"
+    },
+    {
+        "intermediate_1": "jie3shi4",
+        "intermediate_2": "jiěshì",
+        "native_1": "to explain",
+        "primary_1": "解释",
+        "primary_2": "解釋"
+    },
+    {
+        "intermediate_1": "jing3uan3",
+        "intermediate_2": "jǐnguǎn",
+        "native_1": "despite; although; even though | freely; without hesitation",
+        "primary_1": "尽管",
+        "primary_2": "盡管"
+    },
+    {
+        "intermediate_1": "jin3zhang1",
+        "intermediate_2": "jǐnzhāng",
+        "native_1": "nervous; tension; strain",
+        "primary_1": "紧张",
+        "primary_2": "緊張"
+    },
+    {
+        "intermediate_1": "jin4xing2",
+        "intermediate_2": "jìnxíng",
+        "native_1": "carry on; carry out; undertake",
+        "primary_1": "进行",
+        "primary_2": "進行"
+    },
+    {
+        "intermediate_1": "jin4zhi3",
+        "intermediate_2": "jìnzhǐ",
+        "native_1": "to ban; prohibit",
+        "primary_1": "禁止",
+        "primary_2": "禁止"
+    },
+    {
+        "intermediate_1": "jing1ju4",
+        "intermediate_2": "jīngjù",
+        "native_1": "Beijing Opera",
+        "primary_1": "京剧",
+        "primary_2": "京劇"
+    },
+    {
+        "intermediate_1": "jing1ji4",
+        "intermediate_2": "jīngjì",
+        "native_1": "economy; economic",
+        "primary_1": "经济",
+        "primary_2": "經濟"
+    },
+    {
+        "intermediate_1": "jing1li4",
+        "intermediate_2": "jīnglì",
+        "native_1": "undergo; to experience",
+        "primary_1": "经历",
+        "primary_2": "經曆"
+    },
+    {
+        "intermediate_1": "jing1yan4",
+        "intermediate_2": "jīngyàn",
+        "native_1": "experience",
+        "primary_1": "经验",
+        "primary_2": "經驗"
+    },
+    {
+        "intermediate_1": "jing1cai3",
+        "intermediate_2": "jīngcǎi",
+        "native_1": "brilliant; spectacular; wonderful",
+        "primary_1": "精彩",
+        "primary_2": "精彩"
+    },
+    {
+        "intermediate_1": "jing3se4",
+        "intermediate_2": "jǐngsè",
+        "native_1": "scenery; landscape; scene; view",
+        "primary_1": "景色",
+        "primary_2": "景色"
+    },
+    {
+        "intermediate_1": "jing3cha2",
+        "intermediate_2": "jǐngchá",
+        "native_1": "police",
+        "primary_1": "警察",
+        "primary_2": "警察"
+    },
+    {
+        "intermediate_1": "jing4zheng1",
+        "intermediate_2": "jìngzhēng",
+        "native_1": "compete",
+        "primary_1": "竞争",
+        "primary_2": "競爭"
+    },
+    {
+        "intermediate_1": "jing4ran2",
+        "intermediate_2": "jìngrán",
+        "native_1": "unexpectedly; to one's surprise; go so far as to",
+        "primary_1": "竟然",
+        "primary_2": "竟然"
+    },
+    {
+        "intermediate_1": "jing4zi",
+        "intermediate_2": "jìngzi",
+        "native_1": "mirror",
+        "primary_1": "镜子",
+        "primary_2": "鏡子"
+    },
+    {
+        "intermediate_1": "jiu1jing4",
+        "intermediate_2": "jiūjìng",
+        "native_1": "after all; when all is said and done; actually",
+        "primary_1": "究竟",
+        "primary_2": "究竟"
+    },
+    {
+        "intermediate_1": "ju3",
+        "intermediate_2": "jǔ",
+        "native_1": "lift; raise; cite",
+        "primary_1": "举",
+        "primary_2": "舉"
+    },
+    {
+        "intermediate_1": "ju3ban4",
+        "intermediate_2": "jǔbàn",
+        "native_1": "to conduct; to hold",
+        "primary_1": "举办",
+        "primary_2": "舉辦"
+    },
+    {
+        "intermediate_1": "ju3xing2",
+        "intermediate_2": "jǔxíng",
+        "native_1": "convene; to hold (a meeting, ceremony, etc.)",
+        "primary_1": "举行",
+        "primary_2": "舉行"
+    },
+    {
+        "intermediate_1": "ju4jue2",
+        "intermediate_2": "jùjué",
+        "native_1": "to refuse; to decline; to reject",
+        "primary_1": "拒绝",
+        "primary_2": "拒絕"
+    },
+    {
+        "intermediate_1": "ju4li2",
+        "intermediate_2": "jùlí",
+        "native_1": "distance; be apart; away from",
+        "primary_1": "距离",
+        "primary_2": "距離"
+    },
+    {
+        "intermediate_1": "ju4hui4",
+        "intermediate_2": "jùhuì",
+        "native_1": "hold a meeting; get together; a party",
+        "primary_1": "聚会",
+        "primary_2": "聚會"
+    },
+    {
+        "intermediate_1": "kai1 wan2xiao4",
+        "intermediate_2": "kāi wánxiào",
+        "native_1": "joke; play a joke; make fun of",
+        "primary_1": "开玩笑",
+        "primary_2": "開玩笑"
+    },
+    {
+        "intermediate_1": "kai1xin1",
+        "intermediate_2": "kāixīn",
+        "native_1": "feel happy; have a great time; make fun of somebody",
+        "primary_1": "开心",
+        "primary_2": "開心"
+    },
+    {
+        "intermediate_1": "kan4fa3",
+        "intermediate_2": "kànfǎ",
+        "native_1": "point of view; opinion",
+        "primary_1": "看法",
+        "primary_2": "看法"
+    },
+    {
+        "intermediate_1": "kao3lü4",
+        "intermediate_2": "kǎolǜ",
+        "native_1": "think over; consider",
+        "primary_1": "考虑",
+        "primary_2": "考慮"
+    },
+    {
+        "intermediate_1": "kao3ya1",
+        "intermediate_2": "kǎoyā",
+        "native_1": "roast duck",
+        "primary_1": "烤鸭",
+        "primary_2": "烤鴨"
+    },
+    {
+        "intermediate_1": "ke1xue2",
+        "intermediate_2": "kēxué",
+        "native_1": "science; scientific knowledge",
+        "primary_1": "科学",
+        "primary_2": "科學"
+    },
+    {
+        "intermediate_1": "ke1",
+        "intermediate_2": "kē",
+        "native_1": "(mw for plants)",
+        "primary_1": "棵",
+        "primary_2": "棵"
+    },
+    {
+        "intermediate_1": "ke2sou",
+        "intermediate_2": "késou",
+        "native_1": "to cough",
+        "primary_1": "咳嗽",
+        "primary_2": "咳嗽"
+    },
+    {
+        "intermediate_1": "ke3lian2",
+        "intermediate_2": "kělián",
+        "native_1": "pitiful; poor; pathetic",
+        "primary_1": "可怜",
+        "primary_2": "可憐"
+    },
+    {
+        "intermediate_1": "ke3shi4",
+        "intermediate_2": "kěshì",
+        "native_1": "but; however",
+        "primary_1": "可是",
+        "primary_2": "可是"
+    },
+    {
+        "intermediate_1": "ke3xi1",
+        "intermediate_2": "kěxī",
+        "native_1": "it's a pity; regrettable; too bad",
+        "primary_1": "可惜",
+        "primary_2": "可惜"
+    },
+    {
+        "intermediate_1": "ke4ting1",
+        "intermediate_2": "kètīng",
+        "native_1": "living room; parlor",
+        "primary_1": "客厅",
+        "primary_2": "客廳"
+    },
+    {
+        "intermediate_1": "ken3ding4",
+        "intermediate_2": "kěndìng",
+        "native_1": "sure; definite; affirm; approve",
+        "primary_1": "肯定",
+        "primary_2": "肯定"
+    },
+    {
+        "intermediate_1": "kong1, kong4",
+        "intermediate_2": "kōng, kòng",
+        "native_1": "empty; sky | leave blank; leisure",
+        "primary_1": "空",
+        "primary_2": "空"
+    },
+    {
+        "intermediate_1": "kong1qi4",
+        "intermediate_2": "kōngqì",
+        "native_1": "air",
+        "primary_1": "空气",
+        "primary_2": "空氣"
+    },
+    {
+        "intermediate_1": "kong3pa4",
+        "intermediate_2": "kǒngpà",
+        "native_1": "be afraid; to fear; I'm afraid that...",
+        "primary_1": "恐怕",
+        "primary_2": "恐怕"
+    },
+    {
+        "intermediate_1": "ku3",
+        "intermediate_2": "kǔ",
+        "native_1": "bitter; miserable",
+        "primary_1": "苦",
+        "primary_2": "苦"
+    },
+    {
+        "intermediate_1": "kuang4quan2shui3",
+        "intermediate_2": "kuàngquánshuǐ",
+        "native_1": "mineral water",
+        "primary_1": "矿泉水",
+        "primary_2": "礦泉水"
+    },
+    {
+        "intermediate_1": "kun4",
+        "intermediate_2": "kùn",
+        "native_1": "sleepy; surround; hard-pressed",
+        "primary_1": "困",
+        "primary_2": "困"
+    },
+    {
+        "intermediate_1": "kun4nan",
+        "intermediate_2": "kùnnan",
+        "native_1": "difficulty; difficult; problem",
+        "primary_1": "困难",
+        "primary_2": "困難"
+    },
+    {
+        "intermediate_1": "la1ji1tong3",
+        "intermediate_2": "lājītǒng",
+        "native_1": "garbage can",
+        "primary_1": "垃圾桶",
+        "primary_2": "垃圾桶"
+    },
+    {
+        "intermediate_1": "la1",
+        "intermediate_2": "lā",
+        "native_1": "to pull; to play (string instruments); to drag",
+        "primary_1": "拉",
+        "primary_2": "拉"
+    },
+    {
+        "intermediate_1": "la4",
+        "intermediate_2": "là",
+        "native_1": "hot (spicy)",
+        "primary_1": "辣",
+        "primary_2": "辣"
+    },
+    {
+        "intermediate_1": "lai2 bu ji2",
+        "intermediate_2": "lái bu jí",
+        "native_1": "there's not enough time (to do something); it's too late",
+        "primary_1": "来不及",
+        "primary_2": "來不及"
+    },
+    {
+        "intermediate_1": "lai2 de ji2",
+        "intermediate_2": "lái de jí",
+        "native_1": "there's still time",
+        "primary_1": "来得及",
+        "primary_2": "來得及"
+    },
+    {
+        "intermediate_1": "lai2zi4",
+        "intermediate_2": "láizì",
+        "native_1": "come from (a place)",
+        "primary_1": "来自",
+        "primary_2": "來自"
+    },
+    {
+        "intermediate_1": "lan3",
+        "intermediate_2": "lǎn",
+        "native_1": "lazy",
+        "primary_1": "懒",
+        "primary_2": "懶"
+    },
+    {
+        "intermediate_1": "lang4fei4",
+        "intermediate_2": "làngfèi",
+        "native_1": "to waste; squander",
+        "primary_1": "浪费",
+        "primary_2": "浪費"
+    },
+    {
+        "intermediate_1": "lang4man4",
+        "intermediate_2": "làngmàn",
+        "native_1": "romantic",
+        "primary_1": "浪漫",
+        "primary_2": "浪漫"
+    },
+    {
+        "intermediate_1": "lao3hu3",
+        "intermediate_2": "lǎohǔ",
+        "native_1": "tiger",
+        "primary_1": "老虎",
+        "primary_2": "老虎"
+    },
+    {
+        "intermediate_1": "leng3jing4",
+        "intermediate_2": "lěngjìng",
+        "native_1": "calm; cool-headed; sober",
+        "primary_1": "冷静",
+        "primary_2": "冷靜"
+    },
+    {
+        "intermediate_1": "li3bai4tian1",
+        "intermediate_2": "lǐbàitiān",
+        "native_1": "Sunday",
+        "primary_1": "礼拜天",
+        "primary_2": "禮拜天"
+    },
+    {
+        "intermediate_1": "li3mao4",
+        "intermediate_2": "lǐmào",
+        "native_1": "courtesy; politeness; manners",
+        "primary_1": "礼貌",
+        "primary_2": "禮貌"
+    },
+    {
+        "intermediate_1": "li3fa4",
+        "intermediate_2": "lǐfà",
+        "native_1": "a barber, hairdressing; haircut",
+        "primary_1": "理发",
+        "primary_2": "理發"
+    },
+    {
+        "intermediate_1": "li3jie3",
+        "intermediate_2": "lǐjiě",
+        "native_1": "comprehend; understand",
+        "primary_1": "理解",
+        "primary_2": "理解"
+    },
+    {
+        "intermediate_1": "li3xiang3",
+        "intermediate_2": "lǐxiǎng",
+        "native_1": "ideal",
+        "primary_1": "理想",
+        "primary_2": "理想"
+    },
+    {
+        "intermediate_1": "li4qi",
+        "intermediate_2": "lìqi",
+        "native_1": "physical strength; effort",
+        "primary_1": "力气",
+        "primary_2": "力氣"
+    },
+    {
+        "intermediate_1": "li4hai",
+        "intermediate_2": "lìhai",
+        "native_1": "terrible; formidable; fierce; cool; awesome",
+        "primary_1": "厉害",
+        "primary_2": "厲害"
+    },
+    {
+        "intermediate_1": "li4ru2",
+        "intermediate_2": "lìrú",
+        "native_1": "for example; for instance",
+        "primary_1": "例如",
+        "primary_2": "例如"
+    },
+    {
+        "intermediate_1": "liang3",
+        "intermediate_2": "liǎng",
+        "native_1": "(colloquial) two (people)",
+        "primary_1": "俩",
+        "primary_2": "倆"
+    },
+    {
+        "intermediate_1": "lian2",
+        "intermediate_2": "lián",
+        "native_1": "even; including; join",
+        "primary_1": "连",
+        "primary_2": "連"
+    },
+    {
+        "intermediate_1": "lian2xi4",
+        "intermediate_2": "liánxì",
+        "native_1": "integrate; link; connection; contact",
+        "primary_1": "联系",
+        "primary_2": "聯系"
+    },
+    {
+        "intermediate_1": "liang2kuai",
+        "intermediate_2": "liángkuai",
+        "native_1": "nice and cool; pleasantly cool",
+        "primary_1": "凉快",
+        "primary_2": "涼快"
+    },
+    {
+        "intermediate_1": "ling2qian2",
+        "intermediate_2": "língqián",
+        "native_1": "small change (of money)",
+        "primary_1": "零钱",
+        "primary_2": "零錢"
+    },
+    {
+        "intermediate_1": "ling4wai4",
+        "intermediate_2": "lìngwài",
+        "native_1": "another; in addition; besides",
+        "primary_1": "另外",
+        "primary_2": "另外"
+    },
+    {
+        "intermediate_1": "liu2",
+        "intermediate_2": "liú",
+        "native_1": "to leave (behind, a message); to retain; to stay",
+        "primary_1": "留",
+        "primary_2": "留"
+    },
+    {
+        "intermediate_1": "liu2li4",
+        "intermediate_2": "liúlì",
+        "native_1": "fluent",
+        "primary_1": "流利",
+        "primary_2": "流利"
+    },
+    {
+        "intermediate_1": "liu2xing2",
+        "intermediate_2": "liúxíng",
+        "native_1": "spread; prevalent; be popular",
+        "primary_1": "流行",
+        "primary_2": "流行"
+    },
+    {
+        "intermediate_1": "lü3xing2",
+        "intermediate_2": "lǚxíng",
+        "native_1": "travel",
+        "primary_1": "旅行",
+        "primary_2": "旅行"
+    },
+    {
+        "intermediate_1": "lü4shi1",
+        "intermediate_2": "lǜshī",
+        "native_1": "lawyer",
+        "primary_1": "律师",
+        "primary_2": "律師"
+    },
+    {
+        "intermediate_1": "luan4",
+        "intermediate_2": "luàn",
+        "native_1": "disorder; confusion; arbitrarily",
+        "primary_1": "乱",
+        "primary_2": "亂"
+    },
+    {
+        "intermediate_1": "ma2fan",
+        "intermediate_2": "máfan",
+        "native_1": "trouble (someone); troubling; bothersome",
+        "primary_1": "麻烦",
+        "primary_2": "麻煩"
+    },
+    {
+        "intermediate_1": "ma3hu",
+        "intermediate_2": "mǎhu",
+        "native_1": "careless; sloppy; casual",
+        "primary_1": "马虎",
+        "primary_2": "馬虎"
+    },
+    {
+        "intermediate_1": "man3",
+        "intermediate_2": "mǎn",
+        "native_1": "full; abbreviation for Manchurian",
+        "primary_1": "满",
+        "primary_2": "滿"
+    },
+    {
+        "intermediate_1": "mao2",
+        "intermediate_2": "máo",
+        "native_1": "hair; fur; feather; dime (Kangxi radical 82)",
+        "primary_1": "毛",
+        "primary_2": "毛"
+    },
+    {
+        "intermediate_1": "mao2jin1",
+        "intermediate_2": "máojīn",
+        "native_1": "towel; washcloth",
+        "primary_1": "毛巾",
+        "primary_2": "毛巾"
+    },
+    {
+        "intermediate_1": "mei3li4",
+        "intermediate_2": "měilì",
+        "native_1": "beautiful",
+        "primary_1": "美丽",
+        "primary_2": "美麗"
+    },
+    {
+        "intermediate_1": "meng4",
+        "intermediate_2": "mèng",
+        "native_1": "to dream",
+        "primary_1": "梦",
+        "primary_2": "夢"
+    },
+    {
+        "intermediate_1": "mi2lu4",
+        "intermediate_2": "mílù",
+        "native_1": "to get lost",
+        "primary_1": "迷路",
+        "primary_2": "迷路"
+    },
+    {
+        "intermediate_1": "mi4ma3",
+        "intermediate_2": "mìmǎ",
+        "native_1": "password; secret code",
+        "primary_1": "密码",
+        "primary_2": "密碼"
+    },
+    {
+        "intermediate_1": "mian3 fei4",
+        "intermediate_2": "miǎn fèi",
+        "native_1": "free (of charge); no cost",
+        "primary_1": "免费",
+        "primary_2": "免費"
+    },
+    {
+        "intermediate_1": "miao3",
+        "intermediate_2": "miǎo",
+        "native_1": "second (unit of time or angle)",
+        "primary_1": "秒",
+        "primary_2": "秒"
+    },
+    {
+        "intermediate_1": "min2zu2",
+        "intermediate_2": "mínzú",
+        "native_1": "nationality; ethnic group",
+        "primary_1": "民族",
+        "primary_2": "民族"
+    },
+    {
+        "intermediate_1": "mu3qin",
+        "intermediate_2": "mǔqin",
+        "native_1": "mother",
+        "primary_1": "母亲",
+        "primary_2": "母親"
+    },
+    {
+        "intermediate_1": "mu4di4",
+        "intermediate_2": "mùdì",
+        "native_1": "purpose; aim; goal",
+        "primary_1": "目的",
+        "primary_2": "目的"
+    },
+    {
+        "intermediate_1": "nai4xin1",
+        "intermediate_2": "nàixīn",
+        "native_1": "to be patient",
+        "primary_1": "耐心",
+        "primary_2": "耐心"
+    },
+    {
+        "intermediate_1": "nan2dao4",
+        "intermediate_2": "nándào",
+        "native_1": "could it be that ...?; don't tell me ...",
+        "primary_1": "难道",
+        "primary_2": "難道"
+    },
+    {
+        "intermediate_1": "nan2shou4",
+        "intermediate_2": "nánshòu",
+        "native_1": "feel unwell; to suffer pain",
+        "primary_1": "难受",
+        "primary_2": "難受"
+    },
+    {
+        "intermediate_1": "nei4",
+        "intermediate_2": "nèi",
+        "native_1": "inside; inner; internal; within",
+        "primary_1": "内",
+        "primary_2": "內"
+    },
+    {
+        "intermediate_1": "nei4rong2",
+        "intermediate_2": "nèiróng",
+        "native_1": "content; substance; details",
+        "primary_1": "内容",
+        "primary_2": "內容"
+    },
+    {
+        "intermediate_1": "neng2li4",
+        "intermediate_2": "nénglì",
+        "native_1": "capability; capable; ability",
+        "primary_1": "能力",
+        "primary_2": "能力"
+    },
+    {
+        "intermediate_1": "nian2ling2",
+        "intermediate_2": "niánlíng",
+        "native_1": "(a person's) age",
+        "primary_1": "年龄",
+        "primary_2": "年齡"
+    },
+    {
+        "intermediate_1": "nong4",
+        "intermediate_2": "nòng",
+        "native_1": "do; manage; to handle; make",
+        "primary_1": "弄",
+        "primary_2": "弄"
+    },
+    {
+        "intermediate_1": "nuan3huo",
+        "intermediate_2": "nuǎnhuo",
+        "native_1": "warm; nice and warm",
+        "primary_1": "暖和",
+        "primary_2": "暖和"
+    },
+    {
+        "intermediate_1": "ou3'er3",
+        "intermediate_2": "ǒu'ěr",
+        "native_1": "occasionally; once in a while; sometimes",
+        "primary_1": "偶尔",
+        "primary_2": "偶爾"
+    },
+    {
+        "intermediate_1": "pai2 dui4",
+        "intermediate_2": "pái duì",
+        "native_1": "queue; stand in line",
+        "primary_1": "排队",
+        "primary_2": "排隊"
+    },
+    {
+        "intermediate_1": "pai2lie4",
+        "intermediate_2": "páiliè",
+        "native_1": "arrange; align; permutation",
+        "primary_1": "排列",
+        "primary_2": "排列"
+    },
+    {
+        "intermediate_1": "pan4duan4",
+        "intermediate_2": "pànduàn",
+        "native_1": "to judge; judgment; to decide",
+        "primary_1": "判断",
+        "primary_2": "判斷"
+    },
+    {
+        "intermediate_1": "pei2",
+        "intermediate_2": "péi",
+        "native_1": "accompany; keep company",
+        "primary_1": "陪",
+        "primary_2": "陪"
+    },
+    {
+        "intermediate_1": "pi1ping2",
+        "intermediate_2": "pīpíng",
+        "native_1": "criticize",
+        "primary_1": "批评",
+        "primary_2": "批評"
+    },
+    {
+        "intermediate_1": "pi2fu1",
+        "intermediate_2": "pífū",
+        "native_1": "skin",
+        "primary_1": "皮肤",
+        "primary_2": "皮膚"
+    },
+    {
+        "intermediate_1": "pi2qi",
+        "intermediate_2": "píqi",
+        "native_1": "temperament; disposition; temper",
+        "primary_1": "脾气",
+        "primary_2": "脾氣"
+    },
+    {
+        "intermediate_1": "pian1",
+        "intermediate_2": "piān",
+        "native_1": "sheet; (mw for articles); piece of writing",
+        "primary_1": "篇",
+        "primary_2": "篇"
+    },
+    {
+        "intermediate_1": "pian4",
+        "intermediate_2": "piàn",
+        "native_1": "to cheat; to swindle; deceive",
+        "primary_1": "骗",
+        "primary_2": "騙"
+    },
+    {
+        "intermediate_1": "ping1pang1qiu2",
+        "intermediate_2": "pīngpāngqiú",
+        "native_1": "ping pong; table tennis",
+        "primary_1": "乒乓球",
+        "primary_2": "乒乓球"
+    },
+    {
+        "intermediate_1": "ping2shi2",
+        "intermediate_2": "píngshí",
+        "native_1": "ordinarily; in normal times; in peacetime",
+        "primary_1": "平时",
+        "primary_2": "平時"
+    },
+    {
+        "intermediate_1": "po4",
+        "intermediate_2": "pò",
+        "native_1": "broken; damaged; to split",
+        "primary_1": "破",
+        "primary_2": "破"
+    },
+    {
+        "intermediate_1": "pu2tao",
+        "intermediate_2": "pútao",
+        "native_1": "grape",
+        "primary_1": "葡萄",
+        "primary_2": "葡萄"
+    },
+    {
+        "intermediate_1": "pu3bian4",
+        "intermediate_2": "pǔbiàn",
+        "native_1": "common; universal; general; widespread",
+        "primary_1": "普遍",
+        "primary_2": "普遍"
+    },
+    {
+        "intermediate_1": "pu3tong1hua4",
+        "intermediate_2": "pǔtōnghuà",
+        "native_1": "Mandarin (common language)",
+        "primary_1": "普通话",
+        "primary_2": "普通話"
+    },
+    {
+        "intermediate_1": "qi2ci4",
+        "intermediate_2": "qícì",
+        "native_1": "next; secondly",
+        "primary_1": "其次",
+        "primary_2": "其次"
+    },
+    {
+        "intermediate_1": "qi2zhong1",
+        "intermediate_2": "qízhōng",
+        "native_1": "among; in; included among these",
+        "primary_1": "其中",
+        "primary_2": "其中"
+    },
+    {
+        "intermediate_1": "qi4hou4",
+        "intermediate_2": "qìhòu",
+        "native_1": "climate; atmosphere; weather",
+        "primary_1": "气候",
+        "primary_2": "氣候"
+    },
+    {
+        "intermediate_1": "qian1wan4",
+        "intermediate_2": "qiānwàn",
+        "native_1": "ten million; be sure to; must",
+        "primary_1": "千万",
+        "primary_2": "千萬"
+    },
+    {
+        "intermediate_1": "qian1zheng4",
+        "intermediate_2": "qiānzhèng",
+        "native_1": "visa",
+        "primary_1": "签证",
+        "primary_2": "簽證"
+    },
+    {
+        "intermediate_1": "qiao1",
+        "intermediate_2": "qiāo",
+        "native_1": "knock; blackmail",
+        "primary_1": "敲",
+        "primary_2": "敲"
+    },
+    {
+        "intermediate_1": "qiao2",
+        "intermediate_2": "qiáo",
+        "native_1": "bridge",
+        "primary_1": "桥",
+        "primary_2": "橋"
+    },
+    {
+        "intermediate_1": "qiao3ke4li4",
+        "intermediate_2": "qiǎokèlì",
+        "native_1": "chocolate",
+        "primary_1": "巧克力",
+        "primary_2": "巧克力"
+    },
+    {
+        "intermediate_1": "qin1qi",
+        "intermediate_2": "qīnqi",
+        "native_1": "a relative (i.e. family relation)",
+        "primary_1": "亲戚",
+        "primary_2": "親戚"
+    },
+    {
+        "intermediate_1": "qing1",
+        "intermediate_2": "qīng",
+        "native_1": "light; easy; gentle; soft",
+        "primary_1": "轻",
+        "primary_2": "輕"
+    },
+    {
+        "intermediate_1": "qing1song1",
+        "intermediate_2": "qīngsōng",
+        "native_1": "relaxed; gentle; easygoing",
+        "primary_1": "轻松",
+        "primary_2": "輕松"
+    },
+    {
+        "intermediate_1": "qing2kuang4",
+        "intermediate_2": "qíngkuàng",
+        "native_1": "circumstance; state of affairs; situation",
+        "primary_1": "情况",
+        "primary_2": "情況"
+    },
+    {
+        "intermediate_1": "qiong2",
+        "intermediate_2": "qióng",
+        "native_1": "poor; exhausted",
+        "primary_1": "穷",
+        "primary_2": "窮"
+    },
+    {
+        "intermediate_1": "qu1bie2",
+        "intermediate_2": "qūbié",
+        "native_1": "difference; distinguish",
+        "primary_1": "区别",
+        "primary_2": "區別"
+    },
+    {
+        "intermediate_1": "qu3",
+        "intermediate_2": "qǔ",
+        "native_1": "to take; get; choose",
+        "primary_1": "取",
+        "primary_2": "取"
+    },
+    {
+        "intermediate_1": "quan2bu4",
+        "intermediate_2": "quánbù",
+        "native_1": "whole; entire; complete",
+        "primary_1": "全部",
+        "primary_2": "全部"
+    },
+    {
+        "intermediate_1": "que1dian3",
+        "intermediate_2": "quēdiǎn",
+        "native_1": "weak point; defect; fault; shortcoming",
+        "primary_1": "缺点",
+        "primary_2": "缺點"
+    },
+    {
+        "intermediate_1": "que1shao3",
+        "intermediate_2": "quēshǎo",
+        "native_1": "to lack; be short of; be deficient in",
+        "primary_1": "缺少",
+        "primary_2": "缺少"
+    },
+    {
+        "intermediate_1": "que4",
+        "intermediate_2": "què",
+        "native_1": "but; yet; however",
+        "primary_1": "却",
+        "primary_2": "卻"
+    },
+    {
+        "intermediate_1": "que4shi2",
+        "intermediate_2": "quèshí",
+        "native_1": "indeed; in truth; reliable",
+        "primary_1": "确实",
+        "primary_2": "確實"
+    },
+    {
+        "intermediate_1": "ran2'er2",
+        "intermediate_2": "rán'ér",
+        "native_1": "however; yet; but",
+        "primary_1": "然而",
+        "primary_2": "然而"
+    },
+    {
+        "intermediate_1": "ren4ao",
+        "intermediate_2": "rènao",
+        "native_1": "bustling; lively; busy",
+        "primary_1": "热闹",
+        "primary_2": "熱鬧"
+    },
+    {
+        "intermediate_1": "ren4he2",
+        "intermediate_2": "rènhé",
+        "native_1": "any; whatever; whichever",
+        "primary_1": "任何",
+        "primary_2": "任何"
+    },
+    {
+        "intermediate_1": "ren4wu",
+        "intermediate_2": "rènwu",
+        "native_1": "a mission; an assignment; a task",
+        "primary_1": "任务",
+        "primary_2": "任務"
+    },
+    {
+        "intermediate_1": "reng1",
+        "intermediate_2": "rēng",
+        "native_1": "to throw; throw away",
+        "primary_1": "扔",
+        "primary_2": "扔"
+    },
+    {
+        "intermediate_1": "reng2ran2",
+        "intermediate_2": "réngrán",
+        "native_1": "still; yet",
+        "primary_1": "仍然",
+        "primary_2": "仍然"
+    },
+    {
+        "intermediate_1": "ri4ji4",
+        "intermediate_2": "rìjì",
+        "native_1": "diary",
+        "primary_1": "日记",
+        "primary_2": "日記"
+    },
+    {
+        "intermediate_1": "ru4kou3",
+        "intermediate_2": "rùkǒu",
+        "native_1": "entrance",
+        "primary_1": "入口",
+        "primary_2": "入口"
+    },
+    {
+        "intermediate_1": "san4 bu4",
+        "intermediate_2": "sàn bù",
+        "native_1": "to go for a walk",
+        "primary_1": "散步",
+        "primary_2": "散步"
+    },
+    {
+        "intermediate_1": "sen1lin2",
+        "intermediate_2": "sēnlín",
+        "native_1": "forest",
+        "primary_1": "森林",
+        "primary_2": "森林"
+    },
+    {
+        "intermediate_1": "sha1fa1",
+        "intermediate_2": "shāfā",
+        "native_1": "sofa",
+        "primary_1": "沙发",
+        "primary_2": "沙發"
+    },
+    {
+        "intermediate_1": "shang1xin1",
+        "intermediate_2": "shāngxīn",
+        "native_1": "sad; grieve; brokenhearted",
+        "primary_1": "伤心",
+        "primary_2": "傷心"
+    },
+    {
+        "intermediate_1": "shang1liang",
+        "intermediate_2": "shāngliang",
+        "native_1": "consult; talk over; discuss",
+        "primary_1": "商量",
+        "primary_2": "商量"
+    },
+    {
+        "intermediate_1": "shao1wei1",
+        "intermediate_2": "shāowēi",
+        "native_1": "a little bit; slightly",
+        "primary_1": "稍微",
+        "primary_2": "稍微"
+    },
+    {
+        "intermediate_1": "shao2zi",
+        "intermediate_2": "sháozi",
+        "native_1": "spoon; scoop; ladle",
+        "primary_1": "勺子",
+        "primary_2": "勺子"
+    },
+    {
+        "intermediate_1": "she4hui4",
+        "intermediate_2": "shèhuì",
+        "native_1": "society",
+        "primary_1": "社会",
+        "primary_2": "社會"
+    },
+    {
+        "intermediate_1": "shen1qing3",
+        "intermediate_2": "shēnqǐng",
+        "native_1": "apply for; application",
+        "primary_1": "申请",
+        "primary_2": "申請"
+    },
+    {
+        "intermediate_1": "shen1",
+        "intermediate_2": "shēn",
+        "native_1": "deep; profound; dark (of colors)",
+        "primary_1": "深",
+        "primary_2": "深"
+    },
+    {
+        "intermediate_1": "shen4zhi4",
+        "intermediate_2": "shènzhì",
+        "native_1": "even (to the point of); so much so that",
+        "primary_1": "甚至",
+        "primary_2": "甚至"
+    },
+    {
+        "intermediate_1": "sheng1huo2",
+        "intermediate_2": "shēnghuó",
+        "native_1": "life; livelihood; to live",
+        "primary_1": "生活",
+        "primary_2": "生活"
+    },
+    {
+        "intermediate_1": "sheng1ming4",
+        "intermediate_2": "shēngmìng",
+        "native_1": "life",
+        "primary_1": "生命",
+        "primary_2": "生命"
+    },
+    {
+        "intermediate_1": "sheng1yi",
+        "intermediate_2": "shēngyi",
+        "native_1": "business; trade",
+        "primary_1": "生意",
+        "primary_2": "生意"
+    },
+    {
+        "intermediate_1": "sheng3",
+        "intermediate_2": "shěng",
+        "native_1": "to save; economize; omit; province",
+        "primary_1": "省",
+        "primary_2": "省"
+    },
+    {
+        "intermediate_1": "sheng4",
+        "intermediate_2": "shèng",
+        "native_1": "have as remainder; be left over; surplus",
+        "primary_1": "剩",
+        "primary_2": "剩"
+    },
+    {
+        "intermediate_1": "shi1bai4",
+        "intermediate_2": "shībài",
+        "native_1": "be defeated; fail; lose",
+        "primary_1": "失败",
+        "primary_2": "失敗"
+    },
+    {
+        "intermediate_1": "shi1wang4",
+        "intermediate_2": "shīwàng",
+        "native_1": "disappointed; lose hope",
+        "primary_1": "失望",
+        "primary_2": "失望"
+    },
+    {
+        "intermediate_1": "shi1fu",
+        "intermediate_2": "shīfu",
+        "native_1": "master; qualified worker; teacher",
+        "primary_1": "师傅",
+        "primary_2": "師傅"
+    },
+    {
+        "intermediate_1": "shi2fen1",
+        "intermediate_2": "shífēn",
+        "native_1": "very; fully; 100%",
+        "primary_1": "十分",
+        "primary_2": "十分"
+    },
+    {
+        "intermediate_1": "shi2ji4",
+        "intermediate_2": "shíjì",
+        "native_1": "actual; reality; practice",
+        "primary_1": "实际",
+        "primary_2": "實際"
+    },
+    {
+        "intermediate_1": "shi2zai4",
+        "intermediate_2": "shízài",
+        "native_1": "honest; in reality; honestly; indeed; certainly",
+        "primary_1": "实在",
+        "primary_2": "實在"
+    },
+    {
+        "intermediate_1": "shi3",
+        "intermediate_2": "shǐ",
+        "native_1": "to use; to make; to cause; enable; envoy; messenger",
+        "primary_1": "使",
+        "primary_2": "使"
+    },
+    {
+        "intermediate_1": "shi3yong4",
+        "intermediate_2": "shǐyòng",
+        "native_1": "to use; employ; apply; administer; manipulate",
+        "primary_1": "使用",
+        "primary_2": "使用"
+    },
+    {
+        "intermediate_1": "shi4ji4",
+        "intermediate_2": "shìjì",
+        "native_1": "century",
+        "primary_1": "世纪",
+        "primary_2": "世紀"
+    },
+    {
+        "intermediate_1": "shi4fou3",
+        "intermediate_2": "shìfǒu",
+        "native_1": "whether (or not); if",
+        "primary_1": "是否",
+        "primary_2": "是否"
+    },
+    {
+        "intermediate_1": "shi4he2",
+        "intermediate_2": "shìhé",
+        "native_1": "to suit; to fit",
+        "primary_1": "适合",
+        "primary_2": "適合"
+    },
+    {
+        "intermediate_1": "shi4ying4",
+        "intermediate_2": "shìyìng",
+        "native_1": "to suit; to fit; adapt",
+        "primary_1": "适应",
+        "primary_2": "適應"
+    },
+    {
+        "intermediate_1": "shou1",
+        "intermediate_2": "shōu",
+        "native_1": "receive; accept; collect; to harvest",
+        "primary_1": "收",
+        "primary_2": "收"
+    },
+    {
+        "intermediate_1": "shou1ru4",
+        "intermediate_2": "shōurù",
+        "native_1": "take in; income; revenue",
+        "primary_1": "收入",
+        "primary_2": "收入"
+    },
+    {
+        "intermediate_1": "shou1shi",
+        "intermediate_2": "shōushi",
+        "native_1": "to tidy; put in order; to repair; to settle with; punish",
+        "primary_1": "收拾",
+        "primary_2": "收拾"
+    },
+    {
+        "intermediate_1": "shou3du1",
+        "intermediate_2": "shǒudū",
+        "native_1": "capital (city)",
+        "primary_1": "首都",
+        "primary_2": "首都"
+    },
+    {
+        "intermediate_1": "shou3xian1",
+        "intermediate_2": "shǒuxiān",
+        "native_1": "first (of all); in the first place; firstly",
+        "primary_1": "首先",
+        "primary_2": "首先"
+    },
+    {
+        "intermediate_1": "shou4 bu liao3",
+        "intermediate_2": "shòu bu liǎo",
+        "native_1": "cannot endure; unbearable; can't stand",
+        "primary_1": "受不了",
+        "primary_2": "受不了"
+    },
+    {
+        "intermediate_1": "shou4dao4",
+        "intermediate_2": "shòudào",
+        "native_1": "receive (influence, restriction, etc.); be subjected to",
+        "primary_1": "受到",
+        "primary_2": "受到"
+    },
+    {
+        "intermediate_1": "shou4huo4yuan2",
+        "intermediate_2": "shòuhuòyuán",
+        "native_1": "salesclerk; shop assistant",
+        "primary_1": "售货员",
+        "primary_2": "售貨員"
+    },
+    {
+        "intermediate_1": "shu1",
+        "intermediate_2": "shū",
+        "native_1": "to transport; to lose (a game, etc.)",
+        "primary_1": "输",
+        "primary_2": "輸"
+    },
+    {
+        "intermediate_1": "shu2xi1",
+        "intermediate_2": "shúxī",
+        "native_1": "familiar with; know well",
+        "primary_1": "熟悉",
+        "primary_2": "熟悉"
+    },
+    {
+        "intermediate_1": "shu4liang4",
+        "intermediate_2": "shùliàng",
+        "native_1": "amount; quantity; number",
+        "primary_1": "数量",
+        "primary_2": "數量"
+    },
+    {
+        "intermediate_1": "shu4zi4",
+        "intermediate_2": "shùzì",
+        "native_1": "number; numeral; figure; digit",
+        "primary_1": "数字",
+        "primary_2": "數字"
+    },
+    {
+        "intermediate_1": "shuai4",
+        "intermediate_2": "shuài",
+        "native_1": "handsome; graceful; commander-in-chief",
+        "primary_1": "帅",
+        "primary_2": "帥"
+    },
+    {
+        "intermediate_1": "shun4bian4",
+        "intermediate_2": "shùnbiàn",
+        "native_1": "conveniently; in passing; on the way",
+        "primary_1": "顺便",
+        "primary_2": "順便"
+    },
+    {
+        "intermediate_1": "shun4li4",
+        "intermediate_2": "shùnlì",
+        "native_1": "go smoothly; without a hitch; successful",
+        "primary_1": "顺利",
+        "primary_2": "順利"
+    },
+    {
+        "intermediate_1": "shun4xu4",
+        "intermediate_2": "shùnxù",
+        "native_1": "sequence; order",
+        "primary_1": "顺序",
+        "primary_2": "順序"
+    },
+    {
+        "intermediate_1": "shuo1ming2",
+        "intermediate_2": "shuōmíng",
+        "native_1": "explain; explanation; illustrate; to show",
+        "primary_1": "说明",
+        "primary_2": "說明"
+    },
+    {
+        "intermediate_1": "shuo4shi4",
+        "intermediate_2": "shuòshì",
+        "native_1": "Master's degree (M.A.)",
+        "primary_1": "硕士",
+        "primary_2": "碩士"
+    },
+    {
+        "intermediate_1": "si3",
+        "intermediate_2": "sǐ",
+        "native_1": "to die; dead; fixed; impassible; extremely",
+        "primary_1": "死",
+        "primary_2": "死"
+    },
+    {
+        "intermediate_1": "su4du4",
+        "intermediate_2": "sùdù",
+        "native_1": "speed; rate; velocity",
+        "primary_1": "速度",
+        "primary_2": "速度"
+    },
+    {
+        "intermediate_1": "su4liao4dai4",
+        "intermediate_2": "sùliàodài",
+        "native_1": "plastic bag",
+        "primary_1": "塑料袋",
+        "primary_2": "塑料袋"
+    },
+    {
+        "intermediate_1": "suan1",
+        "intermediate_2": "suān",
+        "native_1": "sour; sore; ache",
+        "primary_1": "酸",
+        "primary_2": "酸"
+    },
+    {
+        "intermediate_1": "sui2bian4",
+        "intermediate_2": "suíbiàn",
+        "native_1": "as one pleases; informal; random; casual",
+        "primary_1": "随便",
+        "primary_2": "隨便"
+    },
+    {
+        "intermediate_1": "sui2zhe",
+        "intermediate_2": "suízhe",
+        "native_1": "along with; in the wake of",
+        "primary_1": "随着",
+        "primary_2": "隨著"
+    },
+    {
+        "intermediate_1": "sun1zi",
+        "intermediate_2": "sūnzi",
+        "native_1": "grandson; son's son",
+        "primary_1": "孙子",
+        "primary_2": "孫子"
+    },
+    {
+        "intermediate_1": "suo3you3",
+        "intermediate_2": "suǒyǒu",
+        "native_1": "all; to have; to possess",
+        "primary_1": "所有",
+        "primary_2": "所有"
+    },
+    {
+        "intermediate_1": "tai2",
+        "intermediate_2": "tái",
+        "native_1": "platform; Taiwan (abbr.); desk; stage; typhoon; (mw for machines); (classical) you (in letters)",
+        "primary_1": "台",
+        "primary_2": "台"
+    },
+    {
+        "intermediate_1": "tai2",
+        "intermediate_2": "tái",
+        "native_1": "to lift; to raise (with both palms up); carry (together)",
+        "primary_1": "抬",
+        "primary_2": "擡"
+    },
+    {
+        "intermediate_1": "tai4du",
+        "intermediate_2": "tàidu",
+        "native_1": "manner; bearing; attitude",
+        "primary_1": "态度",
+        "primary_2": "態度"
+    },
+    {
+        "intermediate_1": "tan2",
+        "intermediate_2": "tán",
+        "native_1": "to talk; to chat; discuss",
+        "primary_1": "谈",
+        "primary_2": "談"
+    },
+    {
+        "intermediate_1": "tan2 gang1qin2",
+        "intermediate_2": "tán gāngqín",
+        "native_1": "play the piano",
+        "primary_1": "弹钢琴",
+        "primary_2": "彈鋼琴"
+    },
+    {
+        "intermediate_1": "tang1",
+        "intermediate_2": "tāng",
+        "native_1": "soup; broth",
+        "primary_1": "汤",
+        "primary_2": "湯"
+    },
+    {
+        "intermediate_1": "tang2",
+        "intermediate_2": "táng",
+        "native_1": "sugar; candy; sweets",
+        "primary_1": "糖",
+        "primary_2": "糖"
+    },
+    {
+        "intermediate_1": "tang3",
+        "intermediate_2": "tǎng",
+        "native_1": "recline; lie down (on back or side)",
+        "primary_1": "躺",
+        "primary_2": "躺"
+    },
+    {
+        "intermediate_1": "tang4, tang1",
+        "intermediate_2": "tàng, tāng",
+        "native_1": "(mw for trips times) | to wade",
+        "primary_1": "趟",
+        "primary_2": "趟"
+    },
+    {
+        "intermediate_1": "tao3lun4",
+        "intermediate_2": "tǎolùn",
+        "native_1": "to discuss; discussion; to talk over",
+        "primary_1": "讨论",
+        "primary_2": "討論"
+    },
+    {
+        "intermediate_1": "tao3yan4",
+        "intermediate_2": "tǎoyàn",
+        "native_1": "to hate; loathe; disgusting; troublesome",
+        "primary_1": "讨厌",
+        "primary_2": "討厭"
+    },
+    {
+        "intermediate_1": "te4dian3",
+        "intermediate_2": "tèdiǎn",
+        "native_1": "a characteristic; trait; feature",
+        "primary_1": "特点",
+        "primary_2": "特點"
+    },
+    {
+        "intermediate_1": "ti2",
+        "intermediate_2": "tí",
+        "native_1": "to carry; to lift; to raise (an issue)",
+        "primary_1": "提",
+        "primary_2": "提"
+    },
+    {
+        "intermediate_1": "ti2gong1",
+        "intermediate_2": "tígōng",
+        "native_1": "to supply; provide; furnish",
+        "primary_1": "提供",
+        "primary_2": "提供"
+    },
+    {
+        "intermediate_1": "ti2qian2",
+        "intermediate_2": "tíqián",
+        "native_1": "shift to an earlier date; bring forward; to advance",
+        "primary_1": "提前",
+        "primary_2": "提前"
+    },
+    {
+        "intermediate_1": "ti2xing3",
+        "intermediate_2": "tíxǐng",
+        "native_1": "remind; call attention to; warn of",
+        "primary_1": "提醒",
+        "primary_2": "提醒"
+    },
+    {
+        "intermediate_1": "tian2kong4",
+        "intermediate_2": "tiánkòng",
+        "native_1": "fill in the blanks; fill a vacancy",
+        "primary_1": "填空",
+        "primary_2": "填空"
+    },
+    {
+        "intermediate_1": "tiao2jian4",
+        "intermediate_2": "tiáojiàn",
+        "native_1": "condition; circumstances; prerequisite",
+        "primary_1": "条件",
+        "primary_2": "條件"
+    },
+    {
+        "intermediate_1": "ting2",
+        "intermediate_2": "tíng",
+        "native_1": "to stop; to halt; to park (a car)",
+        "primary_1": "停",
+        "primary_2": "停"
+    },
+    {
+        "intermediate_1": "ting3",
+        "intermediate_2": "tǐng",
+        "native_1": "straighten up; stick out; rather (good); very",
+        "primary_1": "挺",
+        "primary_2": "挺"
+    },
+    {
+        "intermediate_1": "tong1guo4",
+        "intermediate_2": "tōngguò",
+        "native_1": "by means of; through (a method); pass through; via",
+        "primary_1": "通过",
+        "primary_2": "通過"
+    },
+    {
+        "intermediate_1": "tong1zhi1",
+        "intermediate_2": "tōngzhī",
+        "native_1": "notify; to inform; notice",
+        "primary_1": "通知",
+        "primary_2": "通知"
+    },
+    {
+        "intermediate_1": "tong2qing2",
+        "intermediate_2": "tóngqíng",
+        "native_1": "compassion; sympathy",
+        "primary_1": "同情",
+        "primary_2": "同情"
+    },
+    {
+        "intermediate_1": "tong2shi2",
+        "intermediate_2": "tóngshí",
+        "native_1": "at the same time; simultaneously",
+        "primary_1": "同时",
+        "primary_2": "同時"
+    },
+    {
+        "intermediate_1": "tui1",
+        "intermediate_2": "tuī",
+        "native_1": "to push; to scrape; to decline; postpone; elect",
+        "primary_1": "推",
+        "primary_2": "推"
+    },
+    {
+        "intermediate_1": "tui1chi2",
+        "intermediate_2": "tuīchí",
+        "native_1": "postpone; defer",
+        "primary_1": "推迟",
+        "primary_2": "推遲"
+    },
+    {
+        "intermediate_1": "tuo1",
+        "intermediate_2": "tuō",
+        "native_1": "to shed; take off; to escape",
+        "primary_1": "脱",
+        "primary_2": "脫"
+    },
+    {
+        "intermediate_1": "wa4zi",
+        "intermediate_2": "wàzi",
+        "native_1": "socks; stockings",
+        "primary_1": "袜子",
+        "primary_2": "襪子"
+    },
+    {
+        "intermediate_1": "wan2quan2",
+        "intermediate_2": "wánquán",
+        "native_1": "complete; whole; totally",
+        "primary_1": "完全",
+        "primary_2": "完全"
+    },
+    {
+        "intermediate_1": "wang3qiu2",
+        "intermediate_2": "wǎngqiú",
+        "native_1": "tennis; tennis ball",
+        "primary_1": "网球",
+        "primary_2": "網球"
+    },
+    {
+        "intermediate_1": "wang3zhan4",
+        "intermediate_2": "wǎngzhàn",
+        "native_1": "website",
+        "primary_1": "网站",
+        "primary_2": "網站"
+    },
+    {
+        "intermediate_1": "wang3wang3",
+        "intermediate_2": "wǎngwǎng",
+        "native_1": "often; frequently; more often than not",
+        "primary_1": "往往",
+        "primary_2": "往往"
+    },
+    {
+        "intermediate_1": "wei1xian3",
+        "intermediate_2": "wēixiǎn",
+        "native_1": "danger; dangerous; perilous",
+        "primary_1": "危险",
+        "primary_2": "危險"
+    },
+    {
+        "intermediate_1": "wei4sheng1jian1",
+        "intermediate_2": "wèishēngjiān",
+        "native_1": "restroom; bathroom; water closet (WC)",
+        "primary_1": "卫生间",
+        "primary_2": "衛生間"
+    },
+    {
+        "intermediate_1": "wei4dao",
+        "intermediate_2": "wèidao",
+        "native_1": "flavor; taste",
+        "primary_1": "味道",
+        "primary_2": "味道"
+    },
+    {
+        "intermediate_1": "wen1du4",
+        "intermediate_2": "wēndù",
+        "native_1": "temperature",
+        "primary_1": "温度",
+        "primary_2": "溫度"
+    },
+    {
+        "intermediate_1": "wen2zhang1",
+        "intermediate_2": "wénzhāng",
+        "native_1": "article; essay",
+        "primary_1": "文章",
+        "primary_2": "文章"
+    },
+    {
+        "intermediate_1": "wu1ran3",
+        "intermediate_2": "wūrǎn",
+        "native_1": "pollution; contamination",
+        "primary_1": "污染",
+        "primary_2": "汙染"
+    },
+    {
+        "intermediate_1": "wu2",
+        "intermediate_2": "wú",
+        "native_1": "have not; without; not (Kangxi radical 71)",
+        "primary_1": "无",
+        "primary_2": "無"
+    },
+    {
+        "intermediate_1": "wu2liao2",
+        "intermediate_2": "wúliáo",
+        "native_1": "nonsense; bored; silly; stupid",
+        "primary_1": "无聊",
+        "primary_2": "無聊"
+    },
+    {
+        "intermediate_1": "wu2lun4",
+        "intermediate_2": "wúlùn",
+        "native_1": "no matter what; regardless of whether...",
+        "primary_1": "无论",
+        "primary_2": "無論"
+    },
+    {
+        "intermediate_1": "wu4hui4",
+        "intermediate_2": "wùhuì",
+        "native_1": "to misunderstand; to mistake",
+        "primary_1": "误会",
+        "primary_2": "誤會"
+    },
+    {
+        "intermediate_1": "xi1hong2shi4",
+        "intermediate_2": "xīhóngshì",
+        "native_1": "tomato",
+        "primary_1": "西红柿",
+        "primary_2": "西紅柿"
+    },
+    {
+        "intermediate_1": "xi1yin3",
+        "intermediate_2": "xīyǐn",
+        "native_1": "attract (interest, investment, etc.)",
+        "primary_1": "吸引",
+        "primary_2": "吸引"
+    },
+    {
+        "intermediate_1": "xian2",
+        "intermediate_2": "xián",
+        "native_1": "salty; salted; all",
+        "primary_1": "咸",
+        "primary_2": "鹹"
+    },
+    {
+        "intermediate_1": "xian4jin1",
+        "intermediate_2": "xiànjīn",
+        "native_1": "cash",
+        "primary_1": "现金",
+        "primary_2": "現金"
+    },
+    {
+        "intermediate_1": "xian4mu4",
+        "intermediate_2": "xiànmù",
+        "native_1": "to envy; admire",
+        "primary_1": "羡慕",
+        "primary_2": "羨慕"
+    },
+    {
+        "intermediate_1": "xiang1fan3",
+        "intermediate_2": "xiāngfǎn",
+        "native_1": "opposite; contrary",
+        "primary_1": "相反",
+        "primary_2": "相反"
+    },
+    {
+        "intermediate_1": "xiang1tong2",
+        "intermediate_2": "xiāngtóng",
+        "native_1": "identical; same; alike",
+        "primary_1": "相同",
+        "primary_2": "相同"
+    },
+    {
+        "intermediate_1": "xiang1",
+        "intermediate_2": "xiāng",
+        "native_1": "fragrant; savory (Kangxi radical 186)",
+        "primary_1": "香",
+        "primary_2": "香"
+    },
+    {
+        "intermediate_1": "xiang2xi4",
+        "intermediate_2": "xiángxì",
+        "native_1": "detailed; in detail; minute",
+        "primary_1": "详细",
+        "primary_2": "詳細"
+    },
+    {
+        "intermediate_1": "xiang3",
+        "intermediate_2": "xiǎng",
+        "native_1": "make a sound; to ring; echo",
+        "primary_1": "响",
+        "primary_2": "響"
+    },
+    {
+        "intermediate_1": "xiang4pi2",
+        "intermediate_2": "xiàngpí",
+        "native_1": "rubber; an eraser",
+        "primary_1": "橡皮",
+        "primary_2": "橡皮"
+    },
+    {
+        "intermediate_1": "xiao1xi",
+        "intermediate_2": "xiāoxi",
+        "native_1": "news; information",
+        "primary_1": "消息",
+        "primary_2": "消息"
+    },
+    {
+        "intermediate_1": "xiao3chi1",
+        "intermediate_2": "xiǎochī",
+        "native_1": "snack; refreshments",
+        "primary_1": "小吃",
+        "primary_2": "小吃"
+    },
+    {
+        "intermediate_1": "xiao3huo3zi",
+        "intermediate_2": "xiǎohuǒzi",
+        "native_1": "young man; lad; youngster",
+        "primary_1": "小伙子",
+        "primary_2": "小夥子"
+    },
+    {
+        "intermediate_1": "xiao3shuo1",
+        "intermediate_2": "xiǎoshuō",
+        "native_1": "novel; fiction",
+        "primary_1": "小说",
+        "primary_2": "小說"
+    },
+    {
+        "intermediate_1": "xiao4hua",
+        "intermediate_2": "xiàohua",
+        "native_1": "joke; laugh at",
+        "primary_1": "笑话",
+        "primary_2": "笑話"
+    },
+    {
+        "intermediate_1": "xiao4guo3",
+        "intermediate_2": "xiàoguǒ",
+        "native_1": "effect; result",
+        "primary_1": "效果",
+        "primary_2": "效果"
+    },
+    {
+        "intermediate_1": "xin1qing2",
+        "intermediate_2": "xīnqíng",
+        "native_1": "mood; state of mind",
+        "primary_1": "心情",
+        "primary_2": "心情"
+    },
+    {
+        "intermediate_1": "xin1ku3",
+        "intermediate_2": "xīnkǔ",
+        "native_1": "hard; exhausting; toilsome; laborious",
+        "primary_1": "辛苦",
+        "primary_2": "辛苦"
+    },
+    {
+        "intermediate_1": "xin4feng1",
+        "intermediate_2": "xìnfēng",
+        "native_1": "envelope",
+        "primary_1": "信封",
+        "primary_2": "信封"
+    },
+    {
+        "intermediate_1": "xin4xi1",
+        "intermediate_2": "xìnxī",
+        "native_1": "information; news; message",
+        "primary_1": "信息",
+        "primary_2": "信息"
+    },
+    {
+        "intermediate_1": "xin4xin1",
+        "intermediate_2": "xìnxīn",
+        "native_1": "confidence; faith (in sb. or sth.)",
+        "primary_1": "信心",
+        "primary_2": "信心"
+    },
+    {
+        "intermediate_1": "xing1fen4",
+        "intermediate_2": "xīngfèn",
+        "native_1": "excitement； be excited",
+        "primary_1": "兴奋",
+        "primary_2": "興奮"
+    },
+    {
+        "intermediate_1": "xing2",
+        "intermediate_2": "xíng",
+        "native_1": "walk; be current; do; will do; okay",
+        "primary_1": "行",
+        "primary_2": "行"
+    },
+    {
+        "intermediate_1": "xing3",
+        "intermediate_2": "xǐng",
+        "native_1": "wake up",
+        "primary_1": "醒",
+        "primary_2": "醒"
+    },
+    {
+        "intermediate_1": "xing4fu2",
+        "intermediate_2": "xìngfú",
+        "native_1": "happy; blessed; fortunate",
+        "primary_1": "幸福",
+        "primary_2": "幸福"
+    },
+    {
+        "intermediate_1": "xing4bie2",
+        "intermediate_2": "xìngbié",
+        "native_1": "gender; sex; sexual distinction",
+        "primary_1": "性别",
+        "primary_2": "性別"
+    },
+    {
+        "intermediate_1": "xing4ge2",
+        "intermediate_2": "xìnggé",
+        "native_1": "nature; personality; temperament",
+        "primary_1": "性格",
+        "primary_2": "性格"
+    },
+    {
+        "intermediate_1": "xiu1li3",
+        "intermediate_2": "xiūlǐ",
+        "native_1": "to repair; perform maintenance; to overhaul",
+        "primary_1": "修理",
+        "primary_2": "修理"
+    },
+    {
+        "intermediate_1": "xu3duo1",
+        "intermediate_2": "xǔduō",
+        "native_1": "many; a lot; much",
+        "primary_1": "许多",
+        "primary_2": "許多"
+    },
+    {
+        "intermediate_1": "xue2qi1",
+        "intermediate_2": "xuéqī",
+        "native_1": "semester; school term",
+        "primary_1": "学期",
+        "primary_2": "學期"
+    },
+    {
+        "intermediate_1": "ya1li4",
+        "intermediate_2": "yālì",
+        "native_1": "pressure; stress",
+        "primary_1": "压力",
+        "primary_2": "壓力"
+    },
+    {
+        "intermediate_1": "ya",
+        "intermediate_2": "ya",
+        "native_1": "ah; oh; (used for 啊 after words ending with a, e, i, o, or ü)",
+        "primary_1": "呀",
+        "primary_2": "呀"
+    },
+    {
+        "intermediate_1": "ya2gao1",
+        "intermediate_2": "yágāo",
+        "native_1": "toothpaste",
+        "primary_1": "牙膏",
+        "primary_2": "牙膏"
+    },
+    {
+        "intermediate_1": "Ya4zhou1",
+        "intermediate_2": "Yàzhōu",
+        "native_1": "Asia",
+        "primary_1": "亚洲",
+        "primary_2": "亞洲"
+    },
+    {
+        "intermediate_1": "yang2e2",
+        "intermediate_2": "yángé",
+        "native_1": "strict; stringent; tight",
+        "primary_1": "严格",
+        "primary_2": "嚴格"
+    },
+    {
+        "intermediate_1": "yan2zhong4",
+        "intermediate_2": "yánzhòng",
+        "native_1": "grave; serious; critical",
+        "primary_1": "严重",
+        "primary_2": "嚴重"
+    },
+    {
+        "intermediate_1": "yan2jiu1",
+        "intermediate_2": "yánjiū",
+        "native_1": "to study; to research",
+        "primary_1": "研究",
+        "primary_2": "研究"
+    },
+    {
+        "intermediate_1": "yan2",
+        "intermediate_2": "yán",
+        "native_1": "salt",
+        "primary_1": "盐",
+        "primary_2": "鹽"
+    },
+    {
+        "intermediate_1": "yan3jing4",
+        "intermediate_2": "yǎnjìng",
+        "native_1": "glasses; spectacles",
+        "primary_1": "眼镜",
+        "primary_2": "眼鏡"
+    },
+    {
+        "intermediate_1": "yan3chu1",
+        "intermediate_2": "yǎnchū",
+        "native_1": "to act (in a play); to perform; to put on a show; performance",
+        "primary_1": "演出",
+        "primary_2": "演出"
+    },
+    {
+        "intermediate_1": "yan3yuan2",
+        "intermediate_2": "yǎnyuán",
+        "native_1": "actor or actress; performer",
+        "primary_1": "演员",
+        "primary_2": "演員"
+    },
+    {
+        "intermediate_1": "yang2guang1",
+        "intermediate_2": "yángguāng",
+        "native_1": "sunshine; sunlight",
+        "primary_1": "阳光",
+        "primary_2": "陽光"
+    },
+    {
+        "intermediate_1": "yang3cheng2",
+        "intermediate_2": "yǎngchéng",
+        "native_1": "cultivate; acquire; to form",
+        "primary_1": "养成",
+        "primary_2": "養成"
+    },
+    {
+        "intermediate_1": "yang4zi",
+        "intermediate_2": "yàngzi",
+        "native_1": "manner; air; appearance; looks",
+        "primary_1": "样子",
+        "primary_2": "樣子"
+    },
+    {
+        "intermediate_1": "yao1qing3",
+        "intermediate_2": "yāoqǐng",
+        "native_1": "to invite",
+        "primary_1": "邀请",
+        "primary_2": "邀請"
+    },
+    {
+        "intermediate_1": "yao4shi",
+        "intermediate_2": "yàoshi",
+        "native_1": "if; suppose; in case",
+        "primary_1": "要是",
+        "primary_2": "要是"
+    },
+    {
+        "intermediate_1": "yao4shi",
+        "intermediate_2": "yàoshi",
+        "native_1": "key",
+        "primary_1": "钥匙",
+        "primary_2": "鑰匙"
+    },
+    {
+        "intermediate_1": "ye3xu3",
+        "intermediate_2": "yěxǔ",
+        "native_1": "perhaps; probably; maybe",
+        "primary_1": "也许",
+        "primary_2": "也許"
+    },
+    {
+        "intermediate_1": "ye4zi",
+        "intermediate_2": "yèzi",
+        "native_1": "leaves",
+        "primary_1": "叶子",
+        "primary_2": "葉子"
+    },
+    {
+        "intermediate_1": "ye4",
+        "intermediate_2": "yè",
+        "native_1": "page; leaf (Kangxi radical 181)",
+        "primary_1": "页",
+        "primary_2": "頁"
+    },
+    {
+        "intermediate_1": "yi2qie4",
+        "intermediate_2": "yíqiè",
+        "native_1": "all; every; everything",
+        "primary_1": "一切",
+        "primary_2": "一切"
+    },
+    {
+        "intermediate_1": "yi3",
+        "intermediate_2": "yǐ",
+        "native_1": "to use; according to; so as to; for; by",
+        "primary_1": "以",
+        "primary_2": "以"
+    },
+    {
+        "intermediate_1": "yi3wei2",
+        "intermediate_2": "yǐwéi",
+        "native_1": "think (mistakenly); consider (that); believe",
+        "primary_1": "以为",
+        "primary_2": "以爲"
+    },
+    {
+        "intermediate_1": "yi4shu4",
+        "intermediate_2": "yìshù",
+        "native_1": "art",
+        "primary_1": "艺术",
+        "primary_2": "藝術"
+    },
+    {
+        "intermediate_1": "yi4jian4",
+        "intermediate_2": "yìjiàn",
+        "native_1": "opinion; view; suggestion; complaint",
+        "primary_1": "意见",
+        "primary_2": "意見"
+    },
+    {
+        "intermediate_1": "yin1ci3",
+        "intermediate_2": "yīncǐ",
+        "native_1": "therefore; thus; that is why; because of this",
+        "primary_1": "因此",
+        "primary_2": "因此"
+    },
+    {
+        "intermediate_1": "yin3qi3",
+        "intermediate_2": "yǐnqǐ",
+        "native_1": "give rise to; lead to; to cause; arouse",
+        "primary_1": "引起",
+        "primary_2": "引起"
+    },
+    {
+        "intermediate_1": "yin4xiang4",
+        "intermediate_2": "yìnxiàng",
+        "native_1": "impression",
+        "primary_1": "印象",
+        "primary_2": "印象"
+    },
+    {
+        "intermediate_1": "ying2",
+        "intermediate_2": "yíng",
+        "native_1": "to win; to beat; to profit",
+        "primary_1": "赢",
+        "primary_2": "贏"
+    },
+    {
+        "intermediate_1": "ying4pin4",
+        "intermediate_2": "yìngpìn",
+        "native_1": "accept a job offer; to apply for a job",
+        "primary_1": "应聘",
+        "primary_2": "應聘"
+    },
+    {
+        "intermediate_1": "yong3yuan3",
+        "intermediate_2": "yǒngyuǎn",
+        "native_1": "forever; eternal; always",
+        "primary_1": "永远",
+        "primary_2": "永遠"
+    },
+    {
+        "intermediate_1": "yong3gan3",
+        "intermediate_2": "yǒnggǎn",
+        "native_1": "brave; courageous",
+        "primary_1": "勇敢",
+        "primary_2": "勇敢"
+    },
+    {
+        "intermediate_1": "you1dian3",
+        "intermediate_2": "yōudiǎn",
+        "native_1": "merit; good point; a strength; a benefit",
+        "primary_1": "优点",
+        "primary_2": "優點"
+    },
+    {
+        "intermediate_1": "you1xiu4",
+        "intermediate_2": "yōuxiù",
+        "native_1": "outstanding; excellent",
+        "primary_1": "优秀",
+        "primary_2": "優秀"
+    },
+    {
+        "intermediate_1": "you1mo4",
+        "intermediate_2": "yōumò",
+        "native_1": "humorous",
+        "primary_1": "幽默",
+        "primary_2": "幽默"
+    },
+    {
+        "intermediate_1": "you2qi2",
+        "intermediate_2": "yóuqí",
+        "native_1": "especially; particularly",
+        "primary_1": "尤其",
+        "primary_2": "尤其"
+    },
+    {
+        "intermediate_1": "you2",
+        "intermediate_2": "yóu",
+        "native_1": "follow; from; by; through",
+        "primary_1": "由",
+        "primary_2": "由"
+    },
+    {
+        "intermediate_1": "you2yu2",
+        "intermediate_2": "yóuyú",
+        "native_1": "due to; owing to; as a result of; thanks to",
+        "primary_1": "由于",
+        "primary_2": "由于"
+    },
+    {
+        "intermediate_1": "you2ju2",
+        "intermediate_2": "yóujú",
+        "native_1": "post office",
+        "primary_1": "邮局",
+        "primary_2": "郵局"
+    },
+    {
+        "intermediate_1": "you3hao3",
+        "intermediate_2": "yǒuhǎo",
+        "native_1": "friendly (relations); close friends",
+        "primary_1": "友好",
+        "primary_2": "友好"
+    },
+    {
+        "intermediate_1": "you3yi4",
+        "intermediate_2": "yǒuyì",
+        "native_1": "friendship; companionship",
+        "primary_1": "友谊",
+        "primary_2": "友誼"
+    },
+    {
+        "intermediate_1": "you3qu4",
+        "intermediate_2": "yǒuqù",
+        "native_1": "interesting; fascinating; amusing",
+        "primary_1": "有趣",
+        "primary_2": "有趣"
+    },
+    {
+        "intermediate_1": "yu2shi4",
+        "intermediate_2": "yúshì",
+        "native_1": "as a result; thus; therefore",
+        "primary_1": "于是",
+        "primary_2": "于是"
+    },
+    {
+        "intermediate_1": "yu2kuai4",
+        "intermediate_2": "yúkuài",
+        "native_1": "happy; cheerful; delightful",
+        "primary_1": "愉快",
+        "primary_2": "愉快"
+    },
+    {
+        "intermediate_1": "yu3",
+        "intermediate_2": "yǔ",
+        "native_1": "(formal) and; to give; together with; participate; final particle expressing doubt or surprise",
+        "primary_1": "与",
+        "primary_2": "與"
+    },
+    {
+        "intermediate_1": "yu3mao2qiu2",
+        "intermediate_2": "yǔmáoqiú",
+        "native_1": "badminton",
+        "primary_1": "羽毛球",
+        "primary_2": "羽毛球"
+    },
+    {
+        "intermediate_1": "yu3fa3",
+        "intermediate_2": "yǔfǎ",
+        "native_1": "grammar",
+        "primary_1": "语法",
+        "primary_2": "語法"
+    },
+    {
+        "intermediate_1": "yu3yan2",
+        "intermediate_2": "yǔyán",
+        "native_1": "language",
+        "primary_1": "语言",
+        "primary_2": "語言"
+    },
+    {
+        "intermediate_1": "yu4xi2",
+        "intermediate_2": "yùxí",
+        "native_1": "(of students) prepare a lesson before class; preview",
+        "primary_1": "预习",
+        "primary_2": "預習"
+    },
+    {
+        "intermediate_1": "yuan2lai2",
+        "intermediate_2": "yuánlái",
+        "native_1": "original; former; as it turns out",
+        "primary_1": "原来",
+        "primary_2": "原來"
+    },
+    {
+        "intermediate_1": "yuan2liang4",
+        "intermediate_2": "yuánliàng",
+        "native_1": "to excuse; forgive; to pardon",
+        "primary_1": "原谅",
+        "primary_2": "原諒"
+    },
+    {
+        "intermediate_1": "yuan2yin1",
+        "intermediate_2": "yuányīn",
+        "native_1": "cause; reason",
+        "primary_1": "原因",
+        "primary_2": "原因"
+    },
+    {
+        "intermediate_1": "yue1hui4",
+        "intermediate_2": "yuēhuì",
+        "native_1": "appointment; engagement; date",
+        "primary_1": "约会",
+        "primary_2": "約會"
+    },
+    {
+        "intermediate_1": "yue4du2",
+        "intermediate_2": "yuèdú",
+        "native_1": "read; reading",
+        "primary_1": "阅读",
+        "primary_2": "閱讀"
+    },
+    {
+        "intermediate_1": "yun2",
+        "intermediate_2": "yún",
+        "native_1": "cloud; Yunnan province | say; speak",
+        "primary_1": "云",
+        "primary_2": "雲"
+    },
+    {
+        "intermediate_1": "yun3xu3",
+        "intermediate_2": "yǔnxǔ",
+        "native_1": "to permit; allow",
+        "primary_1": "允许",
+        "primary_2": "允許"
+    },
+    {
+        "intermediate_1": "za2zhi4",
+        "intermediate_2": "zázhì",
+        "native_1": "magazine",
+        "primary_1": "杂志",
+        "primary_2": "雜志"
+    },
+    {
+        "intermediate_1": "zan2men",
+        "intermediate_2": "zánmen",
+        "native_1": "we (including the listener); us; our",
+        "primary_1": "咱们",
+        "primary_2": "咱們"
+    },
+    {
+        "intermediate_1": "zan4shi2",
+        "intermediate_2": "zànshí",
+        "native_1": "temporary; transient; for the moment",
+        "primary_1": "暂时",
+        "primary_2": "暫時"
+    },
+    {
+        "intermediate_1": "zang1",
+        "intermediate_2": "zāng",
+        "native_1": "filthy; dirty",
+        "primary_1": "脏",
+        "primary_2": "髒"
+    },
+    {
+        "intermediate_1": "zer2en4",
+        "intermediate_2": "zérèn",
+        "native_1": "responsibility; blame; duty",
+        "primary_1": "责任",
+        "primary_2": "責任"
+    },
+    {
+        "intermediate_1": "zeng1jia1",
+        "intermediate_2": "zēngjiā",
+        "native_1": "to increase; to raise; add",
+        "primary_1": "增加",
+        "primary_2": "增加"
+    },
+    {
+        "intermediate_1": "zhan4xian4",
+        "intermediate_2": "zhànxiàn",
+        "native_1": "the (phone) line is busy",
+        "primary_1": "占线",
+        "primary_2": "占線"
+    },
+    {
+        "intermediate_1": "zhao1pin4",
+        "intermediate_2": "zhāopìn",
+        "native_1": "recruitment; take job applications for a job",
+        "primary_1": "招聘",
+        "primary_2": "招聘"
+    },
+    {
+        "intermediate_1": "zhao4",
+        "intermediate_2": "zhào",
+        "native_1": "to shine; illuminate; according to",
+        "primary_1": "照",
+        "primary_2": "照"
+    },
+    {
+        "intermediate_1": "zhen1zheng4",
+        "intermediate_2": "zhēnzhèng",
+        "native_1": "genuine; real; true",
+        "primary_1": "真正",
+        "primary_2": "真正"
+    },
+    {
+        "intermediate_1": "zheng3li3",
+        "intermediate_2": "zhěnglǐ",
+        "native_1": "put in order; arrange; straighten up; to tidy; to pack (luggage)",
+        "primary_1": "整理",
+        "primary_2": "整理"
+    },
+    {
+        "intermediate_1": "zheng4chang2",
+        "intermediate_2": "zhèngcháng",
+        "native_1": "normal; regular; ordinary",
+        "primary_1": "正常",
+        "primary_2": "正常"
+    },
+    {
+        "intermediate_1": "zheng4hao3",
+        "intermediate_2": "zhènghǎo",
+        "native_1": "just (in time); just right; just enough; happen to; by chance",
+        "primary_1": "正好",
+        "primary_2": "正好"
+    },
+    {
+        "intermediate_1": "zheng4que4",
+        "intermediate_2": "zhèngquè",
+        "native_1": "correct; proper",
+        "primary_1": "正确",
+        "primary_2": "正確"
+    },
+    {
+        "intermediate_1": "zheng4shi4",
+        "intermediate_2": "zhèngshì",
+        "native_1": "formal; official",
+        "primary_1": "正式",
+        "primary_2": "正式"
+    },
+    {
+        "intermediate_1": "zheng4ming2",
+        "intermediate_2": "zhèngmíng",
+        "native_1": "proof; testify; confirm; certificate",
+        "primary_1": "证明",
+        "primary_2": "證明"
+    },
+    {
+        "intermediate_1": "zhi1",
+        "intermediate_2": "zhī",
+        "native_1": "(literary equivalent to 的); (pronoun); of",
+        "primary_1": "之",
+        "primary_2": "之"
+    },
+    {
+        "intermediate_1": "zhi1chi2",
+        "intermediate_2": "zhīchí",
+        "native_1": "sustain; hold out; | support; stand by (e.g. international support)",
+        "primary_1": "支持",
+        "primary_2": "支持"
+    },
+    {
+        "intermediate_1": "zhi1shi",
+        "intermediate_2": "zhīshi",
+        "native_1": "knowledge; intellectual",
+        "primary_1": "知识",
+        "primary_2": "知識"
+    },
+    {
+        "intermediate_1": "zhi2jie1",
+        "intermediate_2": "zhíjiē",
+        "native_1": "direct; immediate",
+        "primary_1": "直接",
+        "primary_2": "直接"
+    },
+    {
+        "intermediate_1": "zhi2de",
+        "intermediate_2": "zhíde",
+        "native_1": "be worth; deserve",
+        "primary_1": "值得",
+        "primary_2": "值得"
+    },
+    {
+        "intermediate_1": "zhi2ye4",
+        "intermediate_2": "zhíyè",
+        "native_1": "profession; occupation",
+        "primary_1": "职业",
+        "primary_2": "職業"
+    },
+    {
+        "intermediate_1": "zhi2wu4",
+        "intermediate_2": "zhíwù",
+        "native_1": "plant; botanical; vegetation",
+        "primary_1": "植物",
+        "primary_2": "植物"
+    },
+    {
+        "intermediate_1": "zhi3hao3",
+        "intermediate_2": "zhǐhǎo",
+        "native_1": "have to; be forced to",
+        "primary_1": "只好",
+        "primary_2": "只好"
+    },
+    {
+        "intermediate_1": "zhi3yao4",
+        "intermediate_2": "zhǐyào",
+        "native_1": "so long as; if only; provided that",
+        "primary_1": "只要",
+        "primary_2": "只要"
+    },
+    {
+        "intermediate_1": "zhi3",
+        "intermediate_2": "zhǐ",
+        "native_1": "finger; to point (at, to, out); refer to",
+        "primary_1": "指",
+        "primary_2": "指"
+    },
+    {
+        "intermediate_1": "zhi4shao3",
+        "intermediate_2": "zhìshǎo",
+        "native_1": "at least; (to say the) least",
+        "primary_1": "至少",
+        "primary_2": "至少"
+    },
+    {
+        "intermediate_1": "zhi4liang4",
+        "intermediate_2": "zhìliàng",
+        "native_1": "quality; mass (physics)",
+        "primary_1": "质量",
+        "primary_2": "質量"
+    },
+    {
+        "intermediate_1": "zhong4",
+        "intermediate_2": "zhòng",
+        "native_1": "heavy; serious; important",
+        "primary_1": "重",
+        "primary_2": "重"
+    },
+    {
+        "intermediate_1": "zhong4dian3",
+        "intermediate_2": "zhòngdiǎn",
+        "native_1": "emphasis; main point",
+        "primary_1": "重点",
+        "primary_2": "重點"
+    },
+    {
+        "intermediate_1": "zhong4shi4",
+        "intermediate_2": "zhòngshì",
+        "native_1": "to value; take seriously",
+        "primary_1": "重视",
+        "primary_2": "重視"
+    },
+    {
+        "intermediate_1": "zhou1wei2",
+        "intermediate_2": "zhōuwéi",
+        "native_1": "surroundings; vicinity; environment",
+        "primary_1": "周围",
+        "primary_2": "周圍"
+    },
+    {
+        "intermediate_1": "zhu3yi",
+        "intermediate_2": "zhǔyi",
+        "native_1": "plan; idea; decision",
+        "primary_1": "主意",
+        "primary_2": "主意"
+    },
+    {
+        "intermediate_1": "zhu4he4",
+        "intermediate_2": "zhùhè",
+        "native_1": "congratulate",
+        "primary_1": "祝贺",
+        "primary_2": "祝賀"
+    },
+    {
+        "intermediate_1": "zhu4ming2",
+        "intermediate_2": "zhùmíng",
+        "native_1": "famous; well-known; celebration",
+        "primary_1": "著名",
+        "primary_2": "著名"
+    },
+    {
+        "intermediate_1": "zhuan1men2",
+        "intermediate_2": "zhuānmén",
+        "native_1": "specialized",
+        "primary_1": "专门",
+        "primary_2": "專門"
+    },
+    {
+        "intermediate_1": "zhuan1ye4",
+        "intermediate_2": "zhuānyè",
+        "native_1": "profession; specialized field of study; major",
+        "primary_1": "专业",
+        "primary_2": "專業"
+    },
+    {
+        "intermediate_1": "zhuan3, zhuan4",
+        "intermediate_2": "zhuǎn, zhuàn",
+        "native_1": "to turn; to change; pass on | revolve; rotate",
+        "primary_1": "转",
+        "primary_2": "轉"
+    },
+    {
+        "intermediate_1": "zhuan4",
+        "intermediate_2": "zhuàn",
+        "native_1": "earn; make a profit",
+        "primary_1": "赚",
+        "primary_2": "賺"
+    },
+    {
+        "intermediate_1": "zhun3que4",
+        "intermediate_2": "zhǔnquè",
+        "native_1": "accurate; precise",
+        "primary_1": "准确",
+        "primary_2": "准確"
+    },
+    {
+        "intermediate_1": "zhun3shi2",
+        "intermediate_2": "zhǔnshí",
+        "native_1": "punctually; on time",
+        "primary_1": "准时",
+        "primary_2": "准時"
+    },
+    {
+        "intermediate_1": "zi3xi4",
+        "intermediate_2": "zǐxì",
+        "native_1": "careful; attentive; cautious",
+        "primary_1": "仔细",
+        "primary_2": "仔細"
+    },
+    {
+        "intermediate_1": "zi4ran2",
+        "intermediate_2": "zìrán",
+        "native_1": "nature; natural",
+        "primary_1": "自然",
+        "primary_2": "自然"
+    },
+    {
+        "intermediate_1": "zi4xin4",
+        "intermediate_2": "zìxìn",
+        "native_1": "self-confidence",
+        "primary_1": "自信",
+        "primary_2": "自信"
+    },
+    {
+        "intermediate_1": "zong3jie2",
+        "intermediate_2": "zǒngjié",
+        "native_1": "summarize; conclude",
+        "primary_1": "总结",
+        "primary_2": "總結"
+    },
+    {
+        "intermediate_1": "zu1",
+        "intermediate_2": "zū",
+        "native_1": "to rent",
+        "primary_1": "租",
+        "primary_2": "租"
+    },
+    {
+        "intermediate_1": "zui4hao3",
+        "intermediate_2": "zuìhǎo",
+        "native_1": "the best; had better ...; it would be best",
+        "primary_1": "最好",
+        "primary_2": "最好"
+    },
+    {
+        "intermediate_1": "zun1zhong4",
+        "intermediate_2": "zūnzhòng",
+        "native_1": "esteem; to respect; to value; to honor",
+        "primary_1": "尊重",
+        "primary_2": "尊重"
+    },
+    {
+        "intermediate_1": "zuo3you4",
+        "intermediate_2": "zuǒyòu",
+        "native_1": "about; approximate; around | left and right",
+        "primary_1": "左右",
+        "primary_2": "左右"
+    },
+    {
+        "intermediate_1": "zuo4jia1",
+        "intermediate_2": "zuòjiā",
+        "native_1": "author; writer",
+        "primary_1": "作家",
+        "primary_2": "作家"
+    },
+    {
+        "intermediate_1": "zuo4yong4",
+        "intermediate_2": "zuòyòng",
+        "native_1": "action; activity; effect",
+        "primary_1": "作用",
+        "primary_2": "作用"
+    },
+    {
+        "intermediate_1": "zuo4zhe3",
+        "intermediate_2": "zuòzhě",
+        "native_1": "author; writer",
+        "primary_1": "作者",
+        "primary_2": "作者"
+    },
+    {
+        "intermediate_1": "zuo4",
+        "intermediate_2": "zuò",
+        "native_1": "(mw for mountains, bridges, tall buildings, etc.); | seat; base; stand; constellation",
+        "primary_1": "座",
+        "primary_2": "座"
+    },
+    {
+        "intermediate_1": "zuo4wei4",
+        "intermediate_2": "zuòwèi",
+        "native_1": "seat; place",
+        "primary_1": "座位",
+        "primary_2": "座位"
+    }
+]

--- a/vocab/mandarin/hsk/5/vocab.csv
+++ b/vocab/mandarin/hsk/5/vocab.csv
@@ -1,0 +1,1301 @@
+PRIMARY	PRIMARY	INTERMEDIATE	INTERMEDIATE	NATIVE
+哎	哎	ai1	āi	hey!; (interjection of surprise or dissatisfaction)
+唉	唉	ai4	ài	(an exclamation indicating resignation); oh well; oh; mm
+爱护	愛護	ai4hu4	àihù	cherish; reassure; take good care of
+爱惜	愛惜	ai4xi1	àixī	cherish; treasure; use sparingly
+爱心	愛心	ai4xin1	àixīn	compassion
+安慰	安慰	an1wei4	ānwèi	to comfort; to console
+安装	安裝	an1zhuang1	ānzhuāng	install; erect; to fix; to mount
+岸	岸	an4	àn	bank; shore; beach; coast
+暗	暗	an4	àn	dark; gloomy; hidden; secret
+熬夜	熬夜	ao2ye4	áoyè	stay up very late or all night
+把握	把握	ba3wo4	bǎwò	grasp; hold; certainty; assurance
+摆	擺	bai3	bǎi	to put (on); arrange; to sway; pendulum
+办理	辦理	ban4li3	bànlǐ	to handle; to transact; to conduct
+傍晚	傍晚	bang4wan3	bàngwǎn	in the evening; when night falls
+包裹	包裹	bao1guo3	bāoguǒ	wrap up; bind up; package
+包含	包含	bao1han2	bāohán	contain; embody; include
+包括	包括	bao1kuo4	bāokuò	comprise; include; consist of
+薄	薄	bao2	báo	thin; flimsy; weak (first two pronunciations)
+宝贝	寶貝	bao3bei4	bǎobèi	treasure; precious things; darling; baby
+宝贵	寶貴	bao3gui4	bǎoguì	valuable; precious; value
+保持	保持	bao3chi2	bǎochí	to keep; maintain; to hold
+保存	保存	bao3cun2	bǎocún	conserve; preserve; to keep, to save a file in a computer
+保留	保留	bao3liu2	bǎoliú	to reserve; hold back; retain
+保险	保險	bao3xian3	bǎoxiǎn	insurance; insure; safe
+报到	報到	bao4dao4	bàodào	report for duty; to check in; register
+报道	報道	bao4dao4	bàodào	to report; news report
+报告	報告	bao4gao4	bàogào	to report; make known; inform; speech; lecture
+报社	報社	bao4she4	bàoshè	newspaper office
+抱怨	抱怨	bao4yuan4	bàoyuàn	complain; grumble
+背	背	bei1	bēi	carry on one's back; to bear
+悲观	悲觀	bei1guan1	bēiguān	pessimistic
+背景	背景	bei4jing3	bèijǐng	background
+被子	被子	bei4zi	bèizi	quilt; blanket
+本科	本科	ben3ke1	běnkē	undergraduate
+本领	本領	ben3ling3	běnlǐng	skill; ability; capability
+本质	本質	ben3zhi4	běnzhì	essence; nature; innate character
+比例	比例	bi3li4	bǐlì	proportion; scale
+彼此	彼此	bi3ci3	bǐcǐ	each other; one another
+必然	必然	bi4ran2	bìrán	inevitable; certain; necessary
+必要	必要	bi4yao4	bìyào	necessary; essential; indispensable
+毕竟	畢竟	bi4jing4	bìjìng	after all; overall; when all is said and done
+避免	避免	bi4mian3	bìmiǎn	avoid; avert; prevent
+编辑	編輯	bian1ji2	biānjí	to edit; compile; editor
+鞭炮	鞭炮	bian1pao4	biānpào	firecracker; a long string of small firecrackers
+便	便	bian4, pian2	biàn, pián	plain; convenient; excretion; formal equivalent to 就 | cheap
+辩论	辯論	bian4lun4	biànlùn	argue; debate; argue over
+标点	標點	biao1dian3	biāodiǎn	punctuation; punctuation mark; punctuate
+标志	標志	biao1zhi4	biāozhì	sign; mark; signal; symbol
+表达	表達	biao3da2	biǎodá	to express; to voice; convey
+表面	表面	biao3mian4	biǎomiàn	surface; outside; face
+表明	表明	biao3ming2	biǎomíng	make clear; make known
+表情	表情	biao3qing2	biǎoqíng	(facial) expression; express one's feelings
+表现	表現	biao3xian4	biǎoxiàn	to show; to show off; display; performance
+冰激凌	冰激淩	bing1ji1ling2	bīngjīlíng	ice cream
+病毒	病毒	bing4du2	bìngdú	virus
+玻璃	玻璃	bo1li	bōli	glass; nylon; plastic
+播放	播放	bo1fang4	bōfàng	broadcast; transmit
+脖子	脖子	bo2zi	bózi	neck
+博物馆	博物館	bo2wu4guan3	bówùguǎn	museum
+补充	補充	bu3chong1	bǔchōng	replenish; to supplement; to complement
+不安	不安	bu4'an1	bù'ān	uneasy; unstable; disturbed
+不得了	不得了	bu4de2liao3	bùdéliǎo	extremely; very; terribly; my god! (expression of surprise)
+不断	不斷	bu2duan4	búduàn	unceasing; uninterrupted; continuously
+不见得	不見得	bu2jian4de2	bújiàndé	not necessarily; not likely
+不耐烦	不耐煩	bun2ai4fan2	búnàifán	impatience; impatient
+不然	不然	bu4ran2	bùrán	otherwise; not so
+不如	不如	bu4ru2	bùrú	not as good as; inferior to
+不要紧	不要緊	bu2 yao4jin3	bú yàojǐn	unimportant; not serious; it doesn't matter
+不足	不足	bu4zu2	bùzú	insufficient; not enough
+布	布	bu4	bù	cloth; announce; to spread
+步骤	步驟	bu4zhou4	bùzhòu	step; move; measure; procedure
+部门	部門	bu4men2	bùmén	department; branch; section
+财产	財産	cai2chan3	cáichǎn	property; fortune
+采访	采訪	cai3fang3	cǎifǎng	interview; gather news; hunt for and collect
+采取	采取	cai3qu3	cǎiqǔ	carry out or adopt; take(measures, policies, attitudes, etc.)
+彩虹	彩虹	cai3hong2	cǎihóng	rainbow
+踩	踩	cai3	cǎi	step upon; to tread; to stamp
+参考	參考	can1kao3	cānkǎo	reference; consult
+参与	參與	can1yu4	cānyù	participate (in sth.); attach oneself to
+惭愧	慚愧	can2kui4	cánkuì	ashamed
+操场	操場	cao1chang3	cāochǎng	playground; sports field
+操心	操心	cao1 xin1	cāo xīn	worry about
+册	冊	ce4	cè	book; (mw for books)
+测验	測驗	ce4yan4	cèyàn	test; exam; to test
+曾经	曾經	ceng2jing1	céngjīng	once; (refers to something that happened previously)
+叉子	叉子	cha1zi	chāzi	fork; cross
+差距	差距	cha1ju4	chājù	disparity; gap; the difference (in distance; amount; progress; etc.)
+插	插	cha1	chā	to insert; stick in; pierce
+拆	拆	chai1	chāi	unravel; to tear; demolish
+产品	産品	chan3pin3	chǎnpǐn	product; goods; merchandise
+产生	産生	chan3sheng1	chǎnshēng	to produce; emerge; to cause
+长途	長途	chang2tu2	chángtú	long distance
+常识	常識	chang2shi2	chángshí	common sense; general knowledge
+抄	抄	chao1	chāo	to copy; plagiarize; search and confiscate
+超级	超級	chao1ji2	chāojí	super; transcending; high grade
+朝	朝	chao2	cháo	to face; towards; dynasty
+潮湿	潮濕	chao2shi1	cháoshī	damp; moist; humid
+吵	吵	chao3	chǎo	to quarrel; make noise
+吵架	吵架	chao3 jia4	chǎo jià	to quarrel; to squabble; bicker
+炒	炒	chao3	chǎo	to stir-fry; saute
+车库	車庫	che1ku4	chēkù	garage
+车厢	車廂	che1xiang1	chēxiāng	carriage; railroad car
+彻底	徹底	che4di3	chèdǐ	thorough; complete; completely
+沉默	沈默	chen2mo4	chénmò	silent; uncommunicative
+趁	趁	chen4	chèn	avail oneself of; take advantage of (an opportunity or situation)
+称	稱	cheng1	chēng	weigh; to call; be called
+称呼	稱呼	cheng1hu	chēnghu	to call; address as; name
+称赞	稱贊	cheng1zan4	chēngzàn	to praise; to acclaim
+成分	成分	cheng2fen4	chéngfèn	ingredient; composition
+成果	成果	cheng2guo3	chéngguǒ	result; achievement; gain
+成就	成就	cheng2jiu4	chéngjiù	accomplishment; achievement; success
+成立	成立	cheng2li4	chénglì	establish; to set up
+成人	成人	cheng2ren2	chéngrén	adult; to grow up; become full-grown
+成熟	成熟	cheng2shu2	chéngshú	mature; ripe
+成语	成語	cheng2yu3	chéngyǔ	idiom; proverb
+成长	成長	cheng2zhang3	chéngzhǎng	to mature; grow up
+诚恳	誠懇	cheng2ken3	chéngkěn	honest; sincere
+承担	承擔	cheng2dan1	chéngdān	undertake; assume (responsibility)
+承认	承認	cheng2ren4	chéngrèn	to admit; concede; acknowledge
+承受	承受	cheng2shou4	chéngshòu	to bear; support; endure; sustain
+程度	程度	cheng2du4	chéngdù	degree; extent; level
+程序	程序	cheng2xu4	chéngxù	procedure; sequence; program
+吃亏	吃虧	chi1kui1	chīkuī	suffer losses; get the worst of
+池塘	池塘	chi2tang2	chítáng	pool; pond
+迟早	遲早	chi2zao3	chízǎo	sooner or later
+持续	持續	chi2xu4	chíxù	continue; persist
+尺子	尺子	chi3zi	chǐzi	ruler (measuring instrument)
+翅膀	翅膀	chi4bang3	chìbǎng	wing
+冲	沖	chong1	chōng	to rush; to clash; to rinse; thoroughfare
+充电器	充電器	chong1dian4qi4	chōngdiànqì	battery charger
+充分	充分	chong1fen4	chōngfèn	full; abundant; ample
+充满	充滿	chong1man3	chōngmǎn	brimming with; very full
+重复	重複	chong2fu4	chóngfù	to repeat; to duplicate
+宠物	寵物	chong3wu4	chǒngwù	a pet
+抽屉	抽屜	chou1ti	chōuti	drawer
+抽象	抽象	chou1xiang4	chōuxiàng	abstract; abstraction
+丑	醜	chou3	chǒu	ugly; disgraceful (2nd Earthly Branch)
+臭	臭	chou4	chòu	stench; stink
+出版	出版	chu1ban3	chūbǎn	publish
+出口	出口	chu1kou3	chūkǒu	exit; speak; export
+出色	出色	chu1se4	chūsè	remarkable; outstanding; excellent
+出示	出示	chu1shi4	chūshì	to show
+出席	出席	chu1xi2	chūxí	attend; be present; participate
+初级	初級	chu1ji2	chūjí	junior; primary
+除非	除非	chu2fei1	chúfēi	only if; unless
+除夕	除夕	chu2xi1	chúxī	Lunar New Year's Eve
+处理	處理	chu3li3	chǔlǐ	deal with; to process; sell at a discount; to treat (by a special process)
+传播	傳播	chuan2bo1	chuánbō	propagate; to spread
+传染	傳染	chuan2ran3	chuánrǎn	infect; be contagious
+传说	傳說	chuan2shuo1	chuánshuō	it is said; legend; pass on (a story)
+传统	傳統	chuan2tong3	chuántǒng	tradition; traditional
+窗帘	窗簾	chuang1lian2	chuānglián	window curtain
+闯	闖	chuang3	chuǎng	rush; break through; to temper oneself (by battling difficulties)
+创造	創造	chuang4zao4	chuàngzào	create; bring about; creativity
+吹	吹	chui1	chuī	to blow; to blast; to puff
+词汇	詞彙	ci2hui4	cíhuì	vocabulary
+辞职	辭職	ci2zhi2	cízhí	resign from a position
+此外	此外	ci3wai4	cǐwài	besides; in addition; moreover
+次要	次要	ci4yao4	cìyào	secondary; less important
+刺激	刺激	ci4ji1	cìjī	exciting; provoke; irritate
+匆忙	匆忙	cong1mang2	cōngmáng	hasty; hurried
+从此	從此	cong2ci3	cóngcǐ	from now on; since then
+从而	從而	cong2'er2	cóng'ér	thus; thereby; as a result
+从前	從前	cong2qian2	cóngqián	previously; formerly; in the past
+从事	從事	cong2shi4	cóngshì	go for; engage in; deal with
+粗糙	粗糙	cu1cao1	cūcāo	coarse
+促进	促進	cu4jin4	cùjìn	promote (an idea or cause); to advance
+促使	促使	cu4shi3	cùshǐ	to urge; impel; to cause; to push
+醋	醋	cu4	cù	vinegar
+催	催	cui1	cuī	to press; to urge; to hurry
+存在	存在	cun2zai4	cúnzài	to exist; to be
+措施	措施	cuo4shi1	cuòshī	measure; step (to be taken)
+答应	答應	da1ying	dāying	to respond; to promise; to answer; agree
+达到	達到	da2 dao4	dá dào	achieve; attain; to reach
+打工	打工	da3gong1	dǎgōng	work a part time job; (regional) do manual labor; do odd jobs
+打交道	打交道	da3 jiao1dao	dǎ jiāodao	come into contact with; to deal with
+打喷嚏	打噴嚏	da3pen1ti4	dǎpēntì	to sneeze
+打听	打聽	da3ting	dǎting	ask about; inquire about
+大方	大方	da4fang	dàfang	generous; poise; (-fang1: expert; scholar)
+大厦	大廈	da4sha4	dàshà	large building; edifice; mansion
+大象	大象	da4xiang4	dàxiàng	elephant
+大型	大型	da4xing2	dàxíng	large-scale; wide-scale
+呆	呆	dai1	dāi	stupid; foolish; blank; dumbstruck; to stay
+代表	代表	dai4biao3	dàibiǎo	represent; to delegate
+代替	代替	dai4ti4	dàitì	to replace
+贷款	貸款	dai4 kuan3	dài kuǎn	(bank) loan; provide a loan
+待遇	待遇	dai4yu4	dàiyù	treatment; pay; wage; salary
+担任	擔任	dan1ren4	dānrèn	hold the post of; serve as
+单纯	單純	dan1chun2	dānchún	simple; pure; merely
+单调	單調	dan1diao4	dāndiào	monotonous; dull
+单独	單獨	dan1du2	dāndú	alone
+单位	單位	dan1wei4	dānwèi	unit; work unit
+单元	單元	dan1yuan2	dānyuán	unit; entrance number; staircase (for residential buildings)
+耽误	耽誤	dan1wu	dānwu	to delay; waste time
+胆小鬼	膽小鬼	dan3xiao3gui3	dǎnxiǎoguǐ	coward
+淡	淡	dan4	dàn	diluted; weak; thin
+当地	當地	dang1di4	dāngdì	local
+当心	當心	dang1xin1	dāngxīn	take care; watch out
+挡	擋	dang3	dǎng	to block; hinder; gear; equipment
+导演	導演	dao3yan3	dǎoyǎn	to direct; director
+导致	導致	dao3zhi4	dǎozhì	lead to; bring about; to cause
+岛屿	島嶼	dao3yu3	dǎoyǔ	islands
+倒霉	倒黴	dao3mei2	dǎoméi	have bad luck; be out of luck
+到达	到達	dao4da2	dàodá	to reach; arrive
+道德	道德	dao4de2	dàodé	morals; morality; ethics
+道理	道理	dao4li3	dàolǐ	reason; sense; argument
+登记	登記	deng1ji4	dēngjì	register (one's name); check in; enroll
+等待	等待	deng3dai4	děngdài	to wait (for); expect
+等于	等于	deng3yu2	děngyú	(Mathematics) equal to
+滴	滴	di1	dī	to drip; drop; (mw for drops of liquid)
+的确	的確	di2que4	díquè	really; indeed
+敌人	敵人	di2ren2	dírén	enemy
+地道	地道	di4dao	dìdao	authentic; genuine; (-dào: tunnel)
+地理	地理	di4li3	dìlǐ	geography
+地区	地區	di4qu1	dìqū	an area; a region; a district
+地毯	地毯	di4tan3	dìtǎn	carpet; rug
+地位	地位	di4wei4	dìwèi	position; status
+地震	地震	di4zhen4	dìzhèn	earthquake
+递	遞	di4	dì	hand over; to pass; to give
+点心	點心	dian3xin	diǎnxin	dim sum; light refreshments; snacks
+电池	電池	dian4chi2	diànchí	battery
+电台	電台	dian4tai2	diàntái	transceiver; broadcasting station
+钓	釣	diao4	diào	to fish
+顶	頂	ding3	dǐng	top; roof; carry on one's head; prop up; to butt; (mw for headwear, i.e. hats)
+动画片	動畫片	dong4hua4pian4	dònghuàpiàn	animated film
+冻	凍	dong4	dòng	to freeze
+洞	洞	dong4	dòng	cave; hole
+豆腐	豆腐	dou4fu	dòufu	tofu; bean curd
+逗	逗	dou4	dòu	to tease; amuse; to stay; to stop; funny
+独立	獨立	du2li4	dúlì	independent
+独特	獨特	du2te4	dútè	unique; distinctive
+度过	度過	du4guo4	dùguò	spend; to pass
+断	斷	duan4	duàn	to break; decide; absolutely (usually negative)
+堆	堆	dui1	duī	pile; heap; stack; crowd
+对比	對比	dui4bi3	duìbǐ	compare; to contrast; comparison
+对待	對待	dui4dai4	duìdài	to treat
+对方	對方	dui4fang1	duìfāng	counterpart; the other party involved
+对手	對手	dui4shou3	duìshǒu	opponent; adversary; match
+对象	對象	dui4xiang4	duìxiàng	target; object; partner; boyfriend or girlfriend
+兑换	兌換	dui4huan4	duìhuàn	to exchange; to convert (currencies)
+吨	噸	dun1	dūn	ton
+蹲	蹲	dun1	dūn	to crouch; to squat
+顿	頓	dun4	dùn	pause; arrange; stamp feet; suddenly; (mw for meals)
+多亏	多虧	duo1kui1	duōkuī	thanks to; luckily
+多余	多余	duo1yu2	duōyú	unnecessary; superfluous
+朵	朵	duo3	duǒ	(mw for flowers and clouds)
+躲藏	躲藏	duo3cang2	duǒcáng	hide oneself; take cover
+恶劣	惡劣	e4lie4	èliè	vile; horrible
+耳环	耳環	er3huan2	ěrhuán	earring
+发表	發表	fa1biao3	fābiǎo	publish; to issue (a statement); announce
+发愁	發愁	fa1 chou2	fā chóu	worry about sth.
+发达	發達	fa1da2	fādá	developed (country, etc.); flourishing; prosper
+发抖	發抖	fa1dou3	fādǒu	to shiver; to shudder; tremble
+发挥	發揮	fa1hui1	fāhuī	to bring (skill, talent, etc.) into play; to develop (an idea)
+发明	發明	fa1ming2	fāmíng	invent
+发票	發票	fa1piao4	fāpiào	receipt or bill for purchase; invoice
+发言	發言	fa1yan2	fāyán	make a speech; statement
+罚款	罰款	fa2kuan3	fákuǎn	fine; penalty (monetary)
+法院	法院	fa3yuan4	fǎyuàn	court of law
+翻	翻	fan1	fān	to turn over; capsize; translate
+繁荣	繁榮	fan2rong2	fánróng	prosperous; prosperity; booming (economy)
+反而	反而	fan3'er2	fǎn'ér	on the contrary; instead
+反复	反複	fan3fu4	fǎnfù	repeatedly; over and over
+反应	反應	fan3ying4	fǎnyìng	react; respond; reply
+反映	反映	fan3ying4	fǎnyìng	reflect; reflection; report on
+反正	反正	fan3zheng4	fǎnzhèng	anyway
+范围	範圍	fan4wei2	fànwéi	scope; range; limits; extent
+方	方	fang1	fāng	square; direction; side (Kangxi radical 70)
+方案	方案	fang1'an4	fāng'àn	plan; program (for action, etc.); proposal
+方式	方式	fang1shi4	fāngshì	way; style; fashion; manner
+妨碍	妨礙	fang2'ai4	fáng'ài	hinder; to hamper; to obstruct
+仿佛	仿佛	fang3fu2	fǎngfú	to seem as though; as if
+非	非	fei1	fēi	non-; un-; not be; wrongdoing; simply must (Kangxi radical 175)
+肥皂	肥皂	fei2zao4	féizào	soap
+废话	廢話	fei4hua4	fèihuà	nonsense; rubbish
+分别	分別	fen1bie2	fēnbié	distinguish; split up; difference; to part
+分布	分布	fen1bu4	fēnbù	be distributed (over an area); be scattered
+分配	分配	fen1pei4	fēnpèi	distribute; assign; allocate
+分手	分手	fen1shou3	fēnshǒu	part company; break up
+分析	分析	fen1xi1	fēnxī	analyze; analysis
+纷纷	紛紛	fen1fen1	fēnfēn	one after another; in succession; in profusion; diverse; pell-mell
+奋斗	奮鬥	fen4dou4	fèndòu	strive; to struggle
+风格	風格	feng1ge2	fēnggé	style
+风景	風景	feng1jing3	fēngjǐng	scenery; landscape
+风俗	風俗	feng1su2	fēngsú	social custom
+风险	風險	feng1xian3	fēngxiǎn	risk; venture; hazard
+疯狂	瘋狂	feng1kuang2	fēngkuáng	crazy; madness; wild; extreme popularity; insane; frenzied; unbridled
+讽刺	諷刺	feng3ci4	fěngcì	satirize; ridicule; mock; irony
+否定	否定	fou3ding4	fǒudìng	negate; negative
+否认	否認	fou3ren4	fǒurèn	deny; declare to be untrue
+扶	扶	fu2	fú	to support with hand; to help somebody up
+服装	服裝	fu2zhuang1	fúzhuāng	(formal) clothing; costume; dress
+幅	幅	fu2	fú	width of cloth; size; (mw for pictures, paintings, textiles)
+辅导	輔導	fu3dao3	fǔdǎo	to coach; to tutor; give advice (in study)
+妇女	婦女	fun4ü3	fùnǚ	woman; women in general
+复制	複制	fu4zhi4	fùzhì	duplicate; reproduce
+改革	改革	gai3ge2	gǎigé	to reform
+改进	改進	gai3jin4	gǎijìn	improve; make better
+改善	改善	gai3shan4	gǎishàn	improve; make better
+改正	改正	gai3zheng4	gǎizhèng	to correct; amend
+盖	蓋	gai4	gài	lid; top; cover; to build
+概括	概括	gai4kuo4	gàikuò	summarize; generalize
+概念	概念	gai4nian4	gàiniàn	concept; idea
+干脆	幹脆	gan1cui4	gāncuì	straightforward; clear-cut; blunt
+干燥	幹燥	gan1zao4	gānzào	to dry (of paint, cement, etc.); dry; dryness
+赶紧	趕緊	gan3jin3	gǎnjǐn	at once; hurriedly; lose no time
+赶快	趕快	gan3kuai4	gǎnkuài	at once; immediately
+感激	感激	gan3ji1	gǎnjī	appreciate; feel grateful
+感受	感受	gan3shou4	gǎnshòu	feel; experience; emotion; impression
+感想	感想	gan3xiang3	gǎnxiǎng	impressions; reflections; thoughts
+干活儿	幹活兒	gan4 huo2r	gàn huór	do manual labor; to work
+钢铁	鋼鐵	gang1tie3	gāngtiě	steel
+高档	高檔	gao1dang4	gāodàng	top quality; first rate; high class
+高级	高級	gao1ji2	gāojí	high-level; high-grade; advanced
+搞	搞	gao3	gǎo	do; make; be engaged in
+告别	告別	gao4bie2	gàobié	say goodbye to; to leave; to part
+格外	格外	ge2wai4	géwài	especially; additionally
+隔壁	隔壁	ge2bi4	gébì	next door
+个别	個別	ge4bie2	gèbié	individual; specific; isolated; very few
+个人	個人	ger4en2	gèrén	individual; personal; oneself
+个性	個性	ge4xing4	gèxìng	individuality; personality
+各自	各自	ge4zi4	gèzì	each; respective; apiece
+根	根	gen1	gēn	root; base; (mw for long, slender objects)
+根本	根本	gen1ben3	gēnběn	root; essence; fundamental; basic; (not) at all; simply
+工厂	工廠	gong1chang3	gōngchǎng	factory
+工程师	工程師	gong1cheng2shi1	gōngchéngshī	engineer
+工具	工具	gong1ju4	gōngjù	tool; instrument; utensil
+工人	工人	gong1ren2	gōngrén	worker
+工业	工業	gong1ye4	gōngyè	industry
+公布	公布	gong1bu4	gōngbù	make public; announce; publicize
+公开	公開	gong1kai1	gōngkāi	public; make public
+公平	公平	gong1ping2	gōngpíng	fair; impartial; just
+公寓	公寓	gong1yu4	gōngyù	apartment building
+公元	公元	gong1yuan2	gōngyuán	(year) AD or CE; Christian era; common era
+公主	公主	gong1zhu3	gōngzhǔ	princess
+功能	功能	gong1neng2	gōngnéng	function; feature
+恭喜	恭喜	gong1xi3	gōngxǐ	congratulate
+贡献	貢獻	gong4xian4	gòngxiàn	contribute; dedicate; contribution
+沟通	溝通	gou1tong1	gōutōng	link; connect; communicate
+构成	構成	gou4cheng2	gòuchéng	to constitute; to compose
+姑姑	姑姑	gu1gu	gūgu	paternal aunt; father's sister
+姑娘	姑娘	gun1iang	gūniang	young woman; girl
+古代	古代	gu3dai4	gǔdài	ancient times
+古典	古典	gu3dian3	gǔdiǎn	classical
+股票	股票	gu3piao4	gǔpiào	shares; stock (market)
+骨头	骨頭	gu3tou	gǔtou	bone; moral character
+鼓舞	鼓舞	gu3wu3	gǔwǔ	inspire; heartening
+鼓掌	鼓掌	gu3 zhang3	gǔ zhǎng	applaud
+固定	固定	gu4ding4	gùdìng	fixed; regular; stable
+挂号	挂號	gua4 hao4	guà hào	register; check into hospital; send by registered mail
+乖	乖	guai1	guāi	(of a child) obedient; well-behaved; clever; perverse; contrary to reason
+拐弯	拐彎	guai3 wan1	guǎi wān	turn a corner; make a turn
+怪不得	怪不得	guai4 bu de	guài bu de	no wonder; so that's why
+关闭	關閉	guan1bi4	guānbì	close; shut
+观察	觀察	guan1cha2	guānchá	observe; to watch; to survey
+观点	觀點	guan1dian3	guāndiǎn	point of view; standpoint
+观念	觀念	guan1nian4	guānniàn	notion; thought; concept
+官	官	guan1	guān	an official; organ; governmental
+管子	管子	guan3zi	guǎnzi	tube; pipe; drinking straw
+冠军	冠軍	guan4jun1	guànjūn	champion
+光滑	光滑	guang1hua2	guānghuá	glossy; sleek; smooth
+光临	光臨	guang1lin2	guānglín	(polite) welcome!; honor somebody with one's presence
+光明	光明	guang1ming2	guāngmíng	bright (future); promising; illuminate
+光盘	光盤	guang1pan2	guāngpán	CD (compact disc)
+广场	廣場	guang3chang3	guǎngchǎng	public square; plaza
+广大	廣大	guang3da4	guǎngdà	vast; extensive
+广泛	廣泛	guang3fan4	guǎngfàn	extensive; wide ranging
+归纳	歸納	guin1a4	guīnà	conclude from the facts; induce; sum up from the facts
+规矩	規矩	gui1ju	guīju	rule; custom
+规律	規律	gui1lü4	guīlǜ	law (e.g. of science); regular pattern; discipline
+规模	規模	gui1mo2	guīmó	scale; scope; extent
+规则	規則	gui1ze2	guīzé	rule; law; regulation
+柜台	櫃台	gui4tai2	guìtái	counter; bar; front desk
+滚	滾	gun3	gǔn	to roll; get lost; to boil
+锅	鍋	guo1	guō	pot; pan; boiler
+国庆节	國慶節	Guo2qing4 Jie2	Guóqìng Jié	National Day
+国王	國王	guo2wang2	guówáng	king
+果然	果然	guo3ran2	guǒrán	really; sure enough; as expected
+果实	果實	guo3shi2	guǒshí	fruit; gains; results
+过分	過分	guo4fen4	guòfèn	excessive; overly
+过敏	過敏	guo4min3	guòmǐn	be allergic; allergy
+过期	過期	guo4qi1	guòqī	overdue; expire
+哈	哈	ha1	hā	exhale; sip; (sound of laughter)
+海关	海關	hai3guan1	hǎiguān	customs (i.e. border inspection)
+海鲜	海鮮	hai3xian1	hǎixiān	seafood
+喊	喊	han3	hǎn	call; cry; shout
+行业	行業	hang2ye4	hángyè	industry; business
+豪华	豪華	hao2hua2	háohuá	luxurious
+好客	好客	hao4ke4	hàokè	hospitable; to enjoy having guests
+好奇	好奇	hao4qi2	hàoqí	curious
+合法	合法	he2fa3	héfǎ	lawful; legitimate; legal
+合理	合理	he2li3	hélǐ	rational; reasonable
+合同	合同	he2tong	hétong	contract
+合影	合影	he2ying3	héyǐng	joint photo; group photo
+合作	合作	he2zuo4	hézuò	cooperate; collaborate; work together
+何必	何必	he2bi4	hébì	why should; there is no need to
+何况	何況	he2kuang4	hékuàng	let alone; much less
+和平	和平	he2ping2	hépíng	peace
+核心	核心	he2xin1	héxīn	core; nucleus
+恨	恨	hen4	hèn	to hate
+猴子	猴子	hou2zi	hóuzi	monkey
+后背	後背	hou4bei4	hòubèi	back (of the body)
+后果	後果	hou4guo3	hòuguǒ	consequences; aftermath
+呼吸	呼吸	hu1xi1	hūxī	breathe
+忽然	忽然	hu1ran2	hūrán	suddenly; all of a sudden
+忽视	忽視	hu1shi4	hūshì	neglect; ignore; to overlook
+胡说	胡說	hu2shuo1	húshuō	talk nonsense; drivel
+胡同	胡同	hu2tong4	hútòng	lane; alley
+壶	壺	hu2	hú	pot; kettle; jug; (mw for bottled liquids)
+蝴蝶	蝴蝶	hu2die2	húdié	butterfly
+糊涂	糊塗	hu2tu	hútu	confused; bewildered; muddled
+花生	花生	hua1sheng1	huāshēng	peanut
+划	劃	hua4, hua2	huà, huá	delimit; to transfer; assign | to row; to paddle; to scratch
+华裔	華裔	Hua2yi4	Huáyì	person of Chinese descent
+滑	滑	hua2	huá	slippery; cunning; crafty
+化学	化學	hua4xue2	huàxué	chemistry
+话题	話題	hua4ti2	huàtí	subject (of a talk or conversation)
+怀念	懷念	huai2nian4	huáiniàn	cherish the memory of; think fondly of
+怀孕	懷孕	huai2yun4	huáiyùn	become pregnant; have conceived
+缓解	緩解	huan3jie3	huǎnjiě	to alleviate
+幻想	幻想	huan4xiang3	huànxiǎng	delusion; fantasy; illusion
+慌张	慌張	huang1zhang1	huāngzhāng	flustered; flurried
+黄金	黃金	huang2jin1	huángjīn	gold
+灰	灰	hui1	huī	ash; gray (grey); dust; lime
+灰尘	灰塵	hui1chen2	huīchén	dust; dirt
+灰心	灰心	hui1 xin1	huī xīn	lose heart; be discouraged
+挥	揮	hui1	huī	to wave; brandish; wield; wipe away
+恢复	恢複	hui1fu4	huīfù	reinstate; resume; recover
+汇率	彙率	hui4lü4	huìlǜ	exchange rate
+婚礼	婚禮	hun1li3	hūnlǐ	wedding ceremony
+婚姻	婚姻	hun1yin1	hūnyīn	marriage; matrimony; wedding
+活跃	活躍	huo2yue4	huóyuè	active; vigorous
+火柴	火柴	huo3chai2	huǒchái	match (for lighting fire)
+伙伴	夥伴	huo3ban4	huǒbàn	partner (for an activity); friend; pal
+或许	或許	huo4xu3	huòxǔ	perhaps; maybe
+机器	機器	ji1qi4	jīqì	machine
+肌肉	肌肉	ji1rou4	jīròu	muscle; flesh
+基本	基本	ji1ben3	jīběn	basic; fundamental
+激烈	激烈	ji1lie4	jīliè	intense; acute; sharp; fierce
+及格	及格	ji2 ge2	jí gé	pass an exam
+极其	極其	ji2qi2	jíqí	extremely; exceedingly
+急忙	急忙	ji2mang2	jímáng	hastily
+急诊	急診	ji2zhen3	jízhěn	emergency call; emergency treatment
+集合	集合	ji2he2	jíhé	gather; assemble; to muster
+集体	集體	ji2ti3	jítǐ	collective; group
+集中	集中	ji2zhong1	jízhōng	concentrate; to focus; amass
+计算	計算	ji4suan4	jìsuàn	to count; calculate; compute
+记录	記錄	ji4lu4	jìlù	to record; take notes
+记忆	記憶	ji4yi4	jìyì	memory; to remember
+纪录	紀錄	ji4lu4	jìlù	a record; to take notes
+纪律	紀律	ji4lü4	jìlǜ	discipline; morale; laws and regulations
+纪念	紀念	jin4ian4	jìniàn	commemorate; remember
+系领带	系領帶	ji4ling3dai4	jìlǐngdài	tie a neck tie
+寂寞	寂寞	ji4mo4	jìmò	lonely; lonesome
+夹子	夾子	jia1zi	jiāzi	clip; tongs; folder
+家庭	家庭	jia1ting2	jiātíng	family; household
+家务	家務	jia1wu4	jiāwù	household duties; chores; housework
+家乡	家鄉	jia1xiang1	jiāxiāng	hometown
+嘉宾	嘉賓	jia1bin1	jiābīn	honored guest
+甲	甲	jia3	jiǎ	one; armor (1st Heavenly Stem)
+假如	假如	jia3ru2	jiǎrú	if; supposing; in case
+假设	假設	jia3she4	jiǎshè	suppose that; hypothesis; conjecture
+假装	假裝	jia3zhuang1	jiǎzhuāng	pretend to be; feign
+价值	價值	jia4zhi2	jiàzhí	value; worth
+驾驶	駕駛	jia4shi3	jiàshǐ	to drive; to pilot (a ship, an airplane, etc.)
+嫁	嫁	jia4	jià	marry (a husband); take a husband
+坚决	堅決	jian1jue2	jiānjué	resolute; determined; uncompromising
+坚强	堅強	jian1qiang2	jiānqiáng	strong; staunch
+肩膀	肩膀	jian1bang3	jiānbǎng	shoulder
+艰巨	艱巨	jian1ju4	jiānjù	very difficult; arduous; hard
+艰苦	艱苦	jian1ku3	jiānkǔ	difficult; hard; arduous
+兼职	兼職	jian1zhi2	jiānzhí	part time
+捡	撿	jian3	jiǎn	to pick up; collect; gather
+剪刀	剪刀	jian3dao1	jiǎndāo	scissors
+简历	簡曆	jian3li4	jiǎnlì	resume; curriculum vitae
+简直	簡直	jian3zhi2	jiǎnzhí	simply; at all
+建立	建立	jian4li4	jiànlì	establish; to construct; to set up
+建设	建設	jian4she4	jiànshè	to build; to construct; construction
+建筑	建築	jian4zhu4	jiànzhù	a building; to construct; architecture
+健身	健身	jian4shen1	jiànshēn	work out; body-building
+键盘	鍵盤	jian4pan2	jiànpán	keyboard
+讲究	講究	jiang3jiu	jiǎngjiu	Be particular about; fastidious; stress; exquisite ; careful study
+讲座	講座	jiang3zuo4	jiǎngzuò	a lecture or course of lectures; lecture hall
+酱油	醬油	jiang4you2	jiàngyóu	soy sauce
+交换	交換	jiao1huan4	jiāohuàn	to exchange; to swap; to switch
+交际	交際	jiao1ji4	jiāojì	socialize; social intercourse; communication
+交往	交往	jiao1wang3	jiāowǎng	to associate; to contact
+浇	澆	jiao1	jiāo	to water; irrigate; to pour; to sprinkle
+胶水	膠水	jiao1shui3	jiāoshuǐ	(watery) glue; gum
+角度	角度	jiao3du4	jiǎodù	angle; point of view
+狡猾	狡猾	jiao3hua2	jiǎohuá	crafty; cunning; sly
+教材	教材	jiao4cai2	jiàocái	teaching materials
+教练	教練	jiao4lian4	jiàoliàn	(athlete's) coach; sports coach; instructor
+教训	教訓	jiao4xun	jiàoxun	lesson; teach someone or learn a lesson; a moral
+阶段	階段	jie1duan4	jiēduàn	stage; phase
+结实	結實	jie1shi	jiēshi	sturdy; (also -shí: bear fruit)
+接触	接觸	jie1chu4	jiēchù	come into contact with
+接待	接待	jie1dai4	jiēdài	receive (a visitor); admit (entry to)
+接近	接近	jie1jin4	jiējìn	near; be close to
+节省	節省	jie2sheng3	jiéshěng	save; use sparingly; frugal
+结构	結構	jie2gou4	jiégòu	structure; composition
+结合	結合	jie2he2	jiéhé	combine; to link; to bind
+结论	結論	jie2lun4	jiélùn	conclusion; verdict
+结账	結賬	jie2zhang4	jiézhàng	pay the bill; settle accounts
+戒	戒	jie4	jiè	warn against; swear off
+戒指	戒指	jie4zhi	jièzhi	(finger) ring
+届	屆	jie4	jiè	arrive at; period; session; (mw for events; meetings; etc.)
+借口	借口	jie4kou3	jièkǒu	excuse
+金属	金屬	jin1shu3	jīnshǔ	metal
+尽快	盡快	jin3kuai4	jǐnkuài	as quickly as possible
+尽量	盡量	jin3liang4	jǐnliàng	as much as possible; to the best of one's ability (jìn-: eat or drink to one's fill)
+紧急	緊急	jin3ji2	jǐnjí	urgent; pressing
+谨慎	謹慎	jin3shen4	jǐnshèn	cautious; prudent
+尽力	盡力	jin4 li4	jìn lì	do one's best; to strive as much as possible
+进步	進步	jin4bu4	jìnbù	make progress; to advance
+进口	進口	jin4 kou3	jìn kǒu	import; entrance; enter
+近代	近代	jin4dai4	jìndài	modern times; latest generation
+经典	經典	jing1dian3	jīngdiǎn	classics; scriptures
+经商	經商	jing1 shang1	jīng shāng	trade; be in business; do commerce
+经营	經營	jing1ying2	jīngyíng	engage in (a business activity, etc.); run/operate (a business)
+精力	精力	jing1li4	jīnglì	energy; vigor
+精神	精神	jing1shen	jīngshen	vigor; spirit; mind
+酒吧	酒吧	jiu3ba1	jiǔbā	bar
+救	救	jiu4	jiù	to save (life); to assist; to rescue
+救护车	救護車	jiu4hu4che1	jiùhùchē	ambulance
+舅舅	舅舅	jiu4jiu	jiùjiu	mother's brother; maternal uncle
+居然	居然	ju1ran2	jūrán	unexpectedly; to one's surprise; go so far as to
+桔子	桔子	ju2zi	júzi	tangerine
+巨大	巨大	ju4da4	jùdà	immense; enormous; very large
+具备	具備	ju4bei4	jùbèi	possess; be equipped with
+具体	具體	ju4ti3	jùtǐ	concrete; definite; specific
+俱乐部	俱樂部	ju4le4bu4	jùlèbù	club (group or organization)
+据说	據說	ju4shuo1	jùshuō	it is said that; reportedly
+捐	捐	juan1	juān	to contribute; to donate; to subsribe to; to abandon; to relinquish; contribution; tax
+决赛	決賽	jue2sai4	juésài	finals (of a competition); final match
+决心	決心	jue2xin1	juéxīn	determination; resolution
+角色	角色	jue2se4	juésè	role; part
+绝对	絕對	jue2dui4	juéduì	absolute; definite
+军事	軍事	jun1shi4	jūnshì	military affairs; military matters
+均匀	均勻	jun1yun2	jūnyún	even; well-distributed
+卡车	卡車	ka3che1	kǎchē	truck
+开发	開發	kai1fa1	kāifā	develop; to exploit (a resource)
+开放	開放	kai1fang4	kāifàng	(of flowers) to bloom; open up; to be open-minded; lift a ban, restriction, etc.; release; liberalization; China's 1979 open policy
+开幕式	開幕式	kai1mu4shi4	kāimùshì	opening ceremony
+开水	開水	kai1shui3	kāishuǐ	boiled water; boil water
+砍	砍	kan3	kǎn	to chop; cut down
+看不起	看不起	kan4 bu qi3	kàn bu qǐ	look down upon; despise
+看望	看望	kan4wang4	kànwàng	visit; call on; see
+靠	靠	kao4	kào	depend on; lean on; near; to trust
+颗	顆	ke1	kē	(mw for hearts and small, round things like seeds, grains, beans, etc.)
+可见	可見	ke3jian4	kějiàn	it can clearly be seen that; clear
+可靠	可靠	ke3kao4	kěkào	reliable
+可怕	可怕	ke3pa4	kěpà	terrible; awful; frightful; scary
+克	克	ke4	kè	gram; overcome; restrain
+克服	克服	ke4fu2	kèfú	overcome (hardships, etc.); conquer
+刻苦	刻苦	ke4ku3	kèkǔ	hardworking; assiduous
+客观	客觀	ke4guan1	kèguān	objective; impartial; unbiased
+课程	課程	ke4cheng2	kèchéng	course; curriculum; class
+空间	空間	kong1jian1	kōngjiān	space
+空闲	空閑	kong4xian2	kòngxián	leisure; free time; idle; unused
+控制	控制	kong4zhi4	kòngzhì	to control
+口味	口味	kou3wei4	kǒuwèi	a person's tastes or preferences
+夸	誇	kua1	kuā	to boast; to praise; exaggerate
+夸张	誇張	kua1zhang1	kuāzhāng	exaggerate; overstate; exaggerated; overstated; vaunted; hyperbole
+会计	會計	kuai4ji4	kuàijì	accountant; accounting
+宽	寬	kuan1	kuān	wide; broad; relaxed; lenient
+昆虫	昆蟲	kun1chong2	kūnchóng	insect
+扩大	擴大	kuo4da4	kuòdà	enlarge; expand
+辣椒	辣椒	la4jiao1	làjiāo	hot pepper; chili
+拦	攔	lan2	lán	to block; to cut off; hinder
+烂	爛	lan4	làn	overcooked; rotten; soft; mushy
+朗读	朗讀	lang3du2	lǎngdú	read aloud
+劳动	勞動	lao2dong4	láodòng	work; toil; (physical) labor
+劳驾	勞駕	lao2 jia4	láo jià	excuse me
+老百姓	老百姓	lao3bai3xing4	lǎobǎixìng	ordinary people; the person on the street; civilians
+老板	老板	lao3ban3	lǎobǎn	boss; proprietor; shopkeeper
+老婆	老婆	lao3po2	lǎopó	(informal) wife
+老实	老實	lao3shi	lǎoshi	honest; sincere; naive; simpleminded
+老鼠	老鼠	lao3shu3	lǎoshǔ	rat; mouse
+姥姥	姥姥	lao3lao	lǎolao	maternal grandmother
+乐观	樂觀	le4guan1	lèguān	optimism; hopeful
+雷	雷	lei2	léi	thunder
+类型	類型	lei4xing2	lèixíng	type
+冷淡	冷淡	leng3dan4	lěngdàn	cold; chill; indifferent; unconcerned
+厘米	厘米	li2mi3	límǐ	centimeter
+离婚	離婚	li2 hun1	lí hūn	to divorce; divorced from (one's spouse)
+梨	梨	li2	lí	pear
+理论	理論	li3lun4	lǐlùn	theory
+理由	理由	li3you2	lǐyóu	a reason; grounds; argument
+力量	力量	li4liang	lìliang	power; force; strength
+立即	立即	li4ji2	lìjí	immediately
+立刻	立刻	li4ke4	lìkè	immediately; at once; right away
+利润	利潤	li4run4	lìrùn	profit
+利息	利息	li4xi1	lìxī	interest (on a loan)
+利益	利益	li4yi4	lìyì	benefit; (in sb.'s) interest
+利用	利用	li4yong4	lìyòng	to use; to make use of; to exploit
+连忙	連忙	lian2mang2	liánmáng	promptly; at once
+连续	連續	lian2xu4	liánxù	continually; in a row; successively
+联合	聯合	lian2he2	liánhé	alliance; combine; unite
+恋爱	戀愛	lian4'ai4	liàn'ài	romantic love; be in love; love affair
+良好	良好	liang2hao3	liánghǎo	good; favorable; well
+粮食	糧食	liang2shi	liángshi	grain; food; cereals
+亮	亮	liang4	liàng	bright; light; shiny
+了不起	了不起	liao3buqi3	liǎobuqǐ	incredible; extraordinary; great; amazing
+列车	列車	lie4che1	lièchē	train (railway term)
+临时	臨時	lin2shi2	línshí	temporary; at the time; when the time comes
+灵活	靈活	ling2huo2	línghuó	flexible; nimble; agile
+铃	鈴	ling2	líng	bell
+零件	零件	ling2jian4	língjiàn	spare parts; component
+零食	零食	ling2shi2	língshí	snack
+领导	領導	ling3dao3	lǐngdǎo	to lead; leader; leadership
+领域	領域	ling3yu4	lǐngyù	domain; sphere; field; area
+浏览	浏覽	liu2lan3	liúlǎn	browse; glance over; skim through
+流传	流傳	liu2chuan2	liúchuán	to spread; circulate; hand down
+流泪	流淚	liu2lei4	liúlèi	shed tears
+龙	龍	long2	lóng	dragon (Kangxi radical 212)
+漏	漏	lou4	lòu	to leak; to funnel; to let out
+陆地	陸地	lu4di4	lùdì	land; dry land (as opposed to the sea)
+陆续	陸續	lu4xu4	lùxù	in turn; successively; one after another
+录取	錄取	lu4qu3	lùqǔ	recruit; enroll; matriculate
+录音	錄音	lu4yin1	lùyīn	sound recording; to record
+轮流	輪流	lun2liu2	lúnliú	to alternate; take turns; rotate
+论文	論文	lun4wen2	lùnwén	thesis; paper; treatise
+逻辑	邏輯	luo2ji	luóji	logic
+落后	落後	luo4hou4	luòhòu	backward; to lag (in technology); to fall behind
+骂	罵	ma4	mà	scold; curse; condemn; verbally abuse
+麦克风	麥克風	mai4ke4feng1	màikèfēng	microphone
+馒头	饅頭	man2tou	mántou	steamed bun/roll
+满足	滿足	man3zu2	mǎnzú	satisfy; meet (the needs of)
+毛病	毛病	mao2bing4	máobìng	fault; bad habit; shortcoming
+矛盾	矛盾	mao2dun4	máodùn	contradiction; conflict
+冒险	冒險	mao4xian3	màoxiǎn	take a risk; take chances
+贸易	貿易	mao4yi4	màoyì	(commercial) trade
+眉毛	眉毛	mei2mao	méimao	eyebrow
+媒体	媒體	mei2ti3	méitǐ	(news) media; medium
+煤炭	煤炭	mei2tan4	méitàn	coal
+美术	美術	mei3shu4	měishù	the fine arts; art
+魅力	魅力	mei4li4	mèilì	charm; glamour; enchantment
+梦想	夢想	meng4xiang3	mèngxiǎng	dream of; wishful thinking
+秘密	秘密	mi4mi4	mìmì	a secret; confidential
+秘书	秘書	mi4shu	mìshu	secretary
+密切	密切	mi4qie4	mìqiè	close; familiar; intimate
+蜜蜂	蜜蜂	mi4feng1	mìfēng	bee; honeybee
+面对	面對	mian4dui4	miànduì	to face; confront
+面积	面積	mian4ji1	miànjī	(surface) area
+面临	面臨	mian4lin2	miànlín	be faced with; be up against
+苗条	苗條	miao2tiao	miáotiao	slim; slender
+描写	描寫	miao2xie3	miáoxiě	to describe; to depict; to portray
+敏感	敏感	ming3an3	mǐngǎn	sensitive; susceptible
+名牌	名牌	ming2pai2	míngpái	famous brand; name brand
+名片	名片	ming2pian4	míngpiàn	business card
+名胜古迹	名勝古迹	ming2sheng4gu3ji4	míngshènggǔjì	famous scenic spots and ancient historic sites
+明确	明確	ming2que4	míngquè	clear-cut; clearly; clarify
+明显	明顯	ming2xian3	míngxiǎn	clear; obvious
+明星	明星	ming2xing1	míngxīng	(movie, etc.) star; celebrity
+命令	命令	ming4ling4	mìnglìng	an order; a command
+命运	命運	ming4yun4	mìngyùn	fate; destiny
+摸	摸	mo1	mō	to touch; to stroke; fish out; feel out
+模仿	模仿	mo2fang3	mófǎng	imitate; to copy
+模糊	模糊	mo2hu	móhu	vague; indistinct; fuzzy; foggy
+模特	模特	mo2te4	mótè	(fashion) model
+摩托车	摩托車	mo2tuo1che1	mótuōchē	motorcycle; motorbike
+陌生	陌生	mo4sheng1	mòshēng	strange; unfamiliar
+某	某	mou3	mǒu	a certain; some
+木头	木頭	mu4tou	mùtou	wood; log; timber
+目标	目標	mu4biao1	mùbiāo	target; goal; objective
+目录	目錄	mu4lu4	mùlù	catalog; table of contents; directory (on computer hard drive)
+目前	目前	mu4qian2	mùqián	at present; now; for the moment
+哪怕	哪怕	na3pa4	nǎpà	even (if/though); no matter how
+难怪	難怪	nang2uai4	nánguài	no wonder
+难免	難免	nan2mian3	nánmiǎn	hard to avoid; difficult to escape from
+脑袋	腦袋	nao3dai	nǎodai	head; mental capability; brains
+内部	內部	nei4bu4	nèibù	internal; interior; inside (part, section)
+内科	內科	nei4ke1	nèikē	internal medicine
+嫩	嫩	nen4	nèn	tender; inexperienced
+能干	能幹	neng2gan4	nénggàn	capable; competent
+能源	能源	neng2yuan2	néngyuán	energy resources; power source
+嗯	嗯	en1	ēn	(interjection expressing what?, huh? hmm? why? ok, etc.)
+年代	年代	nian2dai4	niándài	decade; era
+年纪	年紀	nian2ji4	niánjì	age
+念	念	nian4	niàn	read aloud; to study; to miss or think of somebody
+宁可	甯可	ning4ke3	nìngkě	would rather; it is the lesser of two evils to
+牛仔裤	牛仔褲	niu2zai3ku4	niúzǎikù	jeans; cowboy pants
+农村	農村	nong2cun1	nóngcūn	rural area; countryside
+农民	農民	nong2min2	nóngmín	peasant
+农业	農業	nong2ye4	nóngyè	agriculture; farming
+浓	濃	nong2	nóng	concentrated; dense
+女士	女士	nü3shi4	nǚshì	lady; madam
+欧洲	歐洲	Ōuzhou1	Ōuzhōu	Europe
+偶然	偶然	ou3ran2	ǒurán	accidentally; occasional; fortuitous
+拍	拍	pai1	pāi	to clap; to pat; to shoot (pictures, a film); send (a telegram)
+派	派	pai4	pài	dispatch; (mw for political groups; schools of thought; etc.)
+盼望	盼望	pan4wang4	pànwàng	to hope for; look forward to
+培训	培訓	pei2xun4	péixùn	cultivate; train
+培养	培養	pei2yang3	péiyǎng	to train; cultivate; bring up
+赔偿	賠償	pei2chang2	péicháng	compensate; pay for somebody else's loss
+佩服	佩服	pei4fu	pèifu	admire; to respect
+配合	配合	pei4he2	pèihé	be harmoniously combined or arranged; matching; fitting in with; compatible with; to correspond; to fit; to conform to; rapport; to coordinate with; to act in concern with; to cooperate; to become man and wife; to combine parts of a machine
+盆	盆	pen2	pén	basin; (flower) pot
+碰	碰	peng4	pèng	to touch; to bump; to encounter
+批	批	pi1	pī	criticize; to comment; wholesale; (mw for batches, lots, etc.)
+批准	批准	pi1zhun3	pīzhǔn	approve; ratify
+披	披	pi1	pī	drape over one's shoulders; split open; open
+疲劳	疲勞	pi2lao2	píláo	fatigue; wearily; weariness; tired
+匹	匹	pi3	pǐ	ordinary person; (mw for horses, bolt of cloth)
+片	片	pian4, pian1	piàn, piān	(mw for pieces of things); a slice; a flake (Kangxi radical 91) | film; photo
+片面	片面	pian4mian4	piànmiàn	one-sided; unilateral
+飘	飄	piao1	piāo	to float; flutter
+拼音	拼音	pin1yin1	pīnyīn	pinyin; phonetic writing
+频道	頻道	pin2dao4	píndào	frequency; (television) channel
+平	平	ping2	píng	flat; level; equal; ordinary
+平安	平安	ping2'an1	píng'ān	safe and sound
+平常	平常	ping2chang2	píngcháng	ordinary; usually; common
+平等	平等	ping2deng3	píngděng	equal; equality
+平方	平方	ping2fang1	píngfāng	square (as in square foot, square mile, etc.)
+平衡	平衡	ping2heng2	pínghéng	balance; balanced; equilibrium
+平静	平靜	ping2jing4	píngjìng	calm; peaceful; tranquil; serene
+平均	平均	ping2jun1	píngjūn	average; to share equally
+评价	評價	ping2jia4	píngjià	to evaluate
+凭	憑	ping2	píng	lean against; evidence; proof; no matter (what/how/etc.)
+迫切	迫切	po4qie4	pòqiè	urgent; pressing
+破产	破産	po4 chan3	pò chǎn	go bankrupt; go broke; bankruptcy
+破坏	破壞	po4huai4	pòhuài	destroy; destruction; to wreck; to break
+期待	期待	qi1dai4	qīdài	look forward to; await; expectation
+期间	期間	qi1jian1	qījiān	period of time; time
+其余	其余	qi2yu2	qíyú	the others; the rest; remaining
+奇迹	奇迹	qi2ji4	qíjì	miracle; miraculous; marvel
+企业	企業	qi3ye4	qǐyè	company; business; firm
+启发	啓發	qi3fa1	qǐfā	enlighten; inspire
+气氛	氣氛	qi4fen1	qìfēn	atmosphere; mood; ambience
+汽油	汽油	qi4you2	qìyóu	gasoline; gas; petrol
+谦虚	謙虛	qian1xu1	qiānxū	modest
+签	簽	qian1	qiān	bamboo used for drawing lots; toothpick; to sign (one's name)
+前途	前途	qian2tu2	qiántú	future; prospects; outlook (for the future)
+浅	淺	qian3	qiǎn	shallow; simple; superficial; light (of colors)
+欠	欠	qian4	qiàn	yawn; to lack; owe (Kangxi radical 76)
+枪	槍	qiang1	qiāng	gun; spear
+强调	強調	qiang2diao4	qiángdiào	emphasize; to stress
+强烈	強烈	qiang2lie4	qiángliè	intense; strong; violent
+墙	牆	qiang2	qiáng	wall
+抢	搶	qiang3, qiang1	qiǎng, qiāng	fight over; vie for; grab; rush | bump against
+悄悄	悄悄	qiao1qiao1	qiāoqiāo	quietly
+瞧	瞧	qiao2	qiáo	look at; see (colloquial)
+巧妙	巧妙	qiao3miao4	qiǎomiào	ingenious; clever
+切	切	qie1, qie4	qiē, qiè	to cut; to chop | correspond to; absolutely; ardently
+亲爱	親愛	qin1'ai4	qīn'ài	beloved; Dear ... (a way of starting a letter lovers, intimate friends or close relatives)
+亲切	親切	qin1qie4	qīnqiè	kind; amiable; cordial
+亲自	親自	qin1zi4	qīnzì	personally
+勤奋	勤奮	qin2fen4	qínfèn	hardworking; diligent; industrious
+青	青	qing1	qīng	blue; green; young (Kangxi radical 174); Qinghai province (abbr.)
+青春	青春	qing1chun1	qīngchūn	youth; youthfulness; fresh spring
+青少年	青少年	qing1shao4nian2	qīngshàonián	teenager
+轻视	輕視	qing1shi4	qīngshì	contempt; to scorn; scornful
+轻易	輕易	qing1yi4	qīngyì	easily; lightly; rashly
+清淡	清淡	qing1dan4	qīngdàn	light (of food, not greasy or strongly flavored) ; insipid;  slack (sales)
+情景	情景	qing2jing3	qíngjǐng	scene; sight; circumstances
+情绪	情緒	qing2xu4	qíngxù	emotion; sentiment; mood; morale
+请求	請求	qing3qiu2	qǐngqiú	to request; ask
+庆祝	慶祝	qing4zhu4	qìngzhù	celebrate
+球迷	球迷	qiu2mi2	qiúmí	fan (of ball games: basketball, football, etc.)
+趋势	趨勢	qu1shi4	qūshì	trend; tendency
+取消	取消	qu3xiao1	qǔxiāo	cancel; cancellation; abolish
+娶	娶	qu3	qǔ	marry (a wife); take a wife
+去世	去世	qu4shi4	qùshì	pass away; die
+圈	圈	quan1	quān	circle; ring; (mw for loops, orbits, etc.)
+权力	權力	quan2li4	quánlì	power; authority
+权利	權利	quan2li4	quánlì	right; privilege
+全面	全面	quan2mian4	quánmiàn	all-around; comprehensive; fully
+劝	勸	quan4	quàn	advise; to urge; persuade
+缺乏	缺乏	que1fa2	quēfá	shortage; to lack; be short of
+确定	確定	que4ding4	quèdìng	definite; certain; fixed; determine
+确认	確認	quer4en4	quèrèn	confirm; confirmation; verify
+群	群	qun2	qún	crowd; group; (mw for groups, flocks, or swarms)
+燃烧	燃燒	ran2shao1	ránshāo	combustion; burn; kindle
+绕	繞	rao4	rào	to wind; to coil; move round
+热爱	熱愛	re4'ai4	rè'ài	love ardently; adore; passion
+热烈	熱烈	re4lie4	rèliè	warm; enthusiastic
+热心	熱心	re4xin1	rèxīn	enthusiastic; zealous; warmhearted
+人才	人才	ren2cai2	réncái	talent; talented person
+人口	人口	ren2kou3	rénkǒu	population; the populace
+人类	人類	ren2lei4	rénlèi	humanity; human race; mankind
+人民币	人民幣	ren2min2bi4	rénmínbì	(currency) renminbi (RMB)
+人生	人生	ren2sheng1	rénshēng	human life
+人事	人事	ren2shi4	rénshì	personnel
+人物	人物	ren2wu4	rénwù	figure; personage; character (in a play, story, etc.)
+人员	人員	ren2yuan2	rényuán	staff; crew; personnel
+忍不住	忍不住	ren3 bu zhu4	rěn bu zhù	cannot help but; unable to bear
+日常	日常	ri4chang2	rìcháng	daily; everyday
+日程	日程	ri4cheng2	rìchéng	schedule; itinerary
+日历	日曆	ri4li4	rìlì	calendar
+日期	日期	ri4qi1	rìqī	date
+日用品	日用品	ri4yong4pin3	rìyòngpǐn	daily necessities
+日子	日子	ri4zi	rìzi	days; date; time; life
+如何	如何	ru2he2	rúhé	how; what; what way
+如今	如今	ru2jin1	rújīn	nowadays
+软	軟	ruan3	ruǎn	soft
+软件	軟件	ruan3jian4	ruǎnjiàn	(computer) software
+弱	弱	ruo4	ruò	weak; feeble; young
+洒	灑	sa3	sǎ	to sprinkle; to spray; to spill
+嗓子	嗓子	sang3zi	sǎngzi	throat; voice
+色彩	色彩	se4cai3	sècǎi	tint; color; hue
+杀	殺	sha1	shā	to kill; to murder
+沙漠	沙漠	sha1mo4	shāmò	desert
+沙滩	沙灘	sha1tan1	shātān	sand bar; sand beach
+傻	傻	sha3	shǎ	foolish; fool
+晒	曬	shai4	shài	to dry in the sun; shine upon; to sun; bask
+删除	刪除	shan1chu2	shānchú	to delete
+闪电	閃電	shan3dian4	shǎndiàn	lightning
+扇子	扇子	shan4zi	shànzi	fan (for waving)
+善良	善良	shan4liang2	shànliáng	good and honest; kind-hearted
+善于	善于	shan4yu2	shànyú	be good at; excel at
+伤害	傷害	shang1hai4	shānghài	injure; to harm; wound
+商品	商品	shang1pin3	shāngpǐn	goods; commodity; merchandise
+商务	商務	shang1wu4	shāngwù	business; commercial affairs
+商业	商業	shang1ye4	shāngyè	business; commerce; trade
+上当	上當	shang4 dang4	shàng dàng	be fooled; be duped; be taken in
+蛇	蛇	she2	shé	snake; serpent
+舍不得	舍不得	she3bude	shěbude	hate to part with; begrudge doing something
+设备	設備	she4bei4	shèbèi	equipment; facilities; installations
+设计	設計	she4ji4	shèjì	plan; design
+设施	設施	she4shi1	shèshī	facilities; installation
+射击	射擊	she4ji1	shèjī	to shoot; to fire (a gun)
+摄影	攝影	she4 ying3	shè yǐng	take a photograph; shoot a film
+伸	伸	shen1	shēn	to stretch; extend
+身材	身材	shen1cai2	shēncái	stature; figure; build
+身份	身份	shen1fen4	shēnfèn	identity; status; dignity
+深刻	深刻	shen1ke4	shēnkè	profound; deep
+神话	神話	shen2hua4	shénhuà	mythology; fairy tale
+神秘	神秘	shen2mi4	shénmì	mysterious; mystical
+升	升	sheng1	shēng	rise; hoist; promote; liter
+生产	生産	sheng1chan3	shēngchǎn	to produce; manufacture; give birth to a child
+生动	生動	sheng1dong4	shēngdòng	vivid; lively
+生长	生長	sheng1zhang3	shēngzhǎng	grow; grow up
+声调	聲調	sheng1diao4	shēngdiào	tone; note
+绳子	繩子	sheng2zi	shéngzi	cord; string; rope
+省略	省略	sheng3lüe4	shěnglüè	to omit; to leave out; abbreviate
+胜利	勝利	sheng4li4	shènglì	victory; triumph
+失眠	失眠	shi1mian2	shīmián	lose sleep; insomnia
+失去	失去	shi1qu4	shīqù	to lose (time, an opportunity, work, etc.)
+失业	失業	shi1 ye4	shī yè	lose one's job; unemployment
+诗	詩	shi1	shī	poem; poetry; verse
+狮子	獅子	shi1zi	shīzi	lion
+湿润	濕潤	shi1run4	shīrùn	moist; humid
+石头	石頭	shi2tou	shítou	stone; rock
+时差	時差	shi2cha1	shíchā	jetlag; time difference
+时代	時代	shi2dai4	shídài	age; era; period
+时刻	時刻	shi2ke4	shíkè	moment; constantly
+时髦	時髦	shi2mao2	shímáo	fashionable
+时期	時期	shi2qi1	shíqī	period in time or history; period; time
+时尚	時尚	shi2shang4	shíshàng	fashion; fad
+实话	實話	shi2hua4	shíhuà	truth
+实践	實踐	shi2jian4	shíjiàn	practice; put into practice; carry out
+实习	實習	shi2xi2	shíxí	to practice; field work; work as an intern
+实现	實現	shi2xian4	shíxiàn	achieve; to implement
+实验	實驗	shi2yan4	shíyàn	experiment; test
+实用	實用	shi2yong4	shíyòng	practical; pragmatic; functional
+食物	食物	shi2wu4	shíwù	food
+使劲儿	使勁兒	shi3jin4r	shǐjìnr	exert all one's strength
+始终	始終	shi3zhong1	shǐzhōng	from beginning to end; all along
+士兵	士兵	shi4bing1	shìbīng	soldier
+市场	市場	shi4chang3	shìchǎng	market
+似的	似的	shi4de	shìde	seems as if; rather like
+事实	事實	shi4shi2	shìshí	fact; in fact
+事物	事物	shi4wu4	shìwù	thing; object
+事先	事先	shi4xian1	shìxiān	in advance; beforehand; prior
+试卷	試卷	shi4juan4	shìjuàn	exam paper; test paper
+收获	收獲	shou1huo4	shōuhuò	harvest; acquisition; gain
+收据	收據	shou1ju4	shōujù	receipt
+手工	手工	shou3gong1	shǒugōng	hand-made; handicraft; manual
+手术	手術	shou3shu4	shǒushù	surgery; operation
+手套	手套	shou3tao4	shǒutào	glove; mitten
+手续	手續	shou3xu4	shǒuxù	formalities; procedure
+手指	手指	shou3zhi3	shǒuzhǐ	finger
+首	首	shou3	shǒu	head; chief; first; (mw for poems and songs) (Kangxi radical 185)
+寿命	壽命	shou4ming4	shòumìng	life span; life expectancy
+受伤	受傷	shou4 shang1	shòu shāng	sustain injuries (in an accident, etc.); be injured
+书架	書架	shu1jia4	shūjià	bookshelf
+梳子	梳子	shu1zi	shūzi	comb; hairbrush
+舒适	舒適	shu1shi4	shūshì	cozy; comfortable; snug
+输入	輸入	shu1ru4	shūrù	input; enter; import
+蔬菜	蔬菜	shu1cai4	shūcài	vegetables; produce
+熟练	熟練	shu2lian4	shúliàn	practiced; proficient; skilled
+属于	屬于	shu3yu2	shǔyú	belong to; be part of
+鼠标	鼠標	shu3 biao1	shǔ biāo	mouse (computer)
+数	數	shu4, shu3	shù, shǔ	number | to count; to rank
+数据	數據	shu4ju4	shùjù	data; numbers; digital
+数码	數碼	shu4ma3	shùmǎ	numeral; number; amount; digital
+摔倒	摔倒	shuai1dao3	shuāidǎo	fall down; slip and fall; tumble; trip
+甩	甩	shuai3	shuǎi	to throw; to fling; to swing; cast off
+双方	雙方	shuang1fang1	shuāngfāng	bilateral; both sides; both parties involved
+税	稅	shui4	shuì	tax
+说不定	說不定	shuo1buding4	shuōbudìng	can't say for sure; perhaps; maybe
+说服	說服	shuo1 fu2	shuō fú	persuade; convince
+丝绸	絲綢	si1chou2	sīchóu	silk
+丝毫	絲毫	si1hao2	sīháo	the slightest amount or degree; a very little bit
+私人	私人	si1ren2	sīrén	private (citizen); personal; individual
+思考	思考	si1kao3	sīkǎo	reflect on; ponder; consider
+思想	思想	si1xiang3	sīxiǎng	thought; thinking; idea; ideology
+撕	撕	si1	sī	to tear (something)
+似乎	似乎	si4hu1	sìhū	it seems; as if; seemingly
+搜索	搜索	sou1suo3	sōusuǒ	search; look for something; scour
+宿舍	宿舍	su4she4	sùshè	dormitory; living quarters; hostel
+随身	隨身	sui2shen1	suíshēn	carry on one's person; bring with one
+随时	隨時	sui2shi2	suíshí	at any time; whenever necessary
+随手	隨手	sui2shou3	suíshǒu	convenient; without extra trouble
+碎	碎	sui4	suì	broken; break into pieces
+损失	損失	sun3shi1	sǔnshī	loss (financial); lose
+缩短	縮短	suo1duan3	suōduǎn	shorten; cut down; curtail
+所	所	suo3	suǒ	place; that which; (mw for houses, buildings)
+锁	鎖	suo3	suǒ	lock
+台阶	台階	tai2jie1	táijiē	flight of steps; sidestep; fig. way out of an embarrassing situation
+太极拳	太極拳	tai4ji2quan2	tàijíquán	Tai chi, a Chinese martial art
+太太	太太	tai4tai	tàitai	wife; married woman; Madame; Mrs.
+谈判	談判	tan2pan4	tánpàn	negotiate; negotiation; conference
+坦率	坦率	tan3shuai4	tǎnshuài	frank
+烫	燙	tang4	tàng	to scald; to burn; scalding hot; to iron
+逃	逃	tao2	táo	to escape; run away; flee
+逃避	逃避	tao2bi4	táobì	to escape; evade; shirk
+桃	桃	tao2	táo	peach
+淘气	淘氣	tao2qi4	táoqì	naughty; bad
+讨价还价	討價還價	tao3 jia4 huan2 jia4	tǎo jià huán jià	bargaining; haggling over price
+套	套	tao4	tào	cover; (mw for sets of things); tie together
+特色	特色	te4se4	tèsè	characteristic; distinguishing feature
+特殊	特殊	te4shu1	tèshū	special; particular; extraordinary; unusual
+特征	特征	te4zheng1	tèzhēng	characteristics; distinctive features; trait
+疼爱	疼愛	teng2 ai4	téng ài	love dearly; be very fond of
+提倡	提倡	ti2chang4	tíchàng	promote; to advocate; proposal
+提纲	提綱	ti2gang1	tígāng	outline; the key point
+提问	提問	ti2wen4	tíwèn	put questions to; to quiz
+题目	題目	ti2mu4	tímù	subject; title; topic
+体会	體會	ti3hui4	tǐhuì	know from experience; learn through experience; realize; understanding; experience
+体贴	體貼	ti3tie1	tǐtiē	show consideration for; thoughtful
+体现	體現	ti3xian4	tǐxiàn	embody; incarnate; reflect; to manifest
+体验	體驗	ti3yan4	tǐyàn	experience for oneself; to personally experience (usually a kind of life)
+天空	天空	tian1kong1	tiānkōng	sky; space; heavens
+天真	天真	tian1zhen1	tiānzhēn	naïve; innocent; artless
+调皮	調皮	tiao2pi2	tiáopí	naughty; mischievous; unruly
+调整	調整	tiao2zheng3	tiáozhěng	adjustment; revision
+挑战	挑戰	tiao3zhan4	tiǎozhàn	challenge
+通常	通常	tong1chang2	tōngcháng	regular; usual; normal; ordinary
+统一	統一	tong3yi1	tǒngyī	unify; unite; integrate; universal
+痛苦	痛苦	tong4ku3	tòngkǔ	pain; suffering; agony
+痛快	痛快	tong4kuai	tòngkuai	joyful; delighted; very happy; jolly
+偷	偷	tou1	tōu	steal; pilfer
+投入	投入	tou2ru4	tóurù	put into operation; throw into; to invest
+投资	投資	tou2 zi1	tóu zī	investment
+透明	透明	tou4ming2	tòumíng	transparent; open (non-secretive)
+突出	突出	tu1chu1	tūchū	prominent; stand out; give prominence to
+土地	土地	tu3di4	tǔdì	land; territory; soil
+土豆	土豆	tu3dou4	tǔdòu	potato
+吐	吐	tu3, tu4	tǔ, tù	to spit | to vomit; throw up
+兔子	兔子	tu4zi	tùzi	rabbit; hare
+团	團	tuan2	tuán	round; ball; group; unite; dumpling; (mw for ball-like things)
+推辞	推辭	tui1ci2	tuīcí	to decline; turn down
+推广	推廣	tui1guang3	tuīguǎng	popularize; to spread
+推荐	推薦	tui1jian4	tuījiàn	recommend; recommendation
+退	退	tui4	tuì	to retreat; decline; withdraw
+退步	退步	tui4bu4	tuìbù	to degenerate; to regress
+退休	退休	tui4xiu1	tuìxiū	retirement (from work); retire
+歪	歪	wai1	wāi	askew; crooked; devious; recline to take a rest (colloquial)
+外公	外公	wai4gong1	wàigōng	maternal grandfather
+外交	外交	wai4jiao1	wàijiāo	diplomacy; foreign affairs
+完美	完美	wan2mei3	wánměi	perfect
+完善	完善	wan2shan4	wánshàn	perfect; make perfect; improve
+完整	完整	wan2zheng3	wánzhěng	complete; intact
+玩具	玩具	wan2ju4	wánjù	plaything; toy
+万一	萬一	wan4yi1	wànyī	just in case; if by any chance
+王子	王子	wang2zi3	wángzǐ	prince; son of a king
+网络	網絡	wang3luo4	wǎngluò	network
+往返	往返	wang3fan3	wǎngfǎn	go back and forth; go to and fro
+危害	危害	wei1hai4	wēihài	endanger; jeopardize; to harm
+威胁	威脅	wei1xie2	wēixié	threaten; to menace
+微笑	微笑	wei1xiao4	wēixiào	smile
+违反	違反	wei2fan3	wéifǎn	violate (a law)
+围巾	圍巾	wei2jin1	wéijīn	scarf; shawl
+围绕	圍繞	wei2rao4	wéirào	revolve around; center on (an issue)
+唯一	唯一	wei2yi1	wéiyī	only; sole
+维修	維修	wei2xiu1	wéixiū	maintain (of equipment); to mend; repair
+伟大	偉大	wei3da4	wěidà	great; mighty; large
+尾巴	尾巴	wei3ba	wěiba	tail
+委屈	委屈	wei3qu	wěiqu	feel wronged; nurse a grievance
+未必	未必	wei4bi4	wèibì	not necessarily; need not
+未来	未來	wei4lai2	wèilái	future
+位于	位于	wei4yu2	wèiyú	be located at
+位置	位置	wei4zhi	wèizhi	position; place; seat
+胃	胃	wei4	wèi	stomach
+胃口	胃口	wei4kou3	wèikǒu	appetite
+温暖	溫暖	wen1nuan3	wēnnuǎn	warm
+温柔	溫柔	wen1rou2	wēnróu	gentle and soft; tender; gentle
+文件	文件	wen2jian4	wénjiàn	document; file
+文具	文具	wen2ju4	wénjù	stationery; writing supplies
+文明	文明	wen2ming2	wénmíng	civilization; civilized; culture
+文学	文學	wen2xue2	wénxué	literature
+文字	文字	wen2zi4	wénzì	characters; script; writing
+闻	聞	wen2	wén	hear; to smell; news; reputation
+吻	吻	wen3	wěn	kiss; lips
+稳定	穩定	wen3ding4	wěndìng	stable; steady
+问候	問候	wen4hou4	wènhòu	send a greeting; send one's regards to
+卧室	臥室	wo4shi4	wòshì	bedroom
+握手	握手	wo4 shou3	wò shǒu	to shake hands
+屋子	屋子	wu1zi	wūzi	room; house
+无奈	無奈	wun2ai4	wúnài	can't help but; have no choice
+无数	無數	wu2shu4	wúshù	countless; innumerable
+无所谓	無所謂	wu2suo3wei4	wúsuǒwèi	doesn't matter; be indifferent
+武术	武術	wu3shu4	wǔshù	martial arts
+勿	勿	wu4	wù	not; do not
+物理	物理	wu4li3	wùlǐ	physics; physical
+物质	物質	wu4zhi4	wùzhì	matter; substance; material
+雾	霧	wu4	wù	fog; mist
+吸取	吸取	xi1qu3	xīqǔ	absorb; assimilate
+吸收	吸收	xi1shou1	xīshōu	absorb; ingest
+戏剧	戲劇	xi4ju4	xìjù	drama; play; theater
+系	系	xi4, ji4	xì, jì	be; relate to; system; fasten; department; faculty; connect | to tie
+系统	系統	xi4tong3	xìtǒng	system
+细节	細節	xi4jie2	xìjié	details; particulars
+瞎	瞎	xia1	xiā	blind
+下载	下載	xia4zai3	xiàzǎi	to download
+吓	嚇	xia4	xià	frighten; to scare; intimidate
+夏令营	夏令營	xia4ling4ying2	xiàlìngyíng	summer camp
+鲜艳	鮮豔	xian1yan4	xiānyàn	bright-colored
+显得	顯得	xian3de	xiǎnde	appear; seem; to look
+显然	顯然	xian3ran2	xiǎnrán	clear; evidently; obviously
+显示	顯示	xian3shi4	xiǎnshì	display, illustrate, to show
+县	縣	xian4	xiàn	county; district
+现代	現代	xian4dai4	xiàndài	modern times; modern age
+现实	現實	xian4shi2	xiànshí	reality; actuality; practical
+现象	現象	xian4xiang4	xiànxiàng	appearance; phenomenon
+限制	限制	xian4zhi4	xiànzhì	restrictions; to limit; to bound
+相处	相處	xiang1chu3	xiāngchǔ	get along; interact
+相当	相當	xiang1dang1	xiāngdāng	equivalent to; appropriate; considerably; quite
+相对	相對	xiang1dui4	xiāngduì	opposite; relatively; to resist
+相关	相關	xiang1guan1	xiāngguān	correlation; interrelated; dependence
+相似	相似	xiang1si4	xiāngsì	similar; resemble; like
+香肠	香腸	xiang1chang2	xiāngcháng	sausage
+享受	享受	xiang3shou4	xiǎngshòu	enjoy
+想念	想念	xiang3nian4	xiǎngniàn	to miss; remember with longing; long to see again
+想象	想象	xiang3xiang4	xiǎngxiàng	imagine; visualize
+项	項	xiang4	xiàng	nape (of the neck); sum (of money); mw item
+项链	項鏈	xiang4lian4	xiàngliàn	necklace
+项目	項目	xiang4mu4	xiàngmù	program; item; project
+象棋	象棋	xiang4qi2	xiàngqí	chess; Chinese chess
+象征	象征	xiang4zheng1	xiàngzhēng	symbol; symbolize; signify
+消费	消費	xiao1fei4	xiāofèi	consumption; spending
+消化	消化	xiao1hua4	xiāohuà	to digest
+消极	消極	xiao1ji2	xiāojí	passive; negative; demoralized
+消失	消失	xiao1shi1	xiāoshī	disappear; fade away; dissolve
+销售	銷售	xiao1shou4	xiāoshòu	to sell; to market; sales
+小麦	小麥	xiao3mai4	xiǎomài	wheat
+小气	小氣	xiao3qi4	xiǎoqì	stingy; petty
+孝顺	孝順	xiao4shun4	xiàoshùn	filial piety
+效率	效率	xiao4lü4	xiàolǜ	efficiency
+歇	歇	xie1	xiē	to rest; to go to bed; to take a break
+斜	斜	xie2	xié	slanting; tilted
+写作	寫作	xie3zuo4	xiězuò	writing; composition; written works
+血	血	xue4	xuè	blood (Kangxi radical 143)
+心理	心理	xin1li3	xīnlǐ	psychology; psychological; mental
+心脏	心髒	xin1zang4	xīnzàng	heart
+欣赏	欣賞	xin1shang3	xīnshǎng	appreciate; enjoy; admire
+信号	信號	xin4hao4	xìnhào	signal
+信任	信任	xin4ren4	xìnrèn	to trust; have confidence in
+行动	行動	xing2dong4	xíngdòng	to move; get around; action
+行人	行人	xing2ren2	xíngrén	pedestrian
+行为	行爲	xing2wei2	xíngwéi	action; behavior; conduct
+形成	形成	xing2cheng2	xíngchéng	take shape; form
+形容	形容	xing2rong2	xíngróng	describe; appearance; look
+形式	形式	xing2shi4	xíngshì	form; shape; situation
+形势	形勢	xing2shi4	xíngshì	circumstances; situation; terrain
+形象	形象	xing2xiang4	xíngxiàng	image; form; figure
+形状	形狀	xing2zhuang4	xíngzhuàng	form; figure; shape
+幸亏	幸虧	xing4kui1	xìngkuī	fortunately; luckily
+幸运	幸運	xing4yun4	xìngyùn	luck; fortune
+性质	性質	xing4zhi4	xìngzhì	nature; characteristic; quality
+兄弟	兄弟	xiong1di4	xiōngdì	brothers; younger brother; brethren
+胸	胸	xiong1	xiōng	chest; bosom; heart
+休闲	休閑	xiu1xian2	xiūxián	recreation; leisure
+修改	修改	xiu1gai3	xiūgǎi	amend; modify; revise; alter
+虚心	虛心	xu1xin1	xūxīn	modest; open-minded
+叙述	敘述	xu4shu4	xùshù	retell; narrate
+宣布	宣布	xuan1bu4	xuānbù	announce; declare; proclaim
+宣传	宣傳	xuan1chuan2	xuānchuán	propaganda; to propagate; to give publicity to
+学历	學曆	xue2li4	xuélì	educational background; school record
+学术	學術	xue2shu4	xuéshù	learning; science; academic
+学问	學問	xue2wen	xuéwen	learning; knowledge
+寻找	尋找	xun2zhao3	xúnzhǎo	seek; look for; quest
+询问	詢問	xun2wen4	xúnwèn	inquire about
+训练	訓練	xun4lian4	xùnliàn	to train; to drill; to exercise; training
+迅速	迅速	xun4su4	xùnsù	fast; quick; rapid
+押金	押金	ya1jin1	yājīn	security deposit; down payment
+牙齿	牙齒	ya2chi3	yáchǐ	tooth
+延长	延長	yan2chang2	yáncháng	extend; prolong; lengthen
+严肃	嚴肅	yan2su4	yánsù	solemn; serious; earnest
+演讲	演講	yan3jiang3	yǎnjiǎng	give a lecture; make a speech
+宴会	宴會	yan4hui4	yànhuì	banquet; feast; dinner party
+阳台	陽台	yang2tai2	yángtái	balcony
+痒	癢	yang3	yǎng	to itch; itchy
+样式	樣式	yang4shi4	yàngshì	type; style; form
+腰	腰	yao1	yāo	waist; lower back; pocket
+摇	搖	yao2	yáo	to shake; to rock
+咬	咬	yao3	yǎo	to bite; to nip
+要不	要不	yao4bu4	yàobù	otherwise; or else; how about
+业务	業務	ye4wu4	yèwù	business; profession
+业余	業余	ye4yu2	yèyú	spare time; amateur
+夜	夜	ye4	yè	night; darkness
+一辈子	一輩子	yi2bei4zi	yíbèizi	(for) a lifetime; all one's life
+一旦	一旦	yi2dan4	yídàn	in case (something happens); once (sth. has happened ... then); in one day
+一律	一律	yi2lü4	yílǜ	same; uniformly; all; without exception
+一再	一再	yi2zai4	yízài	repeatedly; again and again
+一致	一致	yi2zhi4	yízhì	unanimous; identical (views or opinions); consistent
+依然	依然	yi1ran2	yīrán	still; as before
+移动	移動	yi2dong4	yídòng	to move
+移民	移民	yi2min2	yímín	immigrate; emigrate; migrate
+遗憾	遺憾	yi2han4	yíhàn	regret; pity; sorry
+疑问	疑問	yi2wen4	yíwèn	doubt; question; to query
+乙	乙	yi3	yǐ	two; twist (2nd Heavenly Stem) (Kangxi radical 5)
+以及	以及	yi3ji2	yǐjí	as well as; too; (formal) and
+以来	以來	yi3lai2	yǐlái	since (a previous event)
+亿	億	yi4	yì	one hundred million (100,000,000)
+义务	義務	yi4wu4	yìwù	duty; obligation; volunteer duty
+议论	議論	yi4lun4	yìlùn	discuss; to comment; talk about
+意外	意外	yi4wai4	yìwài	unexpected; accident; mishap
+意义	意義	yi4yi4	yìyì	meaning; significance
+因而	因而	yin1'er2	yīn'ér	therefore; as a result; thus
+因素	因素	yin1su4	yīnsù	element; factor
+银	銀	yin2	yín	silver (the element)
+印刷	印刷	yin4shua1	yìnshuā	print
+英俊	英俊	ying1jun4	yīngjùn	handsome
+英雄	英雄	ying1xiong2	yīngxióng	hero
+迎接	迎接	ying2jie1	yíngjiē	meet; greet; to welcome
+营养	營養	ying2yang3	yíngyǎng	nutrition; nourishment; sustenance
+营业	營業	ying2ye4	yíngyè	do business; to trade
+影子	影子	ying3zi	yǐngzi	shadow; reflection
+应付	應付	ying4fu	yìngfu	to cope with; deal with; handle; do sth. perfunctorily; do sth. after a fashion; make do
+应用	應用	ying4yong4	yìngyòng	to apply; to use; application
+硬	硬	ying4	yìng	hard; stiff; obstinately
+硬件	硬件	ying4jian4	yìngjiàn	hardware
+拥抱	擁抱	yong1bao4	yōngbào	embrace; to hug
+拥挤	擁擠	yong1ji3	yōngjǐ	to crowd; to push; to squeeze
+勇气	勇氣	yong3qi4	yǒngqì	courage; valor
+用功	用功	yong4 gong1	yòng gōng	diligent; industrious; hardworking
+用途	用途	yong4tu2	yòngtú	use; application; purpose
+优惠	優惠	you1hui4	yōuhuì	preferential; favorable
+优美	優美	you1mei3	yōuměi	graceful; fine; elegant
+优势	優勢	you1shi4	yōushì	advantage; superiority; dominant position
+悠久	悠久	you1jiu3	yōujiǔ	established; long; longstanding
+犹豫	猶豫	you2yu4	yóuyù	hesitate; hesitant; undecided
+油炸	油炸	you2zha2	yóuzhá	deep fry
+游览	遊覽	you2lan3	yóulǎn	go sight-seeing; tour
+有利	有利	you3li4	yǒulì	advantageous; beneficial
+幼儿园	幼兒園	you4'er2yuan2	yòu'éryuán	kindergarten; nursery school
+娱乐	娛樂	yu2le4	yúlè	entertain; amuse; entertainment
+与其	與其	yu3qi2	yǔqí	rather than; better than
+语气	語氣	yu3qi4	yǔqì	tone; manner of speaking; mood
+玉米	玉米	yu4mi3	yùmǐ	corn; maize
+预报	預報	yu4bao4	yùbào	to predict; forecast
+预订	預訂	yu4ding4	yùdìng	place an order; book ahead; subscribe for
+预防	預防	yu4fang2	yùfáng	prevent; take precautions against
+元旦	元旦	yuan2dan4	yuándàn	New Year's Day
+员工	員工	yuang2ong1	yuángōng	employee; staff; personnel
+原料	原料	yuan2liao4	yuánliào	raw material; ingredients
+原则	原則	yuan2ze2	yuánzé	principle; doctrine
+圆	圓	yuan2	yuán	round; circular; formal unit of Chinese currency
+愿望	願望	yuan4wang4	yuànwàng	desire; wish; aspiration
+乐器	樂器	yue4qi4	yuèqì	musical instrument
+晕	暈	yun1	yūn	dizzy; to fain
+运气	運氣	yun4qi	yùnqi	luck
+运输	運輸	yun4shu1	yùnshū	transport; transportation
+运用	運用	yun4yong4	yùnyòng	to use; apply
+灾害	災害	zai1hai4	zāihài	disaster; calamity
+再三	再三	zai4san1	zàisān	over and over again; repeatedly
+在乎	在乎	zai4hu	zàihu	care about; be determined by; to mind
+在于	在于	zai4yu2	zàiyú	lie in; be in; rest with; depend on
+赞成	贊成	zan4cheng2	zànchéng	approve; endorse
+赞美	贊美	zan4mei3	zànměi	admire; applause; to praise
+糟糕	糟糕	zao1gao1	zāogāo	terrible; too bad; how terrible; what bad luck; what a mess
+造成	造成	zao4cheng2	zàochéng	to cause; make; bring out
+则	則	ze2	zé	standard; regulation; however; in that case
+责备	責備	ze2bei4	zébèi	to blame; criticize (sb.); accuse
+摘	摘	zhai1	zhāi	to pick (flowers, fruit, etc.); to pluck; to take; to borrow
+窄	窄	zhai3	zhǎi	narrow; petty; hard-up
+粘贴	粘貼	zhan1tie1	zhāntiē	to paste
+展开	展開	zhan3 kai1	zhǎn kāi	spread out; unfold; carry out; in full swing
+展览	展覽	zhan3lan3	zhǎnlǎn	put on display; to exhibit; exhibition
+占	占	zhan4	zhàn	occupy; seize; to constitute
+战争	戰爭	zhan4zheng1	zhànzhēng	war; conflict
+长辈	長輩	zhang3bei4	zhǎngbèi	an elder; an elder generation
+涨	漲	zhang3, zhang4	zhǎng, zhàng	to rise (of prices, rivers); to go up | to swell; to bloat
+掌握	掌握	zhang3wo4	zhǎngwò	to grasp; to master; to control
+账户	賬戶	zhang4hu4	zhànghù	bank account
+招待	招待	zhao1dai4	zhāodài	receive (guests); entertain; reception
+着火	著火	zhao2huo3	zháohuǒ	catch fire; ignite
+着凉	著涼	zhao2 liang2	zháo liáng	catch a cold
+召开	召開	zhao4kai1	zhàokāi	convene (a conference or meeting); call together
+照常	照常	zhao4chang2	zhàocháng	as usual; normal
+哲学	哲學	zhe2xue2	zhéxué	philosophy
+针对	針對	zhen1dui4	zhēnduì	in connection with; directed towards
+珍惜	珍惜	zhen1xi1	zhēnxī	to treasure; cherish; to value
+真实	真實	zhen1shi2	zhēnshí	true; real; authentic
+诊断	診斷	zhen3duan4	zhěnduàn	diagnosis; diagnose
+阵	陣	zhen4	zhèn	short period; disposition of troops; wave
+振动	振動	zhen4dong4	zhèndòng	vibrate; vibration
+争论	爭論	zheng1lun4	zhēnglùn	argue; to dispute; contend; argument
+争取	爭取	zheng1qu3	zhēngqǔ	fight for; compete for; strive
+征求	征求	zheng1qiu2	zhēngqiú	solicit; seek; ask for; to request
+睁	睜	zheng1	zhēng	to open (eyes)
+整个	整個	zheng3ge4	zhěnggè	whole; entire; total
+整齐	整齊	zheng3qi2	zhěngqí	tidy; neat; in good order
+整体	整體	zheng3ti3	zhěngtǐ	whole; entirety
+正	正	zheng4	zhèng	straight; currently; correct; just (right); pure; precisely
+证件	證件	zheng4jian4	zhèngjiàn	paperwork; credentials; papers; certificates
+证据	證據	zheng4ju4	zhèngjù	evidence; proof; testimony
+政府	政府	zheng4fu3	zhèngfǔ	government
+政治	政治	zheng4zhi4	zhèngzhì	politics
+挣	掙	zheng4, zheng1	zhèng, zhēng	to earn | to struggle
+支	支	zhi1	zhī	branch; support; put up; (mw for long; narrow objects) (Kangxi radical 65)
+支票	支票	zhi1piao4	zhīpiào	(bank) check
+执照	執照	zhi2zhao4	zhízhào	a license; a permit
+直	直	zhi2	zhí	straight; vertical; frank; directly; continuously
+指导	指導	zhi3dao3	zhǐdǎo	to guide; give directions
+指挥	指揮	zhi3hui1	zhǐhuī	to command; to conduct; commander
+至今	至今	zhi4 jin1	zhì jīn	up to now; so far
+至于	至于	zhi4yu2	zhìyú	as for; go so far as to
+志愿者	志願者	zhi4yuan4zhe3	zhìyuànzhě	volunteer
+制定	制定	zhi4ding4	zhìdìng	formulate; lay down (a plan or policy); to draft
+制度	制度	zhi4du4	zhìdù	system; institution
+制造	制造	zhi4zao4	zhìzào	manufacture; make
+制作	制作	zhi4zuo4	zhìzuò	make; manufacture
+治疗	治療	zhi4liao2	zhìliáo	to treat; to cure; medical treatment
+秩序	秩序	zhi4xu4	zhìxù	order; sequence
+智慧	智慧	zhi4hui4	zhìhuì	wisdom; knowledge
+中介	中介	zhong1jie4	zhōngjiè	agent; act as an intermediary
+中心	中心	zhong1xin1	zhōngxīn	center; heart; core
+中旬	中旬	zhong1xun2	zhōngxún	middle third of a month
+种类	種類	zhong3lei4	zhǒnglèi	kind; category; class
+重大	重大	zhong4da4	zhòngdà	great; important; major
+重量	重量	zhong4liang4	zhòngliàng	weight
+周到	周到	zhou1dao4	zhōudào	thoughtful; considerate; thorough
+猪	豬	zhu1	zhū	pig
+竹子	竹子	zhu2zi	zhúzi	bamboo
+逐步	逐步	zhu2bu4	zhúbù	step by step; gradually
+逐渐	逐漸	zhu2jian4	zhújiàn	gradually; by degrees
+主持	主持	zhu3chi2	zhǔchí	preside over; manage; to direct
+主动	主動	zhu3dong4	zhǔdòng	to take initiative; voluntary
+主观	主觀	zhu3guan1	zhǔguān	subjective
+主人	主人	zhu3ren2	zhǔrén	master; host; owner
+主任	主任	zhu3ren4	zhǔrèn	director; head; chief
+主题	主題	zhu3ti2	zhǔtí	theme; subject; topic
+主席	主席	zhu3xi2	zhǔxí	chairperson; president
+主张	主張	zhu3zhang1	zhǔzhāng	to advocate; viewpoint; position
+煮	煮	zhu3	zhǔ	to boil; to cook
+注册	注冊	zhu4ce4	zhùcè	register; registration; enroll
+祝福	祝福	zhu4fu2	zhùfú	blessings; wish well
+抓	抓	zhua1	zhuā	to carry in your hand holding strongly; catch; arrest
+抓紧	抓緊	zhua1 jin3	zhuā jǐn	to grasp firmly; to pay close or special attention to; to rush in; to make the most of
+专家	專家	zhuan1jia1	zhuānjiā	expert; specialist
+专心	專心	zhuan1xin1	zhuānxīn	be absorbed; concentrate; attentive
+转变	轉變	zhuan3bian4	zhuǎnbiàn	to change; to transform
+转告	轉告	zhuang3ao4	zhuǎngào	pass on; to communicate; to transmit
+装	裝	zhuang1	zhuāng	to load; dress up; pretend; clothing; to install
+装饰	裝飾	zhuang1shi4	zhuāngshì	decorate
+装修	裝修	zhuang1xiu1	zhuāngxiū	renovate; to fit up
+状况	狀況	zhuang4kuang4	zhuàngkuàng	condition; state; situation
+状态	狀態	zhuang4tai4	zhuàngtài	state of affairs; condition; state
+撞	撞	zhuang4	zhuàng	to hit; collide; run into
+追	追	zhui1	zhuī	pursue; chase
+追求	追求	zhui1qiu2	zhuīqiú	pursue; seek
+咨询	咨詢	zi1xun2	zīxún	request information; consultant; advisory
+姿势	姿勢	zi1shi4	zīshì	posture; position; pose
+资格	資格	zi1ge2	zīgé	qualifications; seniority
+资金	資金	zi1jin1	zījīn	funds; funding
+资料	資料	zi1liao4	zīliào	data; material; resources; information
+资源	資源	zi1yuan2	zīyuán	natural resource; resource
+紫	紫	zi3	zǐ	purple
+自从	自從	zi4cong2	zìcóng	since; ever since
+自动	自動	zi4dong4	zìdòng	automatic
+自豪	自豪	zi4hao2	zìháo	(feel a sense of) pride
+自觉	自覺	zi4jue2	zìjué	conscious; be aware of; self-motivated
+自私	自私	zi4si1	zìsī	selfish
+自由	自由	zi4you2	zìyóu	freedom; free; liberty
+自愿	自願	zi4yuan4	zìyuàn	voluntary
+字母	字母	zi4mu3	zìmǔ	letter (of the alphabet)
+字幕	字幕	zi4mu4	zìmù	subtitles; captions
+综合	綜合	zong1he2	zōnghé	synthesized; composite; summarize
+总裁	總裁	zong3cai2	zǒngcái	director-general; president
+总共	總共	zong3gong4	zǒnggòng	altogether; in sum; in all; in total
+总理	總理	zong3li3	zǒnglǐ	premier; prime minister
+总算	總算	zong3suan4	zǒngsuàn	at long last; finally; on the whole
+总统	總統	zong3tong3	zǒngtǒng	president (of a country)
+总之	總之	zong3zhi1	zǒngzhī	in a word; in short; in brief / anyway; anyhow
+阻止	阻止	zu3zhi3	zǔzhǐ	prevent; to block
+组	組	zu3	zǔ	compose; team up; group
+组成	組成	zu3cheng2	zǔchéng	to form; part; element; constitute
+组合	組合	zu3he2	zǔhé	assemble; combination
+组织	組織	zu3zhi1	zǔzhī	organize; organization
+最初	最初	zui4chu1	zuìchū	first; primary; initial
+醉	醉	zui4	zuì	intoxicated; become drunk
+尊敬	尊敬	zun1jing4	zūnjìng	respect; revere
+遵守	遵守	zun1shou3	zūnshǒu	observe; abide by; comply with; keep (commandments); to respect (an agreement)
+作品	作品	zuo4pin3	zuòpǐn	works (of literature and art)
+作为	作爲	zuo4wei2	zuòwéi	regard as; act as; action; deed
+作文	作文	zuo4 wen2	zuò wén	write an essay; essay

--- a/vocab/mandarin/hsk/5/vocab.json
+++ b/vocab/mandarin/hsk/5/vocab.json
@@ -1,0 +1,9102 @@
+[
+    {
+        "intermediate_1": "ai1",
+        "intermediate_2": "āi",
+        "native_1": "hey!; (interjection of surprise or dissatisfaction)",
+        "primary_1": "哎",
+        "primary_2": "哎"
+    },
+    {
+        "intermediate_1": "ai4",
+        "intermediate_2": "ài",
+        "native_1": "(an exclamation indicating resignation); oh well; oh; mm",
+        "primary_1": "唉",
+        "primary_2": "唉"
+    },
+    {
+        "intermediate_1": "ai4hu4",
+        "intermediate_2": "àihù",
+        "native_1": "cherish; reassure; take good care of",
+        "primary_1": "爱护",
+        "primary_2": "愛護"
+    },
+    {
+        "intermediate_1": "ai4xi1",
+        "intermediate_2": "àixī",
+        "native_1": "cherish; treasure; use sparingly",
+        "primary_1": "爱惜",
+        "primary_2": "愛惜"
+    },
+    {
+        "intermediate_1": "ai4xin1",
+        "intermediate_2": "àixīn",
+        "native_1": "compassion",
+        "primary_1": "爱心",
+        "primary_2": "愛心"
+    },
+    {
+        "intermediate_1": "an1wei4",
+        "intermediate_2": "ānwèi",
+        "native_1": "to comfort; to console",
+        "primary_1": "安慰",
+        "primary_2": "安慰"
+    },
+    {
+        "intermediate_1": "an1zhuang1",
+        "intermediate_2": "ānzhuāng",
+        "native_1": "install; erect; to fix; to mount",
+        "primary_1": "安装",
+        "primary_2": "安裝"
+    },
+    {
+        "intermediate_1": "an4",
+        "intermediate_2": "àn",
+        "native_1": "bank; shore; beach; coast",
+        "primary_1": "岸",
+        "primary_2": "岸"
+    },
+    {
+        "intermediate_1": "an4",
+        "intermediate_2": "àn",
+        "native_1": "dark; gloomy; hidden; secret",
+        "primary_1": "暗",
+        "primary_2": "暗"
+    },
+    {
+        "intermediate_1": "ao2ye4",
+        "intermediate_2": "áoyè",
+        "native_1": "stay up very late or all night",
+        "primary_1": "熬夜",
+        "primary_2": "熬夜"
+    },
+    {
+        "intermediate_1": "ba3wo4",
+        "intermediate_2": "bǎwò",
+        "native_1": "grasp; hold; certainty; assurance",
+        "primary_1": "把握",
+        "primary_2": "把握"
+    },
+    {
+        "intermediate_1": "bai3",
+        "intermediate_2": "bǎi",
+        "native_1": "to put (on); arrange; to sway; pendulum",
+        "primary_1": "摆",
+        "primary_2": "擺"
+    },
+    {
+        "intermediate_1": "ban4li3",
+        "intermediate_2": "bànlǐ",
+        "native_1": "to handle; to transact; to conduct",
+        "primary_1": "办理",
+        "primary_2": "辦理"
+    },
+    {
+        "intermediate_1": "bang4wan3",
+        "intermediate_2": "bàngwǎn",
+        "native_1": "in the evening; when night falls",
+        "primary_1": "傍晚",
+        "primary_2": "傍晚"
+    },
+    {
+        "intermediate_1": "bao1guo3",
+        "intermediate_2": "bāoguǒ",
+        "native_1": "wrap up; bind up; package",
+        "primary_1": "包裹",
+        "primary_2": "包裹"
+    },
+    {
+        "intermediate_1": "bao1han2",
+        "intermediate_2": "bāohán",
+        "native_1": "contain; embody; include",
+        "primary_1": "包含",
+        "primary_2": "包含"
+    },
+    {
+        "intermediate_1": "bao1kuo4",
+        "intermediate_2": "bāokuò",
+        "native_1": "comprise; include; consist of",
+        "primary_1": "包括",
+        "primary_2": "包括"
+    },
+    {
+        "intermediate_1": "bao2",
+        "intermediate_2": "báo",
+        "native_1": "thin; flimsy; weak (first two pronunciations)",
+        "primary_1": "薄",
+        "primary_2": "薄"
+    },
+    {
+        "intermediate_1": "bao3bei4",
+        "intermediate_2": "bǎobèi",
+        "native_1": "treasure; precious things; darling; baby",
+        "primary_1": "宝贝",
+        "primary_2": "寶貝"
+    },
+    {
+        "intermediate_1": "bao3gui4",
+        "intermediate_2": "bǎoguì",
+        "native_1": "valuable; precious; value",
+        "primary_1": "宝贵",
+        "primary_2": "寶貴"
+    },
+    {
+        "intermediate_1": "bao3chi2",
+        "intermediate_2": "bǎochí",
+        "native_1": "to keep; maintain; to hold",
+        "primary_1": "保持",
+        "primary_2": "保持"
+    },
+    {
+        "intermediate_1": "bao3cun2",
+        "intermediate_2": "bǎocún",
+        "native_1": "conserve; preserve; to keep, to save a file in a computer",
+        "primary_1": "保存",
+        "primary_2": "保存"
+    },
+    {
+        "intermediate_1": "bao3liu2",
+        "intermediate_2": "bǎoliú",
+        "native_1": "to reserve; hold back; retain",
+        "primary_1": "保留",
+        "primary_2": "保留"
+    },
+    {
+        "intermediate_1": "bao3xian3",
+        "intermediate_2": "bǎoxiǎn",
+        "native_1": "insurance; insure; safe",
+        "primary_1": "保险",
+        "primary_2": "保險"
+    },
+    {
+        "intermediate_1": "bao4dao4",
+        "intermediate_2": "bàodào",
+        "native_1": "report for duty; to check in; register",
+        "primary_1": "报到",
+        "primary_2": "報到"
+    },
+    {
+        "intermediate_1": "bao4dao4",
+        "intermediate_2": "bàodào",
+        "native_1": "to report; news report",
+        "primary_1": "报道",
+        "primary_2": "報道"
+    },
+    {
+        "intermediate_1": "bao4gao4",
+        "intermediate_2": "bàogào",
+        "native_1": "to report; make known; inform; speech; lecture",
+        "primary_1": "报告",
+        "primary_2": "報告"
+    },
+    {
+        "intermediate_1": "bao4she4",
+        "intermediate_2": "bàoshè",
+        "native_1": "newspaper office",
+        "primary_1": "报社",
+        "primary_2": "報社"
+    },
+    {
+        "intermediate_1": "bao4yuan4",
+        "intermediate_2": "bàoyuàn",
+        "native_1": "complain; grumble",
+        "primary_1": "抱怨",
+        "primary_2": "抱怨"
+    },
+    {
+        "intermediate_1": "bei1",
+        "intermediate_2": "bēi",
+        "native_1": "carry on one's back; to bear",
+        "primary_1": "背",
+        "primary_2": "背"
+    },
+    {
+        "intermediate_1": "bei1guan1",
+        "intermediate_2": "bēiguān",
+        "native_1": "pessimistic",
+        "primary_1": "悲观",
+        "primary_2": "悲觀"
+    },
+    {
+        "intermediate_1": "bei4jing3",
+        "intermediate_2": "bèijǐng",
+        "native_1": "background",
+        "primary_1": "背景",
+        "primary_2": "背景"
+    },
+    {
+        "intermediate_1": "bei4zi",
+        "intermediate_2": "bèizi",
+        "native_1": "quilt; blanket",
+        "primary_1": "被子",
+        "primary_2": "被子"
+    },
+    {
+        "intermediate_1": "ben3ke1",
+        "intermediate_2": "běnkē",
+        "native_1": "undergraduate",
+        "primary_1": "本科",
+        "primary_2": "本科"
+    },
+    {
+        "intermediate_1": "ben3ling3",
+        "intermediate_2": "běnlǐng",
+        "native_1": "skill; ability; capability",
+        "primary_1": "本领",
+        "primary_2": "本領"
+    },
+    {
+        "intermediate_1": "ben3zhi4",
+        "intermediate_2": "běnzhì",
+        "native_1": "essence; nature; innate character",
+        "primary_1": "本质",
+        "primary_2": "本質"
+    },
+    {
+        "intermediate_1": "bi3li4",
+        "intermediate_2": "bǐlì",
+        "native_1": "proportion; scale",
+        "primary_1": "比例",
+        "primary_2": "比例"
+    },
+    {
+        "intermediate_1": "bi3ci3",
+        "intermediate_2": "bǐcǐ",
+        "native_1": "each other; one another",
+        "primary_1": "彼此",
+        "primary_2": "彼此"
+    },
+    {
+        "intermediate_1": "bi4ran2",
+        "intermediate_2": "bìrán",
+        "native_1": "inevitable; certain; necessary",
+        "primary_1": "必然",
+        "primary_2": "必然"
+    },
+    {
+        "intermediate_1": "bi4yao4",
+        "intermediate_2": "bìyào",
+        "native_1": "necessary; essential; indispensable",
+        "primary_1": "必要",
+        "primary_2": "必要"
+    },
+    {
+        "intermediate_1": "bi4jing4",
+        "intermediate_2": "bìjìng",
+        "native_1": "after all; overall; when all is said and done",
+        "primary_1": "毕竟",
+        "primary_2": "畢竟"
+    },
+    {
+        "intermediate_1": "bi4mian3",
+        "intermediate_2": "bìmiǎn",
+        "native_1": "avoid; avert; prevent",
+        "primary_1": "避免",
+        "primary_2": "避免"
+    },
+    {
+        "intermediate_1": "bian1ji2",
+        "intermediate_2": "biānjí",
+        "native_1": "to edit; compile; editor",
+        "primary_1": "编辑",
+        "primary_2": "編輯"
+    },
+    {
+        "intermediate_1": "bian1pao4",
+        "intermediate_2": "biānpào",
+        "native_1": "firecracker; a long string of small firecrackers",
+        "primary_1": "鞭炮",
+        "primary_2": "鞭炮"
+    },
+    {
+        "intermediate_1": "bian4, pian2",
+        "intermediate_2": "biàn, pián",
+        "native_1": "plain; convenient; excretion; formal equivalent to 就 | cheap",
+        "primary_1": "便",
+        "primary_2": "便"
+    },
+    {
+        "intermediate_1": "bian4lun4",
+        "intermediate_2": "biànlùn",
+        "native_1": "argue; debate; argue over",
+        "primary_1": "辩论",
+        "primary_2": "辯論"
+    },
+    {
+        "intermediate_1": "biao1dian3",
+        "intermediate_2": "biāodiǎn",
+        "native_1": "punctuation; punctuation mark; punctuate",
+        "primary_1": "标点",
+        "primary_2": "標點"
+    },
+    {
+        "intermediate_1": "biao1zhi4",
+        "intermediate_2": "biāozhì",
+        "native_1": "sign; mark; signal; symbol",
+        "primary_1": "标志",
+        "primary_2": "標志"
+    },
+    {
+        "intermediate_1": "biao3da2",
+        "intermediate_2": "biǎodá",
+        "native_1": "to express; to voice; convey",
+        "primary_1": "表达",
+        "primary_2": "表達"
+    },
+    {
+        "intermediate_1": "biao3mian4",
+        "intermediate_2": "biǎomiàn",
+        "native_1": "surface; outside; face",
+        "primary_1": "表面",
+        "primary_2": "表面"
+    },
+    {
+        "intermediate_1": "biao3ming2",
+        "intermediate_2": "biǎomíng",
+        "native_1": "make clear; make known",
+        "primary_1": "表明",
+        "primary_2": "表明"
+    },
+    {
+        "intermediate_1": "biao3qing2",
+        "intermediate_2": "biǎoqíng",
+        "native_1": "(facial) expression; express one's feelings",
+        "primary_1": "表情",
+        "primary_2": "表情"
+    },
+    {
+        "intermediate_1": "biao3xian4",
+        "intermediate_2": "biǎoxiàn",
+        "native_1": "to show; to show off; display; performance",
+        "primary_1": "表现",
+        "primary_2": "表現"
+    },
+    {
+        "intermediate_1": "bing1ji1ling2",
+        "intermediate_2": "bīngjīlíng",
+        "native_1": "ice cream",
+        "primary_1": "冰激凌",
+        "primary_2": "冰激淩"
+    },
+    {
+        "intermediate_1": "bing4du2",
+        "intermediate_2": "bìngdú",
+        "native_1": "virus",
+        "primary_1": "病毒",
+        "primary_2": "病毒"
+    },
+    {
+        "intermediate_1": "bo1li",
+        "intermediate_2": "bōli",
+        "native_1": "glass; nylon; plastic",
+        "primary_1": "玻璃",
+        "primary_2": "玻璃"
+    },
+    {
+        "intermediate_1": "bo1fang4",
+        "intermediate_2": "bōfàng",
+        "native_1": "broadcast; transmit",
+        "primary_1": "播放",
+        "primary_2": "播放"
+    },
+    {
+        "intermediate_1": "bo2zi",
+        "intermediate_2": "bózi",
+        "native_1": "neck",
+        "primary_1": "脖子",
+        "primary_2": "脖子"
+    },
+    {
+        "intermediate_1": "bo2wu4guan3",
+        "intermediate_2": "bówùguǎn",
+        "native_1": "museum",
+        "primary_1": "博物馆",
+        "primary_2": "博物館"
+    },
+    {
+        "intermediate_1": "bu3chong1",
+        "intermediate_2": "bǔchōng",
+        "native_1": "replenish; to supplement; to complement",
+        "primary_1": "补充",
+        "primary_2": "補充"
+    },
+    {
+        "intermediate_1": "bu4'an1",
+        "intermediate_2": "bù'ān",
+        "native_1": "uneasy; unstable; disturbed",
+        "primary_1": "不安",
+        "primary_2": "不安"
+    },
+    {
+        "intermediate_1": "bu4de2liao3",
+        "intermediate_2": "bùdéliǎo",
+        "native_1": "extremely; very; terribly; my god! (expression of surprise)",
+        "primary_1": "不得了",
+        "primary_2": "不得了"
+    },
+    {
+        "intermediate_1": "bu2duan4",
+        "intermediate_2": "búduàn",
+        "native_1": "unceasing; uninterrupted; continuously",
+        "primary_1": "不断",
+        "primary_2": "不斷"
+    },
+    {
+        "intermediate_1": "bu2jian4de2",
+        "intermediate_2": "bújiàndé",
+        "native_1": "not necessarily; not likely",
+        "primary_1": "不见得",
+        "primary_2": "不見得"
+    },
+    {
+        "intermediate_1": "bun2ai4fan2",
+        "intermediate_2": "búnàifán",
+        "native_1": "impatience; impatient",
+        "primary_1": "不耐烦",
+        "primary_2": "不耐煩"
+    },
+    {
+        "intermediate_1": "bu4ran2",
+        "intermediate_2": "bùrán",
+        "native_1": "otherwise; not so",
+        "primary_1": "不然",
+        "primary_2": "不然"
+    },
+    {
+        "intermediate_1": "bu4ru2",
+        "intermediate_2": "bùrú",
+        "native_1": "not as good as; inferior to",
+        "primary_1": "不如",
+        "primary_2": "不如"
+    },
+    {
+        "intermediate_1": "bu2 yao4jin3",
+        "intermediate_2": "bú yàojǐn",
+        "native_1": "unimportant; not serious; it doesn't matter",
+        "primary_1": "不要紧",
+        "primary_2": "不要緊"
+    },
+    {
+        "intermediate_1": "bu4zu2",
+        "intermediate_2": "bùzú",
+        "native_1": "insufficient; not enough",
+        "primary_1": "不足",
+        "primary_2": "不足"
+    },
+    {
+        "intermediate_1": "bu4",
+        "intermediate_2": "bù",
+        "native_1": "cloth; announce; to spread",
+        "primary_1": "布",
+        "primary_2": "布"
+    },
+    {
+        "intermediate_1": "bu4zhou4",
+        "intermediate_2": "bùzhòu",
+        "native_1": "step; move; measure; procedure",
+        "primary_1": "步骤",
+        "primary_2": "步驟"
+    },
+    {
+        "intermediate_1": "bu4men2",
+        "intermediate_2": "bùmén",
+        "native_1": "department; branch; section",
+        "primary_1": "部门",
+        "primary_2": "部門"
+    },
+    {
+        "intermediate_1": "cai2chan3",
+        "intermediate_2": "cáichǎn",
+        "native_1": "property; fortune",
+        "primary_1": "财产",
+        "primary_2": "財産"
+    },
+    {
+        "intermediate_1": "cai3fang3",
+        "intermediate_2": "cǎifǎng",
+        "native_1": "interview; gather news; hunt for and collect",
+        "primary_1": "采访",
+        "primary_2": "采訪"
+    },
+    {
+        "intermediate_1": "cai3qu3",
+        "intermediate_2": "cǎiqǔ",
+        "native_1": "carry out or adopt; take(measures, policies, attitudes, etc.)",
+        "primary_1": "采取",
+        "primary_2": "采取"
+    },
+    {
+        "intermediate_1": "cai3hong2",
+        "intermediate_2": "cǎihóng",
+        "native_1": "rainbow",
+        "primary_1": "彩虹",
+        "primary_2": "彩虹"
+    },
+    {
+        "intermediate_1": "cai3",
+        "intermediate_2": "cǎi",
+        "native_1": "step upon; to tread; to stamp",
+        "primary_1": "踩",
+        "primary_2": "踩"
+    },
+    {
+        "intermediate_1": "can1kao3",
+        "intermediate_2": "cānkǎo",
+        "native_1": "reference; consult",
+        "primary_1": "参考",
+        "primary_2": "參考"
+    },
+    {
+        "intermediate_1": "can1yu4",
+        "intermediate_2": "cānyù",
+        "native_1": "participate (in sth.); attach oneself to",
+        "primary_1": "参与",
+        "primary_2": "參與"
+    },
+    {
+        "intermediate_1": "can2kui4",
+        "intermediate_2": "cánkuì",
+        "native_1": "ashamed",
+        "primary_1": "惭愧",
+        "primary_2": "慚愧"
+    },
+    {
+        "intermediate_1": "cao1chang3",
+        "intermediate_2": "cāochǎng",
+        "native_1": "playground; sports field",
+        "primary_1": "操场",
+        "primary_2": "操場"
+    },
+    {
+        "intermediate_1": "cao1 xin1",
+        "intermediate_2": "cāo xīn",
+        "native_1": "worry about",
+        "primary_1": "操心",
+        "primary_2": "操心"
+    },
+    {
+        "intermediate_1": "ce4",
+        "intermediate_2": "cè",
+        "native_1": "book; (mw for books)",
+        "primary_1": "册",
+        "primary_2": "冊"
+    },
+    {
+        "intermediate_1": "ce4yan4",
+        "intermediate_2": "cèyàn",
+        "native_1": "test; exam; to test",
+        "primary_1": "测验",
+        "primary_2": "測驗"
+    },
+    {
+        "intermediate_1": "ceng2jing1",
+        "intermediate_2": "céngjīng",
+        "native_1": "once; (refers to something that happened previously)",
+        "primary_1": "曾经",
+        "primary_2": "曾經"
+    },
+    {
+        "intermediate_1": "cha1zi",
+        "intermediate_2": "chāzi",
+        "native_1": "fork; cross",
+        "primary_1": "叉子",
+        "primary_2": "叉子"
+    },
+    {
+        "intermediate_1": "cha1ju4",
+        "intermediate_2": "chājù",
+        "native_1": "disparity; gap; the difference (in distance; amount; progress; etc.)",
+        "primary_1": "差距",
+        "primary_2": "差距"
+    },
+    {
+        "intermediate_1": "cha1",
+        "intermediate_2": "chā",
+        "native_1": "to insert; stick in; pierce",
+        "primary_1": "插",
+        "primary_2": "插"
+    },
+    {
+        "intermediate_1": "chai1",
+        "intermediate_2": "chāi",
+        "native_1": "unravel; to tear; demolish",
+        "primary_1": "拆",
+        "primary_2": "拆"
+    },
+    {
+        "intermediate_1": "chan3pin3",
+        "intermediate_2": "chǎnpǐn",
+        "native_1": "product; goods; merchandise",
+        "primary_1": "产品",
+        "primary_2": "産品"
+    },
+    {
+        "intermediate_1": "chan3sheng1",
+        "intermediate_2": "chǎnshēng",
+        "native_1": "to produce; emerge; to cause",
+        "primary_1": "产生",
+        "primary_2": "産生"
+    },
+    {
+        "intermediate_1": "chang2tu2",
+        "intermediate_2": "chángtú",
+        "native_1": "long distance",
+        "primary_1": "长途",
+        "primary_2": "長途"
+    },
+    {
+        "intermediate_1": "chang2shi2",
+        "intermediate_2": "chángshí",
+        "native_1": "common sense; general knowledge",
+        "primary_1": "常识",
+        "primary_2": "常識"
+    },
+    {
+        "intermediate_1": "chao1",
+        "intermediate_2": "chāo",
+        "native_1": "to copy; plagiarize; search and confiscate",
+        "primary_1": "抄",
+        "primary_2": "抄"
+    },
+    {
+        "intermediate_1": "chao1ji2",
+        "intermediate_2": "chāojí",
+        "native_1": "super; transcending; high grade",
+        "primary_1": "超级",
+        "primary_2": "超級"
+    },
+    {
+        "intermediate_1": "chao2",
+        "intermediate_2": "cháo",
+        "native_1": "to face; towards; dynasty",
+        "primary_1": "朝",
+        "primary_2": "朝"
+    },
+    {
+        "intermediate_1": "chao2shi1",
+        "intermediate_2": "cháoshī",
+        "native_1": "damp; moist; humid",
+        "primary_1": "潮湿",
+        "primary_2": "潮濕"
+    },
+    {
+        "intermediate_1": "chao3",
+        "intermediate_2": "chǎo",
+        "native_1": "to quarrel; make noise",
+        "primary_1": "吵",
+        "primary_2": "吵"
+    },
+    {
+        "intermediate_1": "chao3 jia4",
+        "intermediate_2": "chǎo jià",
+        "native_1": "to quarrel; to squabble; bicker",
+        "primary_1": "吵架",
+        "primary_2": "吵架"
+    },
+    {
+        "intermediate_1": "chao3",
+        "intermediate_2": "chǎo",
+        "native_1": "to stir-fry; saute",
+        "primary_1": "炒",
+        "primary_2": "炒"
+    },
+    {
+        "intermediate_1": "che1ku4",
+        "intermediate_2": "chēkù",
+        "native_1": "garage",
+        "primary_1": "车库",
+        "primary_2": "車庫"
+    },
+    {
+        "intermediate_1": "che1xiang1",
+        "intermediate_2": "chēxiāng",
+        "native_1": "carriage; railroad car",
+        "primary_1": "车厢",
+        "primary_2": "車廂"
+    },
+    {
+        "intermediate_1": "che4di3",
+        "intermediate_2": "chèdǐ",
+        "native_1": "thorough; complete; completely",
+        "primary_1": "彻底",
+        "primary_2": "徹底"
+    },
+    {
+        "intermediate_1": "chen2mo4",
+        "intermediate_2": "chénmò",
+        "native_1": "silent; uncommunicative",
+        "primary_1": "沉默",
+        "primary_2": "沈默"
+    },
+    {
+        "intermediate_1": "chen4",
+        "intermediate_2": "chèn",
+        "native_1": "avail oneself of; take advantage of (an opportunity or situation)",
+        "primary_1": "趁",
+        "primary_2": "趁"
+    },
+    {
+        "intermediate_1": "cheng1",
+        "intermediate_2": "chēng",
+        "native_1": "weigh; to call; be called",
+        "primary_1": "称",
+        "primary_2": "稱"
+    },
+    {
+        "intermediate_1": "cheng1hu",
+        "intermediate_2": "chēnghu",
+        "native_1": "to call; address as; name",
+        "primary_1": "称呼",
+        "primary_2": "稱呼"
+    },
+    {
+        "intermediate_1": "cheng1zan4",
+        "intermediate_2": "chēngzàn",
+        "native_1": "to praise; to acclaim",
+        "primary_1": "称赞",
+        "primary_2": "稱贊"
+    },
+    {
+        "intermediate_1": "cheng2fen4",
+        "intermediate_2": "chéngfèn",
+        "native_1": "ingredient; composition",
+        "primary_1": "成分",
+        "primary_2": "成分"
+    },
+    {
+        "intermediate_1": "cheng2guo3",
+        "intermediate_2": "chéngguǒ",
+        "native_1": "result; achievement; gain",
+        "primary_1": "成果",
+        "primary_2": "成果"
+    },
+    {
+        "intermediate_1": "cheng2jiu4",
+        "intermediate_2": "chéngjiù",
+        "native_1": "accomplishment; achievement; success",
+        "primary_1": "成就",
+        "primary_2": "成就"
+    },
+    {
+        "intermediate_1": "cheng2li4",
+        "intermediate_2": "chénglì",
+        "native_1": "establish; to set up",
+        "primary_1": "成立",
+        "primary_2": "成立"
+    },
+    {
+        "intermediate_1": "cheng2ren2",
+        "intermediate_2": "chéngrén",
+        "native_1": "adult; to grow up; become full-grown",
+        "primary_1": "成人",
+        "primary_2": "成人"
+    },
+    {
+        "intermediate_1": "cheng2shu2",
+        "intermediate_2": "chéngshú",
+        "native_1": "mature; ripe",
+        "primary_1": "成熟",
+        "primary_2": "成熟"
+    },
+    {
+        "intermediate_1": "cheng2yu3",
+        "intermediate_2": "chéngyǔ",
+        "native_1": "idiom; proverb",
+        "primary_1": "成语",
+        "primary_2": "成語"
+    },
+    {
+        "intermediate_1": "cheng2zhang3",
+        "intermediate_2": "chéngzhǎng",
+        "native_1": "to mature; grow up",
+        "primary_1": "成长",
+        "primary_2": "成長"
+    },
+    {
+        "intermediate_1": "cheng2ken3",
+        "intermediate_2": "chéngkěn",
+        "native_1": "honest; sincere",
+        "primary_1": "诚恳",
+        "primary_2": "誠懇"
+    },
+    {
+        "intermediate_1": "cheng2dan1",
+        "intermediate_2": "chéngdān",
+        "native_1": "undertake; assume (responsibility)",
+        "primary_1": "承担",
+        "primary_2": "承擔"
+    },
+    {
+        "intermediate_1": "cheng2ren4",
+        "intermediate_2": "chéngrèn",
+        "native_1": "to admit; concede; acknowledge",
+        "primary_1": "承认",
+        "primary_2": "承認"
+    },
+    {
+        "intermediate_1": "cheng2shou4",
+        "intermediate_2": "chéngshòu",
+        "native_1": "to bear; support; endure; sustain",
+        "primary_1": "承受",
+        "primary_2": "承受"
+    },
+    {
+        "intermediate_1": "cheng2du4",
+        "intermediate_2": "chéngdù",
+        "native_1": "degree; extent; level",
+        "primary_1": "程度",
+        "primary_2": "程度"
+    },
+    {
+        "intermediate_1": "cheng2xu4",
+        "intermediate_2": "chéngxù",
+        "native_1": "procedure; sequence; program",
+        "primary_1": "程序",
+        "primary_2": "程序"
+    },
+    {
+        "intermediate_1": "chi1kui1",
+        "intermediate_2": "chīkuī",
+        "native_1": "suffer losses; get the worst of",
+        "primary_1": "吃亏",
+        "primary_2": "吃虧"
+    },
+    {
+        "intermediate_1": "chi2tang2",
+        "intermediate_2": "chítáng",
+        "native_1": "pool; pond",
+        "primary_1": "池塘",
+        "primary_2": "池塘"
+    },
+    {
+        "intermediate_1": "chi2zao3",
+        "intermediate_2": "chízǎo",
+        "native_1": "sooner or later",
+        "primary_1": "迟早",
+        "primary_2": "遲早"
+    },
+    {
+        "intermediate_1": "chi2xu4",
+        "intermediate_2": "chíxù",
+        "native_1": "continue; persist",
+        "primary_1": "持续",
+        "primary_2": "持續"
+    },
+    {
+        "intermediate_1": "chi3zi",
+        "intermediate_2": "chǐzi",
+        "native_1": "ruler (measuring instrument)",
+        "primary_1": "尺子",
+        "primary_2": "尺子"
+    },
+    {
+        "intermediate_1": "chi4bang3",
+        "intermediate_2": "chìbǎng",
+        "native_1": "wing",
+        "primary_1": "翅膀",
+        "primary_2": "翅膀"
+    },
+    {
+        "intermediate_1": "chong1",
+        "intermediate_2": "chōng",
+        "native_1": "to rush; to clash; to rinse; thoroughfare",
+        "primary_1": "冲",
+        "primary_2": "沖"
+    },
+    {
+        "intermediate_1": "chong1dian4qi4",
+        "intermediate_2": "chōngdiànqì",
+        "native_1": "battery charger",
+        "primary_1": "充电器",
+        "primary_2": "充電器"
+    },
+    {
+        "intermediate_1": "chong1fen4",
+        "intermediate_2": "chōngfèn",
+        "native_1": "full; abundant; ample",
+        "primary_1": "充分",
+        "primary_2": "充分"
+    },
+    {
+        "intermediate_1": "chong1man3",
+        "intermediate_2": "chōngmǎn",
+        "native_1": "brimming with; very full",
+        "primary_1": "充满",
+        "primary_2": "充滿"
+    },
+    {
+        "intermediate_1": "chong2fu4",
+        "intermediate_2": "chóngfù",
+        "native_1": "to repeat; to duplicate",
+        "primary_1": "重复",
+        "primary_2": "重複"
+    },
+    {
+        "intermediate_1": "chong3wu4",
+        "intermediate_2": "chǒngwù",
+        "native_1": "a pet",
+        "primary_1": "宠物",
+        "primary_2": "寵物"
+    },
+    {
+        "intermediate_1": "chou1ti",
+        "intermediate_2": "chōuti",
+        "native_1": "drawer",
+        "primary_1": "抽屉",
+        "primary_2": "抽屜"
+    },
+    {
+        "intermediate_1": "chou1xiang4",
+        "intermediate_2": "chōuxiàng",
+        "native_1": "abstract; abstraction",
+        "primary_1": "抽象",
+        "primary_2": "抽象"
+    },
+    {
+        "intermediate_1": "chou3",
+        "intermediate_2": "chǒu",
+        "native_1": "ugly; disgraceful (2nd Earthly Branch)",
+        "primary_1": "丑",
+        "primary_2": "醜"
+    },
+    {
+        "intermediate_1": "chou4",
+        "intermediate_2": "chòu",
+        "native_1": "stench; stink",
+        "primary_1": "臭",
+        "primary_2": "臭"
+    },
+    {
+        "intermediate_1": "chu1ban3",
+        "intermediate_2": "chūbǎn",
+        "native_1": "publish",
+        "primary_1": "出版",
+        "primary_2": "出版"
+    },
+    {
+        "intermediate_1": "chu1kou3",
+        "intermediate_2": "chūkǒu",
+        "native_1": "exit; speak; export",
+        "primary_1": "出口",
+        "primary_2": "出口"
+    },
+    {
+        "intermediate_1": "chu1se4",
+        "intermediate_2": "chūsè",
+        "native_1": "remarkable; outstanding; excellent",
+        "primary_1": "出色",
+        "primary_2": "出色"
+    },
+    {
+        "intermediate_1": "chu1shi4",
+        "intermediate_2": "chūshì",
+        "native_1": "to show",
+        "primary_1": "出示",
+        "primary_2": "出示"
+    },
+    {
+        "intermediate_1": "chu1xi2",
+        "intermediate_2": "chūxí",
+        "native_1": "attend; be present; participate",
+        "primary_1": "出席",
+        "primary_2": "出席"
+    },
+    {
+        "intermediate_1": "chu1ji2",
+        "intermediate_2": "chūjí",
+        "native_1": "junior; primary",
+        "primary_1": "初级",
+        "primary_2": "初級"
+    },
+    {
+        "intermediate_1": "chu2fei1",
+        "intermediate_2": "chúfēi",
+        "native_1": "only if; unless",
+        "primary_1": "除非",
+        "primary_2": "除非"
+    },
+    {
+        "intermediate_1": "chu2xi1",
+        "intermediate_2": "chúxī",
+        "native_1": "Lunar New Year's Eve",
+        "primary_1": "除夕",
+        "primary_2": "除夕"
+    },
+    {
+        "intermediate_1": "chu3li3",
+        "intermediate_2": "chǔlǐ",
+        "native_1": "deal with; to process; sell at a discount; to treat (by a special process)",
+        "primary_1": "处理",
+        "primary_2": "處理"
+    },
+    {
+        "intermediate_1": "chuan2bo1",
+        "intermediate_2": "chuánbō",
+        "native_1": "propagate; to spread",
+        "primary_1": "传播",
+        "primary_2": "傳播"
+    },
+    {
+        "intermediate_1": "chuan2ran3",
+        "intermediate_2": "chuánrǎn",
+        "native_1": "infect; be contagious",
+        "primary_1": "传染",
+        "primary_2": "傳染"
+    },
+    {
+        "intermediate_1": "chuan2shuo1",
+        "intermediate_2": "chuánshuō",
+        "native_1": "it is said; legend; pass on (a story)",
+        "primary_1": "传说",
+        "primary_2": "傳說"
+    },
+    {
+        "intermediate_1": "chuan2tong3",
+        "intermediate_2": "chuántǒng",
+        "native_1": "tradition; traditional",
+        "primary_1": "传统",
+        "primary_2": "傳統"
+    },
+    {
+        "intermediate_1": "chuang1lian2",
+        "intermediate_2": "chuānglián",
+        "native_1": "window curtain",
+        "primary_1": "窗帘",
+        "primary_2": "窗簾"
+    },
+    {
+        "intermediate_1": "chuang3",
+        "intermediate_2": "chuǎng",
+        "native_1": "rush; break through; to temper oneself (by battling difficulties)",
+        "primary_1": "闯",
+        "primary_2": "闖"
+    },
+    {
+        "intermediate_1": "chuang4zao4",
+        "intermediate_2": "chuàngzào",
+        "native_1": "create; bring about; creativity",
+        "primary_1": "创造",
+        "primary_2": "創造"
+    },
+    {
+        "intermediate_1": "chui1",
+        "intermediate_2": "chuī",
+        "native_1": "to blow; to blast; to puff",
+        "primary_1": "吹",
+        "primary_2": "吹"
+    },
+    {
+        "intermediate_1": "ci2hui4",
+        "intermediate_2": "cíhuì",
+        "native_1": "vocabulary",
+        "primary_1": "词汇",
+        "primary_2": "詞彙"
+    },
+    {
+        "intermediate_1": "ci2zhi2",
+        "intermediate_2": "cízhí",
+        "native_1": "resign from a position",
+        "primary_1": "辞职",
+        "primary_2": "辭職"
+    },
+    {
+        "intermediate_1": "ci3wai4",
+        "intermediate_2": "cǐwài",
+        "native_1": "besides; in addition; moreover",
+        "primary_1": "此外",
+        "primary_2": "此外"
+    },
+    {
+        "intermediate_1": "ci4yao4",
+        "intermediate_2": "cìyào",
+        "native_1": "secondary; less important",
+        "primary_1": "次要",
+        "primary_2": "次要"
+    },
+    {
+        "intermediate_1": "ci4ji1",
+        "intermediate_2": "cìjī",
+        "native_1": "exciting; provoke; irritate",
+        "primary_1": "刺激",
+        "primary_2": "刺激"
+    },
+    {
+        "intermediate_1": "cong1mang2",
+        "intermediate_2": "cōngmáng",
+        "native_1": "hasty; hurried",
+        "primary_1": "匆忙",
+        "primary_2": "匆忙"
+    },
+    {
+        "intermediate_1": "cong2ci3",
+        "intermediate_2": "cóngcǐ",
+        "native_1": "from now on; since then",
+        "primary_1": "从此",
+        "primary_2": "從此"
+    },
+    {
+        "intermediate_1": "cong2'er2",
+        "intermediate_2": "cóng'ér",
+        "native_1": "thus; thereby; as a result",
+        "primary_1": "从而",
+        "primary_2": "從而"
+    },
+    {
+        "intermediate_1": "cong2qian2",
+        "intermediate_2": "cóngqián",
+        "native_1": "previously; formerly; in the past",
+        "primary_1": "从前",
+        "primary_2": "從前"
+    },
+    {
+        "intermediate_1": "cong2shi4",
+        "intermediate_2": "cóngshì",
+        "native_1": "go for; engage in; deal with",
+        "primary_1": "从事",
+        "primary_2": "從事"
+    },
+    {
+        "intermediate_1": "cu1cao1",
+        "intermediate_2": "cūcāo",
+        "native_1": "coarse",
+        "primary_1": "粗糙",
+        "primary_2": "粗糙"
+    },
+    {
+        "intermediate_1": "cu4jin4",
+        "intermediate_2": "cùjìn",
+        "native_1": "promote (an idea or cause); to advance",
+        "primary_1": "促进",
+        "primary_2": "促進"
+    },
+    {
+        "intermediate_1": "cu4shi3",
+        "intermediate_2": "cùshǐ",
+        "native_1": "to urge; impel; to cause; to push",
+        "primary_1": "促使",
+        "primary_2": "促使"
+    },
+    {
+        "intermediate_1": "cu4",
+        "intermediate_2": "cù",
+        "native_1": "vinegar",
+        "primary_1": "醋",
+        "primary_2": "醋"
+    },
+    {
+        "intermediate_1": "cui1",
+        "intermediate_2": "cuī",
+        "native_1": "to press; to urge; to hurry",
+        "primary_1": "催",
+        "primary_2": "催"
+    },
+    {
+        "intermediate_1": "cun2zai4",
+        "intermediate_2": "cúnzài",
+        "native_1": "to exist; to be",
+        "primary_1": "存在",
+        "primary_2": "存在"
+    },
+    {
+        "intermediate_1": "cuo4shi1",
+        "intermediate_2": "cuòshī",
+        "native_1": "measure; step (to be taken)",
+        "primary_1": "措施",
+        "primary_2": "措施"
+    },
+    {
+        "intermediate_1": "da1ying",
+        "intermediate_2": "dāying",
+        "native_1": "to respond; to promise; to answer; agree",
+        "primary_1": "答应",
+        "primary_2": "答應"
+    },
+    {
+        "intermediate_1": "da2 dao4",
+        "intermediate_2": "dá dào",
+        "native_1": "achieve; attain; to reach",
+        "primary_1": "达到",
+        "primary_2": "達到"
+    },
+    {
+        "intermediate_1": "da3gong1",
+        "intermediate_2": "dǎgōng",
+        "native_1": "work a part time job; (regional) do manual labor; do odd jobs",
+        "primary_1": "打工",
+        "primary_2": "打工"
+    },
+    {
+        "intermediate_1": "da3 jiao1dao",
+        "intermediate_2": "dǎ jiāodao",
+        "native_1": "come into contact with; to deal with",
+        "primary_1": "打交道",
+        "primary_2": "打交道"
+    },
+    {
+        "intermediate_1": "da3pen1ti4",
+        "intermediate_2": "dǎpēntì",
+        "native_1": "to sneeze",
+        "primary_1": "打喷嚏",
+        "primary_2": "打噴嚏"
+    },
+    {
+        "intermediate_1": "da3ting",
+        "intermediate_2": "dǎting",
+        "native_1": "ask about; inquire about",
+        "primary_1": "打听",
+        "primary_2": "打聽"
+    },
+    {
+        "intermediate_1": "da4fang",
+        "intermediate_2": "dàfang",
+        "native_1": "generous; poise; (-fang1: expert; scholar)",
+        "primary_1": "大方",
+        "primary_2": "大方"
+    },
+    {
+        "intermediate_1": "da4sha4",
+        "intermediate_2": "dàshà",
+        "native_1": "large building; edifice; mansion",
+        "primary_1": "大厦",
+        "primary_2": "大廈"
+    },
+    {
+        "intermediate_1": "da4xiang4",
+        "intermediate_2": "dàxiàng",
+        "native_1": "elephant",
+        "primary_1": "大象",
+        "primary_2": "大象"
+    },
+    {
+        "intermediate_1": "da4xing2",
+        "intermediate_2": "dàxíng",
+        "native_1": "large-scale; wide-scale",
+        "primary_1": "大型",
+        "primary_2": "大型"
+    },
+    {
+        "intermediate_1": "dai1",
+        "intermediate_2": "dāi",
+        "native_1": "stupid; foolish; blank; dumbstruck; to stay",
+        "primary_1": "呆",
+        "primary_2": "呆"
+    },
+    {
+        "intermediate_1": "dai4biao3",
+        "intermediate_2": "dàibiǎo",
+        "native_1": "represent; to delegate",
+        "primary_1": "代表",
+        "primary_2": "代表"
+    },
+    {
+        "intermediate_1": "dai4ti4",
+        "intermediate_2": "dàitì",
+        "native_1": "to replace",
+        "primary_1": "代替",
+        "primary_2": "代替"
+    },
+    {
+        "intermediate_1": "dai4 kuan3",
+        "intermediate_2": "dài kuǎn",
+        "native_1": "(bank) loan; provide a loan",
+        "primary_1": "贷款",
+        "primary_2": "貸款"
+    },
+    {
+        "intermediate_1": "dai4yu4",
+        "intermediate_2": "dàiyù",
+        "native_1": "treatment; pay; wage; salary",
+        "primary_1": "待遇",
+        "primary_2": "待遇"
+    },
+    {
+        "intermediate_1": "dan1ren4",
+        "intermediate_2": "dānrèn",
+        "native_1": "hold the post of; serve as",
+        "primary_1": "担任",
+        "primary_2": "擔任"
+    },
+    {
+        "intermediate_1": "dan1chun2",
+        "intermediate_2": "dānchún",
+        "native_1": "simple; pure; merely",
+        "primary_1": "单纯",
+        "primary_2": "單純"
+    },
+    {
+        "intermediate_1": "dan1diao4",
+        "intermediate_2": "dāndiào",
+        "native_1": "monotonous; dull",
+        "primary_1": "单调",
+        "primary_2": "單調"
+    },
+    {
+        "intermediate_1": "dan1du2",
+        "intermediate_2": "dāndú",
+        "native_1": "alone",
+        "primary_1": "单独",
+        "primary_2": "單獨"
+    },
+    {
+        "intermediate_1": "dan1wei4",
+        "intermediate_2": "dānwèi",
+        "native_1": "unit; work unit",
+        "primary_1": "单位",
+        "primary_2": "單位"
+    },
+    {
+        "intermediate_1": "dan1yuan2",
+        "intermediate_2": "dānyuán",
+        "native_1": "unit; entrance number; staircase (for residential buildings)",
+        "primary_1": "单元",
+        "primary_2": "單元"
+    },
+    {
+        "intermediate_1": "dan1wu",
+        "intermediate_2": "dānwu",
+        "native_1": "to delay; waste time",
+        "primary_1": "耽误",
+        "primary_2": "耽誤"
+    },
+    {
+        "intermediate_1": "dan3xiao3gui3",
+        "intermediate_2": "dǎnxiǎoguǐ",
+        "native_1": "coward",
+        "primary_1": "胆小鬼",
+        "primary_2": "膽小鬼"
+    },
+    {
+        "intermediate_1": "dan4",
+        "intermediate_2": "dàn",
+        "native_1": "diluted; weak; thin",
+        "primary_1": "淡",
+        "primary_2": "淡"
+    },
+    {
+        "intermediate_1": "dang1di4",
+        "intermediate_2": "dāngdì",
+        "native_1": "local",
+        "primary_1": "当地",
+        "primary_2": "當地"
+    },
+    {
+        "intermediate_1": "dang1xin1",
+        "intermediate_2": "dāngxīn",
+        "native_1": "take care; watch out",
+        "primary_1": "当心",
+        "primary_2": "當心"
+    },
+    {
+        "intermediate_1": "dang3",
+        "intermediate_2": "dǎng",
+        "native_1": "to block; hinder; gear; equipment",
+        "primary_1": "挡",
+        "primary_2": "擋"
+    },
+    {
+        "intermediate_1": "dao3yan3",
+        "intermediate_2": "dǎoyǎn",
+        "native_1": "to direct; director",
+        "primary_1": "导演",
+        "primary_2": "導演"
+    },
+    {
+        "intermediate_1": "dao3zhi4",
+        "intermediate_2": "dǎozhì",
+        "native_1": "lead to; bring about; to cause",
+        "primary_1": "导致",
+        "primary_2": "導致"
+    },
+    {
+        "intermediate_1": "dao3yu3",
+        "intermediate_2": "dǎoyǔ",
+        "native_1": "islands",
+        "primary_1": "岛屿",
+        "primary_2": "島嶼"
+    },
+    {
+        "intermediate_1": "dao3mei2",
+        "intermediate_2": "dǎoméi",
+        "native_1": "have bad luck; be out of luck",
+        "primary_1": "倒霉",
+        "primary_2": "倒黴"
+    },
+    {
+        "intermediate_1": "dao4da2",
+        "intermediate_2": "dàodá",
+        "native_1": "to reach; arrive",
+        "primary_1": "到达",
+        "primary_2": "到達"
+    },
+    {
+        "intermediate_1": "dao4de2",
+        "intermediate_2": "dàodé",
+        "native_1": "morals; morality; ethics",
+        "primary_1": "道德",
+        "primary_2": "道德"
+    },
+    {
+        "intermediate_1": "dao4li3",
+        "intermediate_2": "dàolǐ",
+        "native_1": "reason; sense; argument",
+        "primary_1": "道理",
+        "primary_2": "道理"
+    },
+    {
+        "intermediate_1": "deng1ji4",
+        "intermediate_2": "dēngjì",
+        "native_1": "register (one's name); check in; enroll",
+        "primary_1": "登记",
+        "primary_2": "登記"
+    },
+    {
+        "intermediate_1": "deng3dai4",
+        "intermediate_2": "děngdài",
+        "native_1": "to wait (for); expect",
+        "primary_1": "等待",
+        "primary_2": "等待"
+    },
+    {
+        "intermediate_1": "deng3yu2",
+        "intermediate_2": "děngyú",
+        "native_1": "(Mathematics) equal to",
+        "primary_1": "等于",
+        "primary_2": "等于"
+    },
+    {
+        "intermediate_1": "di1",
+        "intermediate_2": "dī",
+        "native_1": "to drip; drop; (mw for drops of liquid)",
+        "primary_1": "滴",
+        "primary_2": "滴"
+    },
+    {
+        "intermediate_1": "di2que4",
+        "intermediate_2": "díquè",
+        "native_1": "really; indeed",
+        "primary_1": "的确",
+        "primary_2": "的確"
+    },
+    {
+        "intermediate_1": "di2ren2",
+        "intermediate_2": "dírén",
+        "native_1": "enemy",
+        "primary_1": "敌人",
+        "primary_2": "敵人"
+    },
+    {
+        "intermediate_1": "di4dao",
+        "intermediate_2": "dìdao",
+        "native_1": "authentic; genuine; (-dào: tunnel)",
+        "primary_1": "地道",
+        "primary_2": "地道"
+    },
+    {
+        "intermediate_1": "di4li3",
+        "intermediate_2": "dìlǐ",
+        "native_1": "geography",
+        "primary_1": "地理",
+        "primary_2": "地理"
+    },
+    {
+        "intermediate_1": "di4qu1",
+        "intermediate_2": "dìqū",
+        "native_1": "an area; a region; a district",
+        "primary_1": "地区",
+        "primary_2": "地區"
+    },
+    {
+        "intermediate_1": "di4tan3",
+        "intermediate_2": "dìtǎn",
+        "native_1": "carpet; rug",
+        "primary_1": "地毯",
+        "primary_2": "地毯"
+    },
+    {
+        "intermediate_1": "di4wei4",
+        "intermediate_2": "dìwèi",
+        "native_1": "position; status",
+        "primary_1": "地位",
+        "primary_2": "地位"
+    },
+    {
+        "intermediate_1": "di4zhen4",
+        "intermediate_2": "dìzhèn",
+        "native_1": "earthquake",
+        "primary_1": "地震",
+        "primary_2": "地震"
+    },
+    {
+        "intermediate_1": "di4",
+        "intermediate_2": "dì",
+        "native_1": "hand over; to pass; to give",
+        "primary_1": "递",
+        "primary_2": "遞"
+    },
+    {
+        "intermediate_1": "dian3xin",
+        "intermediate_2": "diǎnxin",
+        "native_1": "dim sum; light refreshments; snacks",
+        "primary_1": "点心",
+        "primary_2": "點心"
+    },
+    {
+        "intermediate_1": "dian4chi2",
+        "intermediate_2": "diànchí",
+        "native_1": "battery",
+        "primary_1": "电池",
+        "primary_2": "電池"
+    },
+    {
+        "intermediate_1": "dian4tai2",
+        "intermediate_2": "diàntái",
+        "native_1": "transceiver; broadcasting station",
+        "primary_1": "电台",
+        "primary_2": "電台"
+    },
+    {
+        "intermediate_1": "diao4",
+        "intermediate_2": "diào",
+        "native_1": "to fish",
+        "primary_1": "钓",
+        "primary_2": "釣"
+    },
+    {
+        "intermediate_1": "ding3",
+        "intermediate_2": "dǐng",
+        "native_1": "top; roof; carry on one's head; prop up; to butt; (mw for headwear, i.e. hats)",
+        "primary_1": "顶",
+        "primary_2": "頂"
+    },
+    {
+        "intermediate_1": "dong4hua4pian4",
+        "intermediate_2": "dònghuàpiàn",
+        "native_1": "animated film",
+        "primary_1": "动画片",
+        "primary_2": "動畫片"
+    },
+    {
+        "intermediate_1": "dong4",
+        "intermediate_2": "dòng",
+        "native_1": "to freeze",
+        "primary_1": "冻",
+        "primary_2": "凍"
+    },
+    {
+        "intermediate_1": "dong4",
+        "intermediate_2": "dòng",
+        "native_1": "cave; hole",
+        "primary_1": "洞",
+        "primary_2": "洞"
+    },
+    {
+        "intermediate_1": "dou4fu",
+        "intermediate_2": "dòufu",
+        "native_1": "tofu; bean curd",
+        "primary_1": "豆腐",
+        "primary_2": "豆腐"
+    },
+    {
+        "intermediate_1": "dou4",
+        "intermediate_2": "dòu",
+        "native_1": "to tease; amuse; to stay; to stop; funny",
+        "primary_1": "逗",
+        "primary_2": "逗"
+    },
+    {
+        "intermediate_1": "du2li4",
+        "intermediate_2": "dúlì",
+        "native_1": "independent",
+        "primary_1": "独立",
+        "primary_2": "獨立"
+    },
+    {
+        "intermediate_1": "du2te4",
+        "intermediate_2": "dútè",
+        "native_1": "unique; distinctive",
+        "primary_1": "独特",
+        "primary_2": "獨特"
+    },
+    {
+        "intermediate_1": "du4guo4",
+        "intermediate_2": "dùguò",
+        "native_1": "spend; to pass",
+        "primary_1": "度过",
+        "primary_2": "度過"
+    },
+    {
+        "intermediate_1": "duan4",
+        "intermediate_2": "duàn",
+        "native_1": "to break; decide; absolutely (usually negative)",
+        "primary_1": "断",
+        "primary_2": "斷"
+    },
+    {
+        "intermediate_1": "dui1",
+        "intermediate_2": "duī",
+        "native_1": "pile; heap; stack; crowd",
+        "primary_1": "堆",
+        "primary_2": "堆"
+    },
+    {
+        "intermediate_1": "dui4bi3",
+        "intermediate_2": "duìbǐ",
+        "native_1": "compare; to contrast; comparison",
+        "primary_1": "对比",
+        "primary_2": "對比"
+    },
+    {
+        "intermediate_1": "dui4dai4",
+        "intermediate_2": "duìdài",
+        "native_1": "to treat",
+        "primary_1": "对待",
+        "primary_2": "對待"
+    },
+    {
+        "intermediate_1": "dui4fang1",
+        "intermediate_2": "duìfāng",
+        "native_1": "counterpart; the other party involved",
+        "primary_1": "对方",
+        "primary_2": "對方"
+    },
+    {
+        "intermediate_1": "dui4shou3",
+        "intermediate_2": "duìshǒu",
+        "native_1": "opponent; adversary; match",
+        "primary_1": "对手",
+        "primary_2": "對手"
+    },
+    {
+        "intermediate_1": "dui4xiang4",
+        "intermediate_2": "duìxiàng",
+        "native_1": "target; object; partner; boyfriend or girlfriend",
+        "primary_1": "对象",
+        "primary_2": "對象"
+    },
+    {
+        "intermediate_1": "dui4huan4",
+        "intermediate_2": "duìhuàn",
+        "native_1": "to exchange; to convert (currencies)",
+        "primary_1": "兑换",
+        "primary_2": "兌換"
+    },
+    {
+        "intermediate_1": "dun1",
+        "intermediate_2": "dūn",
+        "native_1": "ton",
+        "primary_1": "吨",
+        "primary_2": "噸"
+    },
+    {
+        "intermediate_1": "dun1",
+        "intermediate_2": "dūn",
+        "native_1": "to crouch; to squat",
+        "primary_1": "蹲",
+        "primary_2": "蹲"
+    },
+    {
+        "intermediate_1": "dun4",
+        "intermediate_2": "dùn",
+        "native_1": "pause; arrange; stamp feet; suddenly; (mw for meals)",
+        "primary_1": "顿",
+        "primary_2": "頓"
+    },
+    {
+        "intermediate_1": "duo1kui1",
+        "intermediate_2": "duōkuī",
+        "native_1": "thanks to; luckily",
+        "primary_1": "多亏",
+        "primary_2": "多虧"
+    },
+    {
+        "intermediate_1": "duo1yu2",
+        "intermediate_2": "duōyú",
+        "native_1": "unnecessary; superfluous",
+        "primary_1": "多余",
+        "primary_2": "多余"
+    },
+    {
+        "intermediate_1": "duo3",
+        "intermediate_2": "duǒ",
+        "native_1": "(mw for flowers and clouds)",
+        "primary_1": "朵",
+        "primary_2": "朵"
+    },
+    {
+        "intermediate_1": "duo3cang2",
+        "intermediate_2": "duǒcáng",
+        "native_1": "hide oneself; take cover",
+        "primary_1": "躲藏",
+        "primary_2": "躲藏"
+    },
+    {
+        "intermediate_1": "e4lie4",
+        "intermediate_2": "èliè",
+        "native_1": "vile; horrible",
+        "primary_1": "恶劣",
+        "primary_2": "惡劣"
+    },
+    {
+        "intermediate_1": "er3huan2",
+        "intermediate_2": "ěrhuán",
+        "native_1": "earring",
+        "primary_1": "耳环",
+        "primary_2": "耳環"
+    },
+    {
+        "intermediate_1": "fa1biao3",
+        "intermediate_2": "fābiǎo",
+        "native_1": "publish; to issue (a statement); announce",
+        "primary_1": "发表",
+        "primary_2": "發表"
+    },
+    {
+        "intermediate_1": "fa1 chou2",
+        "intermediate_2": "fā chóu",
+        "native_1": "worry about sth.",
+        "primary_1": "发愁",
+        "primary_2": "發愁"
+    },
+    {
+        "intermediate_1": "fa1da2",
+        "intermediate_2": "fādá",
+        "native_1": "developed (country, etc.); flourishing; prosper",
+        "primary_1": "发达",
+        "primary_2": "發達"
+    },
+    {
+        "intermediate_1": "fa1dou3",
+        "intermediate_2": "fādǒu",
+        "native_1": "to shiver; to shudder; tremble",
+        "primary_1": "发抖",
+        "primary_2": "發抖"
+    },
+    {
+        "intermediate_1": "fa1hui1",
+        "intermediate_2": "fāhuī",
+        "native_1": "to bring (skill, talent, etc.) into play; to develop (an idea)",
+        "primary_1": "发挥",
+        "primary_2": "發揮"
+    },
+    {
+        "intermediate_1": "fa1ming2",
+        "intermediate_2": "fāmíng",
+        "native_1": "invent",
+        "primary_1": "发明",
+        "primary_2": "發明"
+    },
+    {
+        "intermediate_1": "fa1piao4",
+        "intermediate_2": "fāpiào",
+        "native_1": "receipt or bill for purchase; invoice",
+        "primary_1": "发票",
+        "primary_2": "發票"
+    },
+    {
+        "intermediate_1": "fa1yan2",
+        "intermediate_2": "fāyán",
+        "native_1": "make a speech; statement",
+        "primary_1": "发言",
+        "primary_2": "發言"
+    },
+    {
+        "intermediate_1": "fa2kuan3",
+        "intermediate_2": "fákuǎn",
+        "native_1": "fine; penalty (monetary)",
+        "primary_1": "罚款",
+        "primary_2": "罰款"
+    },
+    {
+        "intermediate_1": "fa3yuan4",
+        "intermediate_2": "fǎyuàn",
+        "native_1": "court of law",
+        "primary_1": "法院",
+        "primary_2": "法院"
+    },
+    {
+        "intermediate_1": "fan1",
+        "intermediate_2": "fān",
+        "native_1": "to turn over; capsize; translate",
+        "primary_1": "翻",
+        "primary_2": "翻"
+    },
+    {
+        "intermediate_1": "fan2rong2",
+        "intermediate_2": "fánróng",
+        "native_1": "prosperous; prosperity; booming (economy)",
+        "primary_1": "繁荣",
+        "primary_2": "繁榮"
+    },
+    {
+        "intermediate_1": "fan3'er2",
+        "intermediate_2": "fǎn'ér",
+        "native_1": "on the contrary; instead",
+        "primary_1": "反而",
+        "primary_2": "反而"
+    },
+    {
+        "intermediate_1": "fan3fu4",
+        "intermediate_2": "fǎnfù",
+        "native_1": "repeatedly; over and over",
+        "primary_1": "反复",
+        "primary_2": "反複"
+    },
+    {
+        "intermediate_1": "fan3ying4",
+        "intermediate_2": "fǎnyìng",
+        "native_1": "react; respond; reply",
+        "primary_1": "反应",
+        "primary_2": "反應"
+    },
+    {
+        "intermediate_1": "fan3ying4",
+        "intermediate_2": "fǎnyìng",
+        "native_1": "reflect; reflection; report on",
+        "primary_1": "反映",
+        "primary_2": "反映"
+    },
+    {
+        "intermediate_1": "fan3zheng4",
+        "intermediate_2": "fǎnzhèng",
+        "native_1": "anyway",
+        "primary_1": "反正",
+        "primary_2": "反正"
+    },
+    {
+        "intermediate_1": "fan4wei2",
+        "intermediate_2": "fànwéi",
+        "native_1": "scope; range; limits; extent",
+        "primary_1": "范围",
+        "primary_2": "範圍"
+    },
+    {
+        "intermediate_1": "fang1",
+        "intermediate_2": "fāng",
+        "native_1": "square; direction; side (Kangxi radical 70)",
+        "primary_1": "方",
+        "primary_2": "方"
+    },
+    {
+        "intermediate_1": "fang1'an4",
+        "intermediate_2": "fāng'àn",
+        "native_1": "plan; program (for action, etc.); proposal",
+        "primary_1": "方案",
+        "primary_2": "方案"
+    },
+    {
+        "intermediate_1": "fang1shi4",
+        "intermediate_2": "fāngshì",
+        "native_1": "way; style; fashion; manner",
+        "primary_1": "方式",
+        "primary_2": "方式"
+    },
+    {
+        "intermediate_1": "fang2'ai4",
+        "intermediate_2": "fáng'ài",
+        "native_1": "hinder; to hamper; to obstruct",
+        "primary_1": "妨碍",
+        "primary_2": "妨礙"
+    },
+    {
+        "intermediate_1": "fang3fu2",
+        "intermediate_2": "fǎngfú",
+        "native_1": "to seem as though; as if",
+        "primary_1": "仿佛",
+        "primary_2": "仿佛"
+    },
+    {
+        "intermediate_1": "fei1",
+        "intermediate_2": "fēi",
+        "native_1": "non-; un-; not be; wrongdoing; simply must (Kangxi radical 175)",
+        "primary_1": "非",
+        "primary_2": "非"
+    },
+    {
+        "intermediate_1": "fei2zao4",
+        "intermediate_2": "féizào",
+        "native_1": "soap",
+        "primary_1": "肥皂",
+        "primary_2": "肥皂"
+    },
+    {
+        "intermediate_1": "fei4hua4",
+        "intermediate_2": "fèihuà",
+        "native_1": "nonsense; rubbish",
+        "primary_1": "废话",
+        "primary_2": "廢話"
+    },
+    {
+        "intermediate_1": "fen1bie2",
+        "intermediate_2": "fēnbié",
+        "native_1": "distinguish; split up; difference; to part",
+        "primary_1": "分别",
+        "primary_2": "分別"
+    },
+    {
+        "intermediate_1": "fen1bu4",
+        "intermediate_2": "fēnbù",
+        "native_1": "be distributed (over an area); be scattered",
+        "primary_1": "分布",
+        "primary_2": "分布"
+    },
+    {
+        "intermediate_1": "fen1pei4",
+        "intermediate_2": "fēnpèi",
+        "native_1": "distribute; assign; allocate",
+        "primary_1": "分配",
+        "primary_2": "分配"
+    },
+    {
+        "intermediate_1": "fen1shou3",
+        "intermediate_2": "fēnshǒu",
+        "native_1": "part company; break up",
+        "primary_1": "分手",
+        "primary_2": "分手"
+    },
+    {
+        "intermediate_1": "fen1xi1",
+        "intermediate_2": "fēnxī",
+        "native_1": "analyze; analysis",
+        "primary_1": "分析",
+        "primary_2": "分析"
+    },
+    {
+        "intermediate_1": "fen1fen1",
+        "intermediate_2": "fēnfēn",
+        "native_1": "one after another; in succession; in profusion; diverse; pell-mell",
+        "primary_1": "纷纷",
+        "primary_2": "紛紛"
+    },
+    {
+        "intermediate_1": "fen4dou4",
+        "intermediate_2": "fèndòu",
+        "native_1": "strive; to struggle",
+        "primary_1": "奋斗",
+        "primary_2": "奮鬥"
+    },
+    {
+        "intermediate_1": "feng1ge2",
+        "intermediate_2": "fēnggé",
+        "native_1": "style",
+        "primary_1": "风格",
+        "primary_2": "風格"
+    },
+    {
+        "intermediate_1": "feng1jing3",
+        "intermediate_2": "fēngjǐng",
+        "native_1": "scenery; landscape",
+        "primary_1": "风景",
+        "primary_2": "風景"
+    },
+    {
+        "intermediate_1": "feng1su2",
+        "intermediate_2": "fēngsú",
+        "native_1": "social custom",
+        "primary_1": "风俗",
+        "primary_2": "風俗"
+    },
+    {
+        "intermediate_1": "feng1xian3",
+        "intermediate_2": "fēngxiǎn",
+        "native_1": "risk; venture; hazard",
+        "primary_1": "风险",
+        "primary_2": "風險"
+    },
+    {
+        "intermediate_1": "feng1kuang2",
+        "intermediate_2": "fēngkuáng",
+        "native_1": "crazy; madness; wild; extreme popularity; insane; frenzied; unbridled",
+        "primary_1": "疯狂",
+        "primary_2": "瘋狂"
+    },
+    {
+        "intermediate_1": "feng3ci4",
+        "intermediate_2": "fěngcì",
+        "native_1": "satirize; ridicule; mock; irony",
+        "primary_1": "讽刺",
+        "primary_2": "諷刺"
+    },
+    {
+        "intermediate_1": "fou3ding4",
+        "intermediate_2": "fǒudìng",
+        "native_1": "negate; negative",
+        "primary_1": "否定",
+        "primary_2": "否定"
+    },
+    {
+        "intermediate_1": "fou3ren4",
+        "intermediate_2": "fǒurèn",
+        "native_1": "deny; declare to be untrue",
+        "primary_1": "否认",
+        "primary_2": "否認"
+    },
+    {
+        "intermediate_1": "fu2",
+        "intermediate_2": "fú",
+        "native_1": "to support with hand; to help somebody up",
+        "primary_1": "扶",
+        "primary_2": "扶"
+    },
+    {
+        "intermediate_1": "fu2zhuang1",
+        "intermediate_2": "fúzhuāng",
+        "native_1": "(formal) clothing; costume; dress",
+        "primary_1": "服装",
+        "primary_2": "服裝"
+    },
+    {
+        "intermediate_1": "fu2",
+        "intermediate_2": "fú",
+        "native_1": "width of cloth; size; (mw for pictures, paintings, textiles)",
+        "primary_1": "幅",
+        "primary_2": "幅"
+    },
+    {
+        "intermediate_1": "fu3dao3",
+        "intermediate_2": "fǔdǎo",
+        "native_1": "to coach; to tutor; give advice (in study)",
+        "primary_1": "辅导",
+        "primary_2": "輔導"
+    },
+    {
+        "intermediate_1": "fun4ü3",
+        "intermediate_2": "fùnǚ",
+        "native_1": "woman; women in general",
+        "primary_1": "妇女",
+        "primary_2": "婦女"
+    },
+    {
+        "intermediate_1": "fu4zhi4",
+        "intermediate_2": "fùzhì",
+        "native_1": "duplicate; reproduce",
+        "primary_1": "复制",
+        "primary_2": "複制"
+    },
+    {
+        "intermediate_1": "gai3ge2",
+        "intermediate_2": "gǎigé",
+        "native_1": "to reform",
+        "primary_1": "改革",
+        "primary_2": "改革"
+    },
+    {
+        "intermediate_1": "gai3jin4",
+        "intermediate_2": "gǎijìn",
+        "native_1": "improve; make better",
+        "primary_1": "改进",
+        "primary_2": "改進"
+    },
+    {
+        "intermediate_1": "gai3shan4",
+        "intermediate_2": "gǎishàn",
+        "native_1": "improve; make better",
+        "primary_1": "改善",
+        "primary_2": "改善"
+    },
+    {
+        "intermediate_1": "gai3zheng4",
+        "intermediate_2": "gǎizhèng",
+        "native_1": "to correct; amend",
+        "primary_1": "改正",
+        "primary_2": "改正"
+    },
+    {
+        "intermediate_1": "gai4",
+        "intermediate_2": "gài",
+        "native_1": "lid; top; cover; to build",
+        "primary_1": "盖",
+        "primary_2": "蓋"
+    },
+    {
+        "intermediate_1": "gai4kuo4",
+        "intermediate_2": "gàikuò",
+        "native_1": "summarize; generalize",
+        "primary_1": "概括",
+        "primary_2": "概括"
+    },
+    {
+        "intermediate_1": "gai4nian4",
+        "intermediate_2": "gàiniàn",
+        "native_1": "concept; idea",
+        "primary_1": "概念",
+        "primary_2": "概念"
+    },
+    {
+        "intermediate_1": "gan1cui4",
+        "intermediate_2": "gāncuì",
+        "native_1": "straightforward; clear-cut; blunt",
+        "primary_1": "干脆",
+        "primary_2": "幹脆"
+    },
+    {
+        "intermediate_1": "gan1zao4",
+        "intermediate_2": "gānzào",
+        "native_1": "to dry (of paint, cement, etc.); dry; dryness",
+        "primary_1": "干燥",
+        "primary_2": "幹燥"
+    },
+    {
+        "intermediate_1": "gan3jin3",
+        "intermediate_2": "gǎnjǐn",
+        "native_1": "at once; hurriedly; lose no time",
+        "primary_1": "赶紧",
+        "primary_2": "趕緊"
+    },
+    {
+        "intermediate_1": "gan3kuai4",
+        "intermediate_2": "gǎnkuài",
+        "native_1": "at once; immediately",
+        "primary_1": "赶快",
+        "primary_2": "趕快"
+    },
+    {
+        "intermediate_1": "gan3ji1",
+        "intermediate_2": "gǎnjī",
+        "native_1": "appreciate; feel grateful",
+        "primary_1": "感激",
+        "primary_2": "感激"
+    },
+    {
+        "intermediate_1": "gan3shou4",
+        "intermediate_2": "gǎnshòu",
+        "native_1": "feel; experience; emotion; impression",
+        "primary_1": "感受",
+        "primary_2": "感受"
+    },
+    {
+        "intermediate_1": "gan3xiang3",
+        "intermediate_2": "gǎnxiǎng",
+        "native_1": "impressions; reflections; thoughts",
+        "primary_1": "感想",
+        "primary_2": "感想"
+    },
+    {
+        "intermediate_1": "gan4 huo2r",
+        "intermediate_2": "gàn huór",
+        "native_1": "do manual labor; to work",
+        "primary_1": "干活儿",
+        "primary_2": "幹活兒"
+    },
+    {
+        "intermediate_1": "gang1tie3",
+        "intermediate_2": "gāngtiě",
+        "native_1": "steel",
+        "primary_1": "钢铁",
+        "primary_2": "鋼鐵"
+    },
+    {
+        "intermediate_1": "gao1dang4",
+        "intermediate_2": "gāodàng",
+        "native_1": "top quality; first rate; high class",
+        "primary_1": "高档",
+        "primary_2": "高檔"
+    },
+    {
+        "intermediate_1": "gao1ji2",
+        "intermediate_2": "gāojí",
+        "native_1": "high-level; high-grade; advanced",
+        "primary_1": "高级",
+        "primary_2": "高級"
+    },
+    {
+        "intermediate_1": "gao3",
+        "intermediate_2": "gǎo",
+        "native_1": "do; make; be engaged in",
+        "primary_1": "搞",
+        "primary_2": "搞"
+    },
+    {
+        "intermediate_1": "gao4bie2",
+        "intermediate_2": "gàobié",
+        "native_1": "say goodbye to; to leave; to part",
+        "primary_1": "告别",
+        "primary_2": "告別"
+    },
+    {
+        "intermediate_1": "ge2wai4",
+        "intermediate_2": "géwài",
+        "native_1": "especially; additionally",
+        "primary_1": "格外",
+        "primary_2": "格外"
+    },
+    {
+        "intermediate_1": "ge2bi4",
+        "intermediate_2": "gébì",
+        "native_1": "next door",
+        "primary_1": "隔壁",
+        "primary_2": "隔壁"
+    },
+    {
+        "intermediate_1": "ge4bie2",
+        "intermediate_2": "gèbié",
+        "native_1": "individual; specific; isolated; very few",
+        "primary_1": "个别",
+        "primary_2": "個別"
+    },
+    {
+        "intermediate_1": "ger4en2",
+        "intermediate_2": "gèrén",
+        "native_1": "individual; personal; oneself",
+        "primary_1": "个人",
+        "primary_2": "個人"
+    },
+    {
+        "intermediate_1": "ge4xing4",
+        "intermediate_2": "gèxìng",
+        "native_1": "individuality; personality",
+        "primary_1": "个性",
+        "primary_2": "個性"
+    },
+    {
+        "intermediate_1": "ge4zi4",
+        "intermediate_2": "gèzì",
+        "native_1": "each; respective; apiece",
+        "primary_1": "各自",
+        "primary_2": "各自"
+    },
+    {
+        "intermediate_1": "gen1",
+        "intermediate_2": "gēn",
+        "native_1": "root; base; (mw for long, slender objects)",
+        "primary_1": "根",
+        "primary_2": "根"
+    },
+    {
+        "intermediate_1": "gen1ben3",
+        "intermediate_2": "gēnběn",
+        "native_1": "root; essence; fundamental; basic; (not) at all; simply",
+        "primary_1": "根本",
+        "primary_2": "根本"
+    },
+    {
+        "intermediate_1": "gong1chang3",
+        "intermediate_2": "gōngchǎng",
+        "native_1": "factory",
+        "primary_1": "工厂",
+        "primary_2": "工廠"
+    },
+    {
+        "intermediate_1": "gong1cheng2shi1",
+        "intermediate_2": "gōngchéngshī",
+        "native_1": "engineer",
+        "primary_1": "工程师",
+        "primary_2": "工程師"
+    },
+    {
+        "intermediate_1": "gong1ju4",
+        "intermediate_2": "gōngjù",
+        "native_1": "tool; instrument; utensil",
+        "primary_1": "工具",
+        "primary_2": "工具"
+    },
+    {
+        "intermediate_1": "gong1ren2",
+        "intermediate_2": "gōngrén",
+        "native_1": "worker",
+        "primary_1": "工人",
+        "primary_2": "工人"
+    },
+    {
+        "intermediate_1": "gong1ye4",
+        "intermediate_2": "gōngyè",
+        "native_1": "industry",
+        "primary_1": "工业",
+        "primary_2": "工業"
+    },
+    {
+        "intermediate_1": "gong1bu4",
+        "intermediate_2": "gōngbù",
+        "native_1": "make public; announce; publicize",
+        "primary_1": "公布",
+        "primary_2": "公布"
+    },
+    {
+        "intermediate_1": "gong1kai1",
+        "intermediate_2": "gōngkāi",
+        "native_1": "public; make public",
+        "primary_1": "公开",
+        "primary_2": "公開"
+    },
+    {
+        "intermediate_1": "gong1ping2",
+        "intermediate_2": "gōngpíng",
+        "native_1": "fair; impartial; just",
+        "primary_1": "公平",
+        "primary_2": "公平"
+    },
+    {
+        "intermediate_1": "gong1yu4",
+        "intermediate_2": "gōngyù",
+        "native_1": "apartment building",
+        "primary_1": "公寓",
+        "primary_2": "公寓"
+    },
+    {
+        "intermediate_1": "gong1yuan2",
+        "intermediate_2": "gōngyuán",
+        "native_1": "(year) AD or CE; Christian era; common era",
+        "primary_1": "公元",
+        "primary_2": "公元"
+    },
+    {
+        "intermediate_1": "gong1zhu3",
+        "intermediate_2": "gōngzhǔ",
+        "native_1": "princess",
+        "primary_1": "公主",
+        "primary_2": "公主"
+    },
+    {
+        "intermediate_1": "gong1neng2",
+        "intermediate_2": "gōngnéng",
+        "native_1": "function; feature",
+        "primary_1": "功能",
+        "primary_2": "功能"
+    },
+    {
+        "intermediate_1": "gong1xi3",
+        "intermediate_2": "gōngxǐ",
+        "native_1": "congratulate",
+        "primary_1": "恭喜",
+        "primary_2": "恭喜"
+    },
+    {
+        "intermediate_1": "gong4xian4",
+        "intermediate_2": "gòngxiàn",
+        "native_1": "contribute; dedicate; contribution",
+        "primary_1": "贡献",
+        "primary_2": "貢獻"
+    },
+    {
+        "intermediate_1": "gou1tong1",
+        "intermediate_2": "gōutōng",
+        "native_1": "link; connect; communicate",
+        "primary_1": "沟通",
+        "primary_2": "溝通"
+    },
+    {
+        "intermediate_1": "gou4cheng2",
+        "intermediate_2": "gòuchéng",
+        "native_1": "to constitute; to compose",
+        "primary_1": "构成",
+        "primary_2": "構成"
+    },
+    {
+        "intermediate_1": "gu1gu",
+        "intermediate_2": "gūgu",
+        "native_1": "paternal aunt; father's sister",
+        "primary_1": "姑姑",
+        "primary_2": "姑姑"
+    },
+    {
+        "intermediate_1": "gun1iang",
+        "intermediate_2": "gūniang",
+        "native_1": "young woman; girl",
+        "primary_1": "姑娘",
+        "primary_2": "姑娘"
+    },
+    {
+        "intermediate_1": "gu3dai4",
+        "intermediate_2": "gǔdài",
+        "native_1": "ancient times",
+        "primary_1": "古代",
+        "primary_2": "古代"
+    },
+    {
+        "intermediate_1": "gu3dian3",
+        "intermediate_2": "gǔdiǎn",
+        "native_1": "classical",
+        "primary_1": "古典",
+        "primary_2": "古典"
+    },
+    {
+        "intermediate_1": "gu3piao4",
+        "intermediate_2": "gǔpiào",
+        "native_1": "shares; stock (market)",
+        "primary_1": "股票",
+        "primary_2": "股票"
+    },
+    {
+        "intermediate_1": "gu3tou",
+        "intermediate_2": "gǔtou",
+        "native_1": "bone; moral character",
+        "primary_1": "骨头",
+        "primary_2": "骨頭"
+    },
+    {
+        "intermediate_1": "gu3wu3",
+        "intermediate_2": "gǔwǔ",
+        "native_1": "inspire; heartening",
+        "primary_1": "鼓舞",
+        "primary_2": "鼓舞"
+    },
+    {
+        "intermediate_1": "gu3 zhang3",
+        "intermediate_2": "gǔ zhǎng",
+        "native_1": "applaud",
+        "primary_1": "鼓掌",
+        "primary_2": "鼓掌"
+    },
+    {
+        "intermediate_1": "gu4ding4",
+        "intermediate_2": "gùdìng",
+        "native_1": "fixed; regular; stable",
+        "primary_1": "固定",
+        "primary_2": "固定"
+    },
+    {
+        "intermediate_1": "gua4 hao4",
+        "intermediate_2": "guà hào",
+        "native_1": "register; check into hospital; send by registered mail",
+        "primary_1": "挂号",
+        "primary_2": "挂號"
+    },
+    {
+        "intermediate_1": "guai1",
+        "intermediate_2": "guāi",
+        "native_1": "(of a child) obedient; well-behaved; clever; perverse; contrary to reason",
+        "primary_1": "乖",
+        "primary_2": "乖"
+    },
+    {
+        "intermediate_1": "guai3 wan1",
+        "intermediate_2": "guǎi wān",
+        "native_1": "turn a corner; make a turn",
+        "primary_1": "拐弯",
+        "primary_2": "拐彎"
+    },
+    {
+        "intermediate_1": "guai4 bu de",
+        "intermediate_2": "guài bu de",
+        "native_1": "no wonder; so that's why",
+        "primary_1": "怪不得",
+        "primary_2": "怪不得"
+    },
+    {
+        "intermediate_1": "guan1bi4",
+        "intermediate_2": "guānbì",
+        "native_1": "close; shut",
+        "primary_1": "关闭",
+        "primary_2": "關閉"
+    },
+    {
+        "intermediate_1": "guan1cha2",
+        "intermediate_2": "guānchá",
+        "native_1": "observe; to watch; to survey",
+        "primary_1": "观察",
+        "primary_2": "觀察"
+    },
+    {
+        "intermediate_1": "guan1dian3",
+        "intermediate_2": "guāndiǎn",
+        "native_1": "point of view; standpoint",
+        "primary_1": "观点",
+        "primary_2": "觀點"
+    },
+    {
+        "intermediate_1": "guan1nian4",
+        "intermediate_2": "guānniàn",
+        "native_1": "notion; thought; concept",
+        "primary_1": "观念",
+        "primary_2": "觀念"
+    },
+    {
+        "intermediate_1": "guan1",
+        "intermediate_2": "guān",
+        "native_1": "an official; organ; governmental",
+        "primary_1": "官",
+        "primary_2": "官"
+    },
+    {
+        "intermediate_1": "guan3zi",
+        "intermediate_2": "guǎnzi",
+        "native_1": "tube; pipe; drinking straw",
+        "primary_1": "管子",
+        "primary_2": "管子"
+    },
+    {
+        "intermediate_1": "guan4jun1",
+        "intermediate_2": "guànjūn",
+        "native_1": "champion",
+        "primary_1": "冠军",
+        "primary_2": "冠軍"
+    },
+    {
+        "intermediate_1": "guang1hua2",
+        "intermediate_2": "guānghuá",
+        "native_1": "glossy; sleek; smooth",
+        "primary_1": "光滑",
+        "primary_2": "光滑"
+    },
+    {
+        "intermediate_1": "guang1lin2",
+        "intermediate_2": "guānglín",
+        "native_1": "(polite) welcome!; honor somebody with one's presence",
+        "primary_1": "光临",
+        "primary_2": "光臨"
+    },
+    {
+        "intermediate_1": "guang1ming2",
+        "intermediate_2": "guāngmíng",
+        "native_1": "bright (future); promising; illuminate",
+        "primary_1": "光明",
+        "primary_2": "光明"
+    },
+    {
+        "intermediate_1": "guang1pan2",
+        "intermediate_2": "guāngpán",
+        "native_1": "CD (compact disc)",
+        "primary_1": "光盘",
+        "primary_2": "光盤"
+    },
+    {
+        "intermediate_1": "guang3chang3",
+        "intermediate_2": "guǎngchǎng",
+        "native_1": "public square; plaza",
+        "primary_1": "广场",
+        "primary_2": "廣場"
+    },
+    {
+        "intermediate_1": "guang3da4",
+        "intermediate_2": "guǎngdà",
+        "native_1": "vast; extensive",
+        "primary_1": "广大",
+        "primary_2": "廣大"
+    },
+    {
+        "intermediate_1": "guang3fan4",
+        "intermediate_2": "guǎngfàn",
+        "native_1": "extensive; wide ranging",
+        "primary_1": "广泛",
+        "primary_2": "廣泛"
+    },
+    {
+        "intermediate_1": "guin1a4",
+        "intermediate_2": "guīnà",
+        "native_1": "conclude from the facts; induce; sum up from the facts",
+        "primary_1": "归纳",
+        "primary_2": "歸納"
+    },
+    {
+        "intermediate_1": "gui1ju",
+        "intermediate_2": "guīju",
+        "native_1": "rule; custom",
+        "primary_1": "规矩",
+        "primary_2": "規矩"
+    },
+    {
+        "intermediate_1": "gui1lü4",
+        "intermediate_2": "guīlǜ",
+        "native_1": "law (e.g. of science); regular pattern; discipline",
+        "primary_1": "规律",
+        "primary_2": "規律"
+    },
+    {
+        "intermediate_1": "gui1mo2",
+        "intermediate_2": "guīmó",
+        "native_1": "scale; scope; extent",
+        "primary_1": "规模",
+        "primary_2": "規模"
+    },
+    {
+        "intermediate_1": "gui1ze2",
+        "intermediate_2": "guīzé",
+        "native_1": "rule; law; regulation",
+        "primary_1": "规则",
+        "primary_2": "規則"
+    },
+    {
+        "intermediate_1": "gui4tai2",
+        "intermediate_2": "guìtái",
+        "native_1": "counter; bar; front desk",
+        "primary_1": "柜台",
+        "primary_2": "櫃台"
+    },
+    {
+        "intermediate_1": "gun3",
+        "intermediate_2": "gǔn",
+        "native_1": "to roll; get lost; to boil",
+        "primary_1": "滚",
+        "primary_2": "滾"
+    },
+    {
+        "intermediate_1": "guo1",
+        "intermediate_2": "guō",
+        "native_1": "pot; pan; boiler",
+        "primary_1": "锅",
+        "primary_2": "鍋"
+    },
+    {
+        "intermediate_1": "Guo2qing4 Jie2",
+        "intermediate_2": "Guóqìng Jié",
+        "native_1": "National Day",
+        "primary_1": "国庆节",
+        "primary_2": "國慶節"
+    },
+    {
+        "intermediate_1": "guo2wang2",
+        "intermediate_2": "guówáng",
+        "native_1": "king",
+        "primary_1": "国王",
+        "primary_2": "國王"
+    },
+    {
+        "intermediate_1": "guo3ran2",
+        "intermediate_2": "guǒrán",
+        "native_1": "really; sure enough; as expected",
+        "primary_1": "果然",
+        "primary_2": "果然"
+    },
+    {
+        "intermediate_1": "guo3shi2",
+        "intermediate_2": "guǒshí",
+        "native_1": "fruit; gains; results",
+        "primary_1": "果实",
+        "primary_2": "果實"
+    },
+    {
+        "intermediate_1": "guo4fen4",
+        "intermediate_2": "guòfèn",
+        "native_1": "excessive; overly",
+        "primary_1": "过分",
+        "primary_2": "過分"
+    },
+    {
+        "intermediate_1": "guo4min3",
+        "intermediate_2": "guòmǐn",
+        "native_1": "be allergic; allergy",
+        "primary_1": "过敏",
+        "primary_2": "過敏"
+    },
+    {
+        "intermediate_1": "guo4qi1",
+        "intermediate_2": "guòqī",
+        "native_1": "overdue; expire",
+        "primary_1": "过期",
+        "primary_2": "過期"
+    },
+    {
+        "intermediate_1": "ha1",
+        "intermediate_2": "hā",
+        "native_1": "exhale; sip; (sound of laughter)",
+        "primary_1": "哈",
+        "primary_2": "哈"
+    },
+    {
+        "intermediate_1": "hai3guan1",
+        "intermediate_2": "hǎiguān",
+        "native_1": "customs (i.e. border inspection)",
+        "primary_1": "海关",
+        "primary_2": "海關"
+    },
+    {
+        "intermediate_1": "hai3xian1",
+        "intermediate_2": "hǎixiān",
+        "native_1": "seafood",
+        "primary_1": "海鲜",
+        "primary_2": "海鮮"
+    },
+    {
+        "intermediate_1": "han3",
+        "intermediate_2": "hǎn",
+        "native_1": "call; cry; shout",
+        "primary_1": "喊",
+        "primary_2": "喊"
+    },
+    {
+        "intermediate_1": "hang2ye4",
+        "intermediate_2": "hángyè",
+        "native_1": "industry; business",
+        "primary_1": "行业",
+        "primary_2": "行業"
+    },
+    {
+        "intermediate_1": "hao2hua2",
+        "intermediate_2": "háohuá",
+        "native_1": "luxurious",
+        "primary_1": "豪华",
+        "primary_2": "豪華"
+    },
+    {
+        "intermediate_1": "hao4ke4",
+        "intermediate_2": "hàokè",
+        "native_1": "hospitable; to enjoy having guests",
+        "primary_1": "好客",
+        "primary_2": "好客"
+    },
+    {
+        "intermediate_1": "hao4qi2",
+        "intermediate_2": "hàoqí",
+        "native_1": "curious",
+        "primary_1": "好奇",
+        "primary_2": "好奇"
+    },
+    {
+        "intermediate_1": "he2fa3",
+        "intermediate_2": "héfǎ",
+        "native_1": "lawful; legitimate; legal",
+        "primary_1": "合法",
+        "primary_2": "合法"
+    },
+    {
+        "intermediate_1": "he2li3",
+        "intermediate_2": "hélǐ",
+        "native_1": "rational; reasonable",
+        "primary_1": "合理",
+        "primary_2": "合理"
+    },
+    {
+        "intermediate_1": "he2tong",
+        "intermediate_2": "hétong",
+        "native_1": "contract",
+        "primary_1": "合同",
+        "primary_2": "合同"
+    },
+    {
+        "intermediate_1": "he2ying3",
+        "intermediate_2": "héyǐng",
+        "native_1": "joint photo; group photo",
+        "primary_1": "合影",
+        "primary_2": "合影"
+    },
+    {
+        "intermediate_1": "he2zuo4",
+        "intermediate_2": "hézuò",
+        "native_1": "cooperate; collaborate; work together",
+        "primary_1": "合作",
+        "primary_2": "合作"
+    },
+    {
+        "intermediate_1": "he2bi4",
+        "intermediate_2": "hébì",
+        "native_1": "why should; there is no need to",
+        "primary_1": "何必",
+        "primary_2": "何必"
+    },
+    {
+        "intermediate_1": "he2kuang4",
+        "intermediate_2": "hékuàng",
+        "native_1": "let alone; much less",
+        "primary_1": "何况",
+        "primary_2": "何況"
+    },
+    {
+        "intermediate_1": "he2ping2",
+        "intermediate_2": "hépíng",
+        "native_1": "peace",
+        "primary_1": "和平",
+        "primary_2": "和平"
+    },
+    {
+        "intermediate_1": "he2xin1",
+        "intermediate_2": "héxīn",
+        "native_1": "core; nucleus",
+        "primary_1": "核心",
+        "primary_2": "核心"
+    },
+    {
+        "intermediate_1": "hen4",
+        "intermediate_2": "hèn",
+        "native_1": "to hate",
+        "primary_1": "恨",
+        "primary_2": "恨"
+    },
+    {
+        "intermediate_1": "hou2zi",
+        "intermediate_2": "hóuzi",
+        "native_1": "monkey",
+        "primary_1": "猴子",
+        "primary_2": "猴子"
+    },
+    {
+        "intermediate_1": "hou4bei4",
+        "intermediate_2": "hòubèi",
+        "native_1": "back (of the body)",
+        "primary_1": "后背",
+        "primary_2": "後背"
+    },
+    {
+        "intermediate_1": "hou4guo3",
+        "intermediate_2": "hòuguǒ",
+        "native_1": "consequences; aftermath",
+        "primary_1": "后果",
+        "primary_2": "後果"
+    },
+    {
+        "intermediate_1": "hu1xi1",
+        "intermediate_2": "hūxī",
+        "native_1": "breathe",
+        "primary_1": "呼吸",
+        "primary_2": "呼吸"
+    },
+    {
+        "intermediate_1": "hu1ran2",
+        "intermediate_2": "hūrán",
+        "native_1": "suddenly; all of a sudden",
+        "primary_1": "忽然",
+        "primary_2": "忽然"
+    },
+    {
+        "intermediate_1": "hu1shi4",
+        "intermediate_2": "hūshì",
+        "native_1": "neglect; ignore; to overlook",
+        "primary_1": "忽视",
+        "primary_2": "忽視"
+    },
+    {
+        "intermediate_1": "hu2shuo1",
+        "intermediate_2": "húshuō",
+        "native_1": "talk nonsense; drivel",
+        "primary_1": "胡说",
+        "primary_2": "胡說"
+    },
+    {
+        "intermediate_1": "hu2tong4",
+        "intermediate_2": "hútòng",
+        "native_1": "lane; alley",
+        "primary_1": "胡同",
+        "primary_2": "胡同"
+    },
+    {
+        "intermediate_1": "hu2",
+        "intermediate_2": "hú",
+        "native_1": "pot; kettle; jug; (mw for bottled liquids)",
+        "primary_1": "壶",
+        "primary_2": "壺"
+    },
+    {
+        "intermediate_1": "hu2die2",
+        "intermediate_2": "húdié",
+        "native_1": "butterfly",
+        "primary_1": "蝴蝶",
+        "primary_2": "蝴蝶"
+    },
+    {
+        "intermediate_1": "hu2tu",
+        "intermediate_2": "hútu",
+        "native_1": "confused; bewildered; muddled",
+        "primary_1": "糊涂",
+        "primary_2": "糊塗"
+    },
+    {
+        "intermediate_1": "hua1sheng1",
+        "intermediate_2": "huāshēng",
+        "native_1": "peanut",
+        "primary_1": "花生",
+        "primary_2": "花生"
+    },
+    {
+        "intermediate_1": "hua4, hua2",
+        "intermediate_2": "huà, huá",
+        "native_1": "delimit; to transfer; assign | to row; to paddle; to scratch",
+        "primary_1": "划",
+        "primary_2": "劃"
+    },
+    {
+        "intermediate_1": "Hua2yi4",
+        "intermediate_2": "Huáyì",
+        "native_1": "person of Chinese descent",
+        "primary_1": "华裔",
+        "primary_2": "華裔"
+    },
+    {
+        "intermediate_1": "hua2",
+        "intermediate_2": "huá",
+        "native_1": "slippery; cunning; crafty",
+        "primary_1": "滑",
+        "primary_2": "滑"
+    },
+    {
+        "intermediate_1": "hua4xue2",
+        "intermediate_2": "huàxué",
+        "native_1": "chemistry",
+        "primary_1": "化学",
+        "primary_2": "化學"
+    },
+    {
+        "intermediate_1": "hua4ti2",
+        "intermediate_2": "huàtí",
+        "native_1": "subject (of a talk or conversation)",
+        "primary_1": "话题",
+        "primary_2": "話題"
+    },
+    {
+        "intermediate_1": "huai2nian4",
+        "intermediate_2": "huáiniàn",
+        "native_1": "cherish the memory of; think fondly of",
+        "primary_1": "怀念",
+        "primary_2": "懷念"
+    },
+    {
+        "intermediate_1": "huai2yun4",
+        "intermediate_2": "huáiyùn",
+        "native_1": "become pregnant; have conceived",
+        "primary_1": "怀孕",
+        "primary_2": "懷孕"
+    },
+    {
+        "intermediate_1": "huan3jie3",
+        "intermediate_2": "huǎnjiě",
+        "native_1": "to alleviate",
+        "primary_1": "缓解",
+        "primary_2": "緩解"
+    },
+    {
+        "intermediate_1": "huan4xiang3",
+        "intermediate_2": "huànxiǎng",
+        "native_1": "delusion; fantasy; illusion",
+        "primary_1": "幻想",
+        "primary_2": "幻想"
+    },
+    {
+        "intermediate_1": "huang1zhang1",
+        "intermediate_2": "huāngzhāng",
+        "native_1": "flustered; flurried",
+        "primary_1": "慌张",
+        "primary_2": "慌張"
+    },
+    {
+        "intermediate_1": "huang2jin1",
+        "intermediate_2": "huángjīn",
+        "native_1": "gold",
+        "primary_1": "黄金",
+        "primary_2": "黃金"
+    },
+    {
+        "intermediate_1": "hui1",
+        "intermediate_2": "huī",
+        "native_1": "ash; gray (grey); dust; lime",
+        "primary_1": "灰",
+        "primary_2": "灰"
+    },
+    {
+        "intermediate_1": "hui1chen2",
+        "intermediate_2": "huīchén",
+        "native_1": "dust; dirt",
+        "primary_1": "灰尘",
+        "primary_2": "灰塵"
+    },
+    {
+        "intermediate_1": "hui1 xin1",
+        "intermediate_2": "huī xīn",
+        "native_1": "lose heart; be discouraged",
+        "primary_1": "灰心",
+        "primary_2": "灰心"
+    },
+    {
+        "intermediate_1": "hui1",
+        "intermediate_2": "huī",
+        "native_1": "to wave; brandish; wield; wipe away",
+        "primary_1": "挥",
+        "primary_2": "揮"
+    },
+    {
+        "intermediate_1": "hui1fu4",
+        "intermediate_2": "huīfù",
+        "native_1": "reinstate; resume; recover",
+        "primary_1": "恢复",
+        "primary_2": "恢複"
+    },
+    {
+        "intermediate_1": "hui4lü4",
+        "intermediate_2": "huìlǜ",
+        "native_1": "exchange rate",
+        "primary_1": "汇率",
+        "primary_2": "彙率"
+    },
+    {
+        "intermediate_1": "hun1li3",
+        "intermediate_2": "hūnlǐ",
+        "native_1": "wedding ceremony",
+        "primary_1": "婚礼",
+        "primary_2": "婚禮"
+    },
+    {
+        "intermediate_1": "hun1yin1",
+        "intermediate_2": "hūnyīn",
+        "native_1": "marriage; matrimony; wedding",
+        "primary_1": "婚姻",
+        "primary_2": "婚姻"
+    },
+    {
+        "intermediate_1": "huo2yue4",
+        "intermediate_2": "huóyuè",
+        "native_1": "active; vigorous",
+        "primary_1": "活跃",
+        "primary_2": "活躍"
+    },
+    {
+        "intermediate_1": "huo3chai2",
+        "intermediate_2": "huǒchái",
+        "native_1": "match (for lighting fire)",
+        "primary_1": "火柴",
+        "primary_2": "火柴"
+    },
+    {
+        "intermediate_1": "huo3ban4",
+        "intermediate_2": "huǒbàn",
+        "native_1": "partner (for an activity); friend; pal",
+        "primary_1": "伙伴",
+        "primary_2": "夥伴"
+    },
+    {
+        "intermediate_1": "huo4xu3",
+        "intermediate_2": "huòxǔ",
+        "native_1": "perhaps; maybe",
+        "primary_1": "或许",
+        "primary_2": "或許"
+    },
+    {
+        "intermediate_1": "ji1qi4",
+        "intermediate_2": "jīqì",
+        "native_1": "machine",
+        "primary_1": "机器",
+        "primary_2": "機器"
+    },
+    {
+        "intermediate_1": "ji1rou4",
+        "intermediate_2": "jīròu",
+        "native_1": "muscle; flesh",
+        "primary_1": "肌肉",
+        "primary_2": "肌肉"
+    },
+    {
+        "intermediate_1": "ji1ben3",
+        "intermediate_2": "jīběn",
+        "native_1": "basic; fundamental",
+        "primary_1": "基本",
+        "primary_2": "基本"
+    },
+    {
+        "intermediate_1": "ji1lie4",
+        "intermediate_2": "jīliè",
+        "native_1": "intense; acute; sharp; fierce",
+        "primary_1": "激烈",
+        "primary_2": "激烈"
+    },
+    {
+        "intermediate_1": "ji2 ge2",
+        "intermediate_2": "jí gé",
+        "native_1": "pass an exam",
+        "primary_1": "及格",
+        "primary_2": "及格"
+    },
+    {
+        "intermediate_1": "ji2qi2",
+        "intermediate_2": "jíqí",
+        "native_1": "extremely; exceedingly",
+        "primary_1": "极其",
+        "primary_2": "極其"
+    },
+    {
+        "intermediate_1": "ji2mang2",
+        "intermediate_2": "jímáng",
+        "native_1": "hastily",
+        "primary_1": "急忙",
+        "primary_2": "急忙"
+    },
+    {
+        "intermediate_1": "ji2zhen3",
+        "intermediate_2": "jízhěn",
+        "native_1": "emergency call; emergency treatment",
+        "primary_1": "急诊",
+        "primary_2": "急診"
+    },
+    {
+        "intermediate_1": "ji2he2",
+        "intermediate_2": "jíhé",
+        "native_1": "gather; assemble; to muster",
+        "primary_1": "集合",
+        "primary_2": "集合"
+    },
+    {
+        "intermediate_1": "ji2ti3",
+        "intermediate_2": "jítǐ",
+        "native_1": "collective; group",
+        "primary_1": "集体",
+        "primary_2": "集體"
+    },
+    {
+        "intermediate_1": "ji2zhong1",
+        "intermediate_2": "jízhōng",
+        "native_1": "concentrate; to focus; amass",
+        "primary_1": "集中",
+        "primary_2": "集中"
+    },
+    {
+        "intermediate_1": "ji4suan4",
+        "intermediate_2": "jìsuàn",
+        "native_1": "to count; calculate; compute",
+        "primary_1": "计算",
+        "primary_2": "計算"
+    },
+    {
+        "intermediate_1": "ji4lu4",
+        "intermediate_2": "jìlù",
+        "native_1": "to record; take notes",
+        "primary_1": "记录",
+        "primary_2": "記錄"
+    },
+    {
+        "intermediate_1": "ji4yi4",
+        "intermediate_2": "jìyì",
+        "native_1": "memory; to remember",
+        "primary_1": "记忆",
+        "primary_2": "記憶"
+    },
+    {
+        "intermediate_1": "ji4lu4",
+        "intermediate_2": "jìlù",
+        "native_1": "a record; to take notes",
+        "primary_1": "纪录",
+        "primary_2": "紀錄"
+    },
+    {
+        "intermediate_1": "ji4lü4",
+        "intermediate_2": "jìlǜ",
+        "native_1": "discipline; morale; laws and regulations",
+        "primary_1": "纪律",
+        "primary_2": "紀律"
+    },
+    {
+        "intermediate_1": "jin4ian4",
+        "intermediate_2": "jìniàn",
+        "native_1": "commemorate; remember",
+        "primary_1": "纪念",
+        "primary_2": "紀念"
+    },
+    {
+        "intermediate_1": "ji4ling3dai4",
+        "intermediate_2": "jìlǐngdài",
+        "native_1": "tie a neck tie",
+        "primary_1": "系领带",
+        "primary_2": "系領帶"
+    },
+    {
+        "intermediate_1": "ji4mo4",
+        "intermediate_2": "jìmò",
+        "native_1": "lonely; lonesome",
+        "primary_1": "寂寞",
+        "primary_2": "寂寞"
+    },
+    {
+        "intermediate_1": "jia1zi",
+        "intermediate_2": "jiāzi",
+        "native_1": "clip; tongs; folder",
+        "primary_1": "夹子",
+        "primary_2": "夾子"
+    },
+    {
+        "intermediate_1": "jia1ting2",
+        "intermediate_2": "jiātíng",
+        "native_1": "family; household",
+        "primary_1": "家庭",
+        "primary_2": "家庭"
+    },
+    {
+        "intermediate_1": "jia1wu4",
+        "intermediate_2": "jiāwù",
+        "native_1": "household duties; chores; housework",
+        "primary_1": "家务",
+        "primary_2": "家務"
+    },
+    {
+        "intermediate_1": "jia1xiang1",
+        "intermediate_2": "jiāxiāng",
+        "native_1": "hometown",
+        "primary_1": "家乡",
+        "primary_2": "家鄉"
+    },
+    {
+        "intermediate_1": "jia1bin1",
+        "intermediate_2": "jiābīn",
+        "native_1": "honored guest",
+        "primary_1": "嘉宾",
+        "primary_2": "嘉賓"
+    },
+    {
+        "intermediate_1": "jia3",
+        "intermediate_2": "jiǎ",
+        "native_1": "one; armor (1st Heavenly Stem)",
+        "primary_1": "甲",
+        "primary_2": "甲"
+    },
+    {
+        "intermediate_1": "jia3ru2",
+        "intermediate_2": "jiǎrú",
+        "native_1": "if; supposing; in case",
+        "primary_1": "假如",
+        "primary_2": "假如"
+    },
+    {
+        "intermediate_1": "jia3she4",
+        "intermediate_2": "jiǎshè",
+        "native_1": "suppose that; hypothesis; conjecture",
+        "primary_1": "假设",
+        "primary_2": "假設"
+    },
+    {
+        "intermediate_1": "jia3zhuang1",
+        "intermediate_2": "jiǎzhuāng",
+        "native_1": "pretend to be; feign",
+        "primary_1": "假装",
+        "primary_2": "假裝"
+    },
+    {
+        "intermediate_1": "jia4zhi2",
+        "intermediate_2": "jiàzhí",
+        "native_1": "value; worth",
+        "primary_1": "价值",
+        "primary_2": "價值"
+    },
+    {
+        "intermediate_1": "jia4shi3",
+        "intermediate_2": "jiàshǐ",
+        "native_1": "to drive; to pilot (a ship, an airplane, etc.)",
+        "primary_1": "驾驶",
+        "primary_2": "駕駛"
+    },
+    {
+        "intermediate_1": "jia4",
+        "intermediate_2": "jià",
+        "native_1": "marry (a husband); take a husband",
+        "primary_1": "嫁",
+        "primary_2": "嫁"
+    },
+    {
+        "intermediate_1": "jian1jue2",
+        "intermediate_2": "jiānjué",
+        "native_1": "resolute; determined; uncompromising",
+        "primary_1": "坚决",
+        "primary_2": "堅決"
+    },
+    {
+        "intermediate_1": "jian1qiang2",
+        "intermediate_2": "jiānqiáng",
+        "native_1": "strong; staunch",
+        "primary_1": "坚强",
+        "primary_2": "堅強"
+    },
+    {
+        "intermediate_1": "jian1bang3",
+        "intermediate_2": "jiānbǎng",
+        "native_1": "shoulder",
+        "primary_1": "肩膀",
+        "primary_2": "肩膀"
+    },
+    {
+        "intermediate_1": "jian1ju4",
+        "intermediate_2": "jiānjù",
+        "native_1": "very difficult; arduous; hard",
+        "primary_1": "艰巨",
+        "primary_2": "艱巨"
+    },
+    {
+        "intermediate_1": "jian1ku3",
+        "intermediate_2": "jiānkǔ",
+        "native_1": "difficult; hard; arduous",
+        "primary_1": "艰苦",
+        "primary_2": "艱苦"
+    },
+    {
+        "intermediate_1": "jian1zhi2",
+        "intermediate_2": "jiānzhí",
+        "native_1": "part time",
+        "primary_1": "兼职",
+        "primary_2": "兼職"
+    },
+    {
+        "intermediate_1": "jian3",
+        "intermediate_2": "jiǎn",
+        "native_1": "to pick up; collect; gather",
+        "primary_1": "捡",
+        "primary_2": "撿"
+    },
+    {
+        "intermediate_1": "jian3dao1",
+        "intermediate_2": "jiǎndāo",
+        "native_1": "scissors",
+        "primary_1": "剪刀",
+        "primary_2": "剪刀"
+    },
+    {
+        "intermediate_1": "jian3li4",
+        "intermediate_2": "jiǎnlì",
+        "native_1": "resume; curriculum vitae",
+        "primary_1": "简历",
+        "primary_2": "簡曆"
+    },
+    {
+        "intermediate_1": "jian3zhi2",
+        "intermediate_2": "jiǎnzhí",
+        "native_1": "simply; at all",
+        "primary_1": "简直",
+        "primary_2": "簡直"
+    },
+    {
+        "intermediate_1": "jian4li4",
+        "intermediate_2": "jiànlì",
+        "native_1": "establish; to construct; to set up",
+        "primary_1": "建立",
+        "primary_2": "建立"
+    },
+    {
+        "intermediate_1": "jian4she4",
+        "intermediate_2": "jiànshè",
+        "native_1": "to build; to construct; construction",
+        "primary_1": "建设",
+        "primary_2": "建設"
+    },
+    {
+        "intermediate_1": "jian4zhu4",
+        "intermediate_2": "jiànzhù",
+        "native_1": "a building; to construct; architecture",
+        "primary_1": "建筑",
+        "primary_2": "建築"
+    },
+    {
+        "intermediate_1": "jian4shen1",
+        "intermediate_2": "jiànshēn",
+        "native_1": "work out; body-building",
+        "primary_1": "健身",
+        "primary_2": "健身"
+    },
+    {
+        "intermediate_1": "jian4pan2",
+        "intermediate_2": "jiànpán",
+        "native_1": "keyboard",
+        "primary_1": "键盘",
+        "primary_2": "鍵盤"
+    },
+    {
+        "intermediate_1": "jiang3jiu",
+        "intermediate_2": "jiǎngjiu",
+        "native_1": "Be particular about; fastidious; stress; exquisite ; careful study",
+        "primary_1": "讲究",
+        "primary_2": "講究"
+    },
+    {
+        "intermediate_1": "jiang3zuo4",
+        "intermediate_2": "jiǎngzuò",
+        "native_1": "a lecture or course of lectures; lecture hall",
+        "primary_1": "讲座",
+        "primary_2": "講座"
+    },
+    {
+        "intermediate_1": "jiang4you2",
+        "intermediate_2": "jiàngyóu",
+        "native_1": "soy sauce",
+        "primary_1": "酱油",
+        "primary_2": "醬油"
+    },
+    {
+        "intermediate_1": "jiao1huan4",
+        "intermediate_2": "jiāohuàn",
+        "native_1": "to exchange; to swap; to switch",
+        "primary_1": "交换",
+        "primary_2": "交換"
+    },
+    {
+        "intermediate_1": "jiao1ji4",
+        "intermediate_2": "jiāojì",
+        "native_1": "socialize; social intercourse; communication",
+        "primary_1": "交际",
+        "primary_2": "交際"
+    },
+    {
+        "intermediate_1": "jiao1wang3",
+        "intermediate_2": "jiāowǎng",
+        "native_1": "to associate; to contact",
+        "primary_1": "交往",
+        "primary_2": "交往"
+    },
+    {
+        "intermediate_1": "jiao1",
+        "intermediate_2": "jiāo",
+        "native_1": "to water; irrigate; to pour; to sprinkle",
+        "primary_1": "浇",
+        "primary_2": "澆"
+    },
+    {
+        "intermediate_1": "jiao1shui3",
+        "intermediate_2": "jiāoshuǐ",
+        "native_1": "(watery) glue; gum",
+        "primary_1": "胶水",
+        "primary_2": "膠水"
+    },
+    {
+        "intermediate_1": "jiao3du4",
+        "intermediate_2": "jiǎodù",
+        "native_1": "angle; point of view",
+        "primary_1": "角度",
+        "primary_2": "角度"
+    },
+    {
+        "intermediate_1": "jiao3hua2",
+        "intermediate_2": "jiǎohuá",
+        "native_1": "crafty; cunning; sly",
+        "primary_1": "狡猾",
+        "primary_2": "狡猾"
+    },
+    {
+        "intermediate_1": "jiao4cai2",
+        "intermediate_2": "jiàocái",
+        "native_1": "teaching materials",
+        "primary_1": "教材",
+        "primary_2": "教材"
+    },
+    {
+        "intermediate_1": "jiao4lian4",
+        "intermediate_2": "jiàoliàn",
+        "native_1": "(athlete's) coach; sports coach; instructor",
+        "primary_1": "教练",
+        "primary_2": "教練"
+    },
+    {
+        "intermediate_1": "jiao4xun",
+        "intermediate_2": "jiàoxun",
+        "native_1": "lesson; teach someone or learn a lesson; a moral",
+        "primary_1": "教训",
+        "primary_2": "教訓"
+    },
+    {
+        "intermediate_1": "jie1duan4",
+        "intermediate_2": "jiēduàn",
+        "native_1": "stage; phase",
+        "primary_1": "阶段",
+        "primary_2": "階段"
+    },
+    {
+        "intermediate_1": "jie1shi",
+        "intermediate_2": "jiēshi",
+        "native_1": "sturdy; (also -shí: bear fruit)",
+        "primary_1": "结实",
+        "primary_2": "結實"
+    },
+    {
+        "intermediate_1": "jie1chu4",
+        "intermediate_2": "jiēchù",
+        "native_1": "come into contact with",
+        "primary_1": "接触",
+        "primary_2": "接觸"
+    },
+    {
+        "intermediate_1": "jie1dai4",
+        "intermediate_2": "jiēdài",
+        "native_1": "receive (a visitor); admit (entry to)",
+        "primary_1": "接待",
+        "primary_2": "接待"
+    },
+    {
+        "intermediate_1": "jie1jin4",
+        "intermediate_2": "jiējìn",
+        "native_1": "near; be close to",
+        "primary_1": "接近",
+        "primary_2": "接近"
+    },
+    {
+        "intermediate_1": "jie2sheng3",
+        "intermediate_2": "jiéshěng",
+        "native_1": "save; use sparingly; frugal",
+        "primary_1": "节省",
+        "primary_2": "節省"
+    },
+    {
+        "intermediate_1": "jie2gou4",
+        "intermediate_2": "jiégòu",
+        "native_1": "structure; composition",
+        "primary_1": "结构",
+        "primary_2": "結構"
+    },
+    {
+        "intermediate_1": "jie2he2",
+        "intermediate_2": "jiéhé",
+        "native_1": "combine; to link; to bind",
+        "primary_1": "结合",
+        "primary_2": "結合"
+    },
+    {
+        "intermediate_1": "jie2lun4",
+        "intermediate_2": "jiélùn",
+        "native_1": "conclusion; verdict",
+        "primary_1": "结论",
+        "primary_2": "結論"
+    },
+    {
+        "intermediate_1": "jie2zhang4",
+        "intermediate_2": "jiézhàng",
+        "native_1": "pay the bill; settle accounts",
+        "primary_1": "结账",
+        "primary_2": "結賬"
+    },
+    {
+        "intermediate_1": "jie4",
+        "intermediate_2": "jiè",
+        "native_1": "warn against; swear off",
+        "primary_1": "戒",
+        "primary_2": "戒"
+    },
+    {
+        "intermediate_1": "jie4zhi",
+        "intermediate_2": "jièzhi",
+        "native_1": "(finger) ring",
+        "primary_1": "戒指",
+        "primary_2": "戒指"
+    },
+    {
+        "intermediate_1": "jie4",
+        "intermediate_2": "jiè",
+        "native_1": "arrive at; period; session; (mw for events; meetings; etc.)",
+        "primary_1": "届",
+        "primary_2": "屆"
+    },
+    {
+        "intermediate_1": "jie4kou3",
+        "intermediate_2": "jièkǒu",
+        "native_1": "excuse",
+        "primary_1": "借口",
+        "primary_2": "借口"
+    },
+    {
+        "intermediate_1": "jin1shu3",
+        "intermediate_2": "jīnshǔ",
+        "native_1": "metal",
+        "primary_1": "金属",
+        "primary_2": "金屬"
+    },
+    {
+        "intermediate_1": "jin3kuai4",
+        "intermediate_2": "jǐnkuài",
+        "native_1": "as quickly as possible",
+        "primary_1": "尽快",
+        "primary_2": "盡快"
+    },
+    {
+        "intermediate_1": "jin3liang4",
+        "intermediate_2": "jǐnliàng",
+        "native_1": "as much as possible; to the best of one's ability (jìn-: eat or drink to one's fill)",
+        "primary_1": "尽量",
+        "primary_2": "盡量"
+    },
+    {
+        "intermediate_1": "jin3ji2",
+        "intermediate_2": "jǐnjí",
+        "native_1": "urgent; pressing",
+        "primary_1": "紧急",
+        "primary_2": "緊急"
+    },
+    {
+        "intermediate_1": "jin3shen4",
+        "intermediate_2": "jǐnshèn",
+        "native_1": "cautious; prudent",
+        "primary_1": "谨慎",
+        "primary_2": "謹慎"
+    },
+    {
+        "intermediate_1": "jin4 li4",
+        "intermediate_2": "jìn lì",
+        "native_1": "do one's best; to strive as much as possible",
+        "primary_1": "尽力",
+        "primary_2": "盡力"
+    },
+    {
+        "intermediate_1": "jin4bu4",
+        "intermediate_2": "jìnbù",
+        "native_1": "make progress; to advance",
+        "primary_1": "进步",
+        "primary_2": "進步"
+    },
+    {
+        "intermediate_1": "jin4 kou3",
+        "intermediate_2": "jìn kǒu",
+        "native_1": "import; entrance; enter",
+        "primary_1": "进口",
+        "primary_2": "進口"
+    },
+    {
+        "intermediate_1": "jin4dai4",
+        "intermediate_2": "jìndài",
+        "native_1": "modern times; latest generation",
+        "primary_1": "近代",
+        "primary_2": "近代"
+    },
+    {
+        "intermediate_1": "jing1dian3",
+        "intermediate_2": "jīngdiǎn",
+        "native_1": "classics; scriptures",
+        "primary_1": "经典",
+        "primary_2": "經典"
+    },
+    {
+        "intermediate_1": "jing1 shang1",
+        "intermediate_2": "jīng shāng",
+        "native_1": "trade; be in business; do commerce",
+        "primary_1": "经商",
+        "primary_2": "經商"
+    },
+    {
+        "intermediate_1": "jing1ying2",
+        "intermediate_2": "jīngyíng",
+        "native_1": "engage in (a business activity, etc.); run/operate (a business)",
+        "primary_1": "经营",
+        "primary_2": "經營"
+    },
+    {
+        "intermediate_1": "jing1li4",
+        "intermediate_2": "jīnglì",
+        "native_1": "energy; vigor",
+        "primary_1": "精力",
+        "primary_2": "精力"
+    },
+    {
+        "intermediate_1": "jing1shen",
+        "intermediate_2": "jīngshen",
+        "native_1": "vigor; spirit; mind",
+        "primary_1": "精神",
+        "primary_2": "精神"
+    },
+    {
+        "intermediate_1": "jiu3ba1",
+        "intermediate_2": "jiǔbā",
+        "native_1": "bar",
+        "primary_1": "酒吧",
+        "primary_2": "酒吧"
+    },
+    {
+        "intermediate_1": "jiu4",
+        "intermediate_2": "jiù",
+        "native_1": "to save (life); to assist; to rescue",
+        "primary_1": "救",
+        "primary_2": "救"
+    },
+    {
+        "intermediate_1": "jiu4hu4che1",
+        "intermediate_2": "jiùhùchē",
+        "native_1": "ambulance",
+        "primary_1": "救护车",
+        "primary_2": "救護車"
+    },
+    {
+        "intermediate_1": "jiu4jiu",
+        "intermediate_2": "jiùjiu",
+        "native_1": "mother's brother; maternal uncle",
+        "primary_1": "舅舅",
+        "primary_2": "舅舅"
+    },
+    {
+        "intermediate_1": "ju1ran2",
+        "intermediate_2": "jūrán",
+        "native_1": "unexpectedly; to one's surprise; go so far as to",
+        "primary_1": "居然",
+        "primary_2": "居然"
+    },
+    {
+        "intermediate_1": "ju2zi",
+        "intermediate_2": "júzi",
+        "native_1": "tangerine",
+        "primary_1": "桔子",
+        "primary_2": "桔子"
+    },
+    {
+        "intermediate_1": "ju4da4",
+        "intermediate_2": "jùdà",
+        "native_1": "immense; enormous; very large",
+        "primary_1": "巨大",
+        "primary_2": "巨大"
+    },
+    {
+        "intermediate_1": "ju4bei4",
+        "intermediate_2": "jùbèi",
+        "native_1": "possess; be equipped with",
+        "primary_1": "具备",
+        "primary_2": "具備"
+    },
+    {
+        "intermediate_1": "ju4ti3",
+        "intermediate_2": "jùtǐ",
+        "native_1": "concrete; definite; specific",
+        "primary_1": "具体",
+        "primary_2": "具體"
+    },
+    {
+        "intermediate_1": "ju4le4bu4",
+        "intermediate_2": "jùlèbù",
+        "native_1": "club (group or organization)",
+        "primary_1": "俱乐部",
+        "primary_2": "俱樂部"
+    },
+    {
+        "intermediate_1": "ju4shuo1",
+        "intermediate_2": "jùshuō",
+        "native_1": "it is said that; reportedly",
+        "primary_1": "据说",
+        "primary_2": "據說"
+    },
+    {
+        "intermediate_1": "juan1",
+        "intermediate_2": "juān",
+        "native_1": "to contribute; to donate; to subsribe to; to abandon; to relinquish; contribution; tax",
+        "primary_1": "捐",
+        "primary_2": "捐"
+    },
+    {
+        "intermediate_1": "jue2sai4",
+        "intermediate_2": "juésài",
+        "native_1": "finals (of a competition); final match",
+        "primary_1": "决赛",
+        "primary_2": "決賽"
+    },
+    {
+        "intermediate_1": "jue2xin1",
+        "intermediate_2": "juéxīn",
+        "native_1": "determination; resolution",
+        "primary_1": "决心",
+        "primary_2": "決心"
+    },
+    {
+        "intermediate_1": "jue2se4",
+        "intermediate_2": "juésè",
+        "native_1": "role; part",
+        "primary_1": "角色",
+        "primary_2": "角色"
+    },
+    {
+        "intermediate_1": "jue2dui4",
+        "intermediate_2": "juéduì",
+        "native_1": "absolute; definite",
+        "primary_1": "绝对",
+        "primary_2": "絕對"
+    },
+    {
+        "intermediate_1": "jun1shi4",
+        "intermediate_2": "jūnshì",
+        "native_1": "military affairs; military matters",
+        "primary_1": "军事",
+        "primary_2": "軍事"
+    },
+    {
+        "intermediate_1": "jun1yun2",
+        "intermediate_2": "jūnyún",
+        "native_1": "even; well-distributed",
+        "primary_1": "均匀",
+        "primary_2": "均勻"
+    },
+    {
+        "intermediate_1": "ka3che1",
+        "intermediate_2": "kǎchē",
+        "native_1": "truck",
+        "primary_1": "卡车",
+        "primary_2": "卡車"
+    },
+    {
+        "intermediate_1": "kai1fa1",
+        "intermediate_2": "kāifā",
+        "native_1": "develop; to exploit (a resource)",
+        "primary_1": "开发",
+        "primary_2": "開發"
+    },
+    {
+        "intermediate_1": "kai1fang4",
+        "intermediate_2": "kāifàng",
+        "native_1": "(of flowers) to bloom; open up; to be open-minded; lift a ban, restriction, etc.; release; liberalization; China's 1979 open policy",
+        "primary_1": "开放",
+        "primary_2": "開放"
+    },
+    {
+        "intermediate_1": "kai1mu4shi4",
+        "intermediate_2": "kāimùshì",
+        "native_1": "opening ceremony",
+        "primary_1": "开幕式",
+        "primary_2": "開幕式"
+    },
+    {
+        "intermediate_1": "kai1shui3",
+        "intermediate_2": "kāishuǐ",
+        "native_1": "boiled water; boil water",
+        "primary_1": "开水",
+        "primary_2": "開水"
+    },
+    {
+        "intermediate_1": "kan3",
+        "intermediate_2": "kǎn",
+        "native_1": "to chop; cut down",
+        "primary_1": "砍",
+        "primary_2": "砍"
+    },
+    {
+        "intermediate_1": "kan4 bu qi3",
+        "intermediate_2": "kàn bu qǐ",
+        "native_1": "look down upon; despise",
+        "primary_1": "看不起",
+        "primary_2": "看不起"
+    },
+    {
+        "intermediate_1": "kan4wang4",
+        "intermediate_2": "kànwàng",
+        "native_1": "visit; call on; see",
+        "primary_1": "看望",
+        "primary_2": "看望"
+    },
+    {
+        "intermediate_1": "kao4",
+        "intermediate_2": "kào",
+        "native_1": "depend on; lean on; near; to trust",
+        "primary_1": "靠",
+        "primary_2": "靠"
+    },
+    {
+        "intermediate_1": "ke1",
+        "intermediate_2": "kē",
+        "native_1": "(mw for hearts and small, round things like seeds, grains, beans, etc.)",
+        "primary_1": "颗",
+        "primary_2": "顆"
+    },
+    {
+        "intermediate_1": "ke3jian4",
+        "intermediate_2": "kějiàn",
+        "native_1": "it can clearly be seen that; clear",
+        "primary_1": "可见",
+        "primary_2": "可見"
+    },
+    {
+        "intermediate_1": "ke3kao4",
+        "intermediate_2": "kěkào",
+        "native_1": "reliable",
+        "primary_1": "可靠",
+        "primary_2": "可靠"
+    },
+    {
+        "intermediate_1": "ke3pa4",
+        "intermediate_2": "kěpà",
+        "native_1": "terrible; awful; frightful; scary",
+        "primary_1": "可怕",
+        "primary_2": "可怕"
+    },
+    {
+        "intermediate_1": "ke4",
+        "intermediate_2": "kè",
+        "native_1": "gram; overcome; restrain",
+        "primary_1": "克",
+        "primary_2": "克"
+    },
+    {
+        "intermediate_1": "ke4fu2",
+        "intermediate_2": "kèfú",
+        "native_1": "overcome (hardships, etc.); conquer",
+        "primary_1": "克服",
+        "primary_2": "克服"
+    },
+    {
+        "intermediate_1": "ke4ku3",
+        "intermediate_2": "kèkǔ",
+        "native_1": "hardworking; assiduous",
+        "primary_1": "刻苦",
+        "primary_2": "刻苦"
+    },
+    {
+        "intermediate_1": "ke4guan1",
+        "intermediate_2": "kèguān",
+        "native_1": "objective; impartial; unbiased",
+        "primary_1": "客观",
+        "primary_2": "客觀"
+    },
+    {
+        "intermediate_1": "ke4cheng2",
+        "intermediate_2": "kèchéng",
+        "native_1": "course; curriculum; class",
+        "primary_1": "课程",
+        "primary_2": "課程"
+    },
+    {
+        "intermediate_1": "kong1jian1",
+        "intermediate_2": "kōngjiān",
+        "native_1": "space",
+        "primary_1": "空间",
+        "primary_2": "空間"
+    },
+    {
+        "intermediate_1": "kong4xian2",
+        "intermediate_2": "kòngxián",
+        "native_1": "leisure; free time; idle; unused",
+        "primary_1": "空闲",
+        "primary_2": "空閑"
+    },
+    {
+        "intermediate_1": "kong4zhi4",
+        "intermediate_2": "kòngzhì",
+        "native_1": "to control",
+        "primary_1": "控制",
+        "primary_2": "控制"
+    },
+    {
+        "intermediate_1": "kou3wei4",
+        "intermediate_2": "kǒuwèi",
+        "native_1": "a person's tastes or preferences",
+        "primary_1": "口味",
+        "primary_2": "口味"
+    },
+    {
+        "intermediate_1": "kua1",
+        "intermediate_2": "kuā",
+        "native_1": "to boast; to praise; exaggerate",
+        "primary_1": "夸",
+        "primary_2": "誇"
+    },
+    {
+        "intermediate_1": "kua1zhang1",
+        "intermediate_2": "kuāzhāng",
+        "native_1": "exaggerate; overstate; exaggerated; overstated; vaunted; hyperbole",
+        "primary_1": "夸张",
+        "primary_2": "誇張"
+    },
+    {
+        "intermediate_1": "kuai4ji4",
+        "intermediate_2": "kuàijì",
+        "native_1": "accountant; accounting",
+        "primary_1": "会计",
+        "primary_2": "會計"
+    },
+    {
+        "intermediate_1": "kuan1",
+        "intermediate_2": "kuān",
+        "native_1": "wide; broad; relaxed; lenient",
+        "primary_1": "宽",
+        "primary_2": "寬"
+    },
+    {
+        "intermediate_1": "kun1chong2",
+        "intermediate_2": "kūnchóng",
+        "native_1": "insect",
+        "primary_1": "昆虫",
+        "primary_2": "昆蟲"
+    },
+    {
+        "intermediate_1": "kuo4da4",
+        "intermediate_2": "kuòdà",
+        "native_1": "enlarge; expand",
+        "primary_1": "扩大",
+        "primary_2": "擴大"
+    },
+    {
+        "intermediate_1": "la4jiao1",
+        "intermediate_2": "làjiāo",
+        "native_1": "hot pepper; chili",
+        "primary_1": "辣椒",
+        "primary_2": "辣椒"
+    },
+    {
+        "intermediate_1": "lan2",
+        "intermediate_2": "lán",
+        "native_1": "to block; to cut off; hinder",
+        "primary_1": "拦",
+        "primary_2": "攔"
+    },
+    {
+        "intermediate_1": "lan4",
+        "intermediate_2": "làn",
+        "native_1": "overcooked; rotten; soft; mushy",
+        "primary_1": "烂",
+        "primary_2": "爛"
+    },
+    {
+        "intermediate_1": "lang3du2",
+        "intermediate_2": "lǎngdú",
+        "native_1": "read aloud",
+        "primary_1": "朗读",
+        "primary_2": "朗讀"
+    },
+    {
+        "intermediate_1": "lao2dong4",
+        "intermediate_2": "láodòng",
+        "native_1": "work; toil; (physical) labor",
+        "primary_1": "劳动",
+        "primary_2": "勞動"
+    },
+    {
+        "intermediate_1": "lao2 jia4",
+        "intermediate_2": "láo jià",
+        "native_1": "excuse me",
+        "primary_1": "劳驾",
+        "primary_2": "勞駕"
+    },
+    {
+        "intermediate_1": "lao3bai3xing4",
+        "intermediate_2": "lǎobǎixìng",
+        "native_1": "ordinary people; the person on the street; civilians",
+        "primary_1": "老百姓",
+        "primary_2": "老百姓"
+    },
+    {
+        "intermediate_1": "lao3ban3",
+        "intermediate_2": "lǎobǎn",
+        "native_1": "boss; proprietor; shopkeeper",
+        "primary_1": "老板",
+        "primary_2": "老板"
+    },
+    {
+        "intermediate_1": "lao3po2",
+        "intermediate_2": "lǎopó",
+        "native_1": "(informal) wife",
+        "primary_1": "老婆",
+        "primary_2": "老婆"
+    },
+    {
+        "intermediate_1": "lao3shi",
+        "intermediate_2": "lǎoshi",
+        "native_1": "honest; sincere; naive; simpleminded",
+        "primary_1": "老实",
+        "primary_2": "老實"
+    },
+    {
+        "intermediate_1": "lao3shu3",
+        "intermediate_2": "lǎoshǔ",
+        "native_1": "rat; mouse",
+        "primary_1": "老鼠",
+        "primary_2": "老鼠"
+    },
+    {
+        "intermediate_1": "lao3lao",
+        "intermediate_2": "lǎolao",
+        "native_1": "maternal grandmother",
+        "primary_1": "姥姥",
+        "primary_2": "姥姥"
+    },
+    {
+        "intermediate_1": "le4guan1",
+        "intermediate_2": "lèguān",
+        "native_1": "optimism; hopeful",
+        "primary_1": "乐观",
+        "primary_2": "樂觀"
+    },
+    {
+        "intermediate_1": "lei2",
+        "intermediate_2": "léi",
+        "native_1": "thunder",
+        "primary_1": "雷",
+        "primary_2": "雷"
+    },
+    {
+        "intermediate_1": "lei4xing2",
+        "intermediate_2": "lèixíng",
+        "native_1": "type",
+        "primary_1": "类型",
+        "primary_2": "類型"
+    },
+    {
+        "intermediate_1": "leng3dan4",
+        "intermediate_2": "lěngdàn",
+        "native_1": "cold; chill; indifferent; unconcerned",
+        "primary_1": "冷淡",
+        "primary_2": "冷淡"
+    },
+    {
+        "intermediate_1": "li2mi3",
+        "intermediate_2": "límǐ",
+        "native_1": "centimeter",
+        "primary_1": "厘米",
+        "primary_2": "厘米"
+    },
+    {
+        "intermediate_1": "li2 hun1",
+        "intermediate_2": "lí hūn",
+        "native_1": "to divorce; divorced from (one's spouse)",
+        "primary_1": "离婚",
+        "primary_2": "離婚"
+    },
+    {
+        "intermediate_1": "li2",
+        "intermediate_2": "lí",
+        "native_1": "pear",
+        "primary_1": "梨",
+        "primary_2": "梨"
+    },
+    {
+        "intermediate_1": "li3lun4",
+        "intermediate_2": "lǐlùn",
+        "native_1": "theory",
+        "primary_1": "理论",
+        "primary_2": "理論"
+    },
+    {
+        "intermediate_1": "li3you2",
+        "intermediate_2": "lǐyóu",
+        "native_1": "a reason; grounds; argument",
+        "primary_1": "理由",
+        "primary_2": "理由"
+    },
+    {
+        "intermediate_1": "li4liang",
+        "intermediate_2": "lìliang",
+        "native_1": "power; force; strength",
+        "primary_1": "力量",
+        "primary_2": "力量"
+    },
+    {
+        "intermediate_1": "li4ji2",
+        "intermediate_2": "lìjí",
+        "native_1": "immediately",
+        "primary_1": "立即",
+        "primary_2": "立即"
+    },
+    {
+        "intermediate_1": "li4ke4",
+        "intermediate_2": "lìkè",
+        "native_1": "immediately; at once; right away",
+        "primary_1": "立刻",
+        "primary_2": "立刻"
+    },
+    {
+        "intermediate_1": "li4run4",
+        "intermediate_2": "lìrùn",
+        "native_1": "profit",
+        "primary_1": "利润",
+        "primary_2": "利潤"
+    },
+    {
+        "intermediate_1": "li4xi1",
+        "intermediate_2": "lìxī",
+        "native_1": "interest (on a loan)",
+        "primary_1": "利息",
+        "primary_2": "利息"
+    },
+    {
+        "intermediate_1": "li4yi4",
+        "intermediate_2": "lìyì",
+        "native_1": "benefit; (in sb.'s) interest",
+        "primary_1": "利益",
+        "primary_2": "利益"
+    },
+    {
+        "intermediate_1": "li4yong4",
+        "intermediate_2": "lìyòng",
+        "native_1": "to use; to make use of; to exploit",
+        "primary_1": "利用",
+        "primary_2": "利用"
+    },
+    {
+        "intermediate_1": "lian2mang2",
+        "intermediate_2": "liánmáng",
+        "native_1": "promptly; at once",
+        "primary_1": "连忙",
+        "primary_2": "連忙"
+    },
+    {
+        "intermediate_1": "lian2xu4",
+        "intermediate_2": "liánxù",
+        "native_1": "continually; in a row; successively",
+        "primary_1": "连续",
+        "primary_2": "連續"
+    },
+    {
+        "intermediate_1": "lian2he2",
+        "intermediate_2": "liánhé",
+        "native_1": "alliance; combine; unite",
+        "primary_1": "联合",
+        "primary_2": "聯合"
+    },
+    {
+        "intermediate_1": "lian4'ai4",
+        "intermediate_2": "liàn'ài",
+        "native_1": "romantic love; be in love; love affair",
+        "primary_1": "恋爱",
+        "primary_2": "戀愛"
+    },
+    {
+        "intermediate_1": "liang2hao3",
+        "intermediate_2": "liánghǎo",
+        "native_1": "good; favorable; well",
+        "primary_1": "良好",
+        "primary_2": "良好"
+    },
+    {
+        "intermediate_1": "liang2shi",
+        "intermediate_2": "liángshi",
+        "native_1": "grain; food; cereals",
+        "primary_1": "粮食",
+        "primary_2": "糧食"
+    },
+    {
+        "intermediate_1": "liang4",
+        "intermediate_2": "liàng",
+        "native_1": "bright; light; shiny",
+        "primary_1": "亮",
+        "primary_2": "亮"
+    },
+    {
+        "intermediate_1": "liao3buqi3",
+        "intermediate_2": "liǎobuqǐ",
+        "native_1": "incredible; extraordinary; great; amazing",
+        "primary_1": "了不起",
+        "primary_2": "了不起"
+    },
+    {
+        "intermediate_1": "lie4che1",
+        "intermediate_2": "lièchē",
+        "native_1": "train (railway term)",
+        "primary_1": "列车",
+        "primary_2": "列車"
+    },
+    {
+        "intermediate_1": "lin2shi2",
+        "intermediate_2": "línshí",
+        "native_1": "temporary; at the time; when the time comes",
+        "primary_1": "临时",
+        "primary_2": "臨時"
+    },
+    {
+        "intermediate_1": "ling2huo2",
+        "intermediate_2": "línghuó",
+        "native_1": "flexible; nimble; agile",
+        "primary_1": "灵活",
+        "primary_2": "靈活"
+    },
+    {
+        "intermediate_1": "ling2",
+        "intermediate_2": "líng",
+        "native_1": "bell",
+        "primary_1": "铃",
+        "primary_2": "鈴"
+    },
+    {
+        "intermediate_1": "ling2jian4",
+        "intermediate_2": "língjiàn",
+        "native_1": "spare parts; component",
+        "primary_1": "零件",
+        "primary_2": "零件"
+    },
+    {
+        "intermediate_1": "ling2shi2",
+        "intermediate_2": "língshí",
+        "native_1": "snack",
+        "primary_1": "零食",
+        "primary_2": "零食"
+    },
+    {
+        "intermediate_1": "ling3dao3",
+        "intermediate_2": "lǐngdǎo",
+        "native_1": "to lead; leader; leadership",
+        "primary_1": "领导",
+        "primary_2": "領導"
+    },
+    {
+        "intermediate_1": "ling3yu4",
+        "intermediate_2": "lǐngyù",
+        "native_1": "domain; sphere; field; area",
+        "primary_1": "领域",
+        "primary_2": "領域"
+    },
+    {
+        "intermediate_1": "liu2lan3",
+        "intermediate_2": "liúlǎn",
+        "native_1": "browse; glance over; skim through",
+        "primary_1": "浏览",
+        "primary_2": "浏覽"
+    },
+    {
+        "intermediate_1": "liu2chuan2",
+        "intermediate_2": "liúchuán",
+        "native_1": "to spread; circulate; hand down",
+        "primary_1": "流传",
+        "primary_2": "流傳"
+    },
+    {
+        "intermediate_1": "liu2lei4",
+        "intermediate_2": "liúlèi",
+        "native_1": "shed tears",
+        "primary_1": "流泪",
+        "primary_2": "流淚"
+    },
+    {
+        "intermediate_1": "long2",
+        "intermediate_2": "lóng",
+        "native_1": "dragon (Kangxi radical 212)",
+        "primary_1": "龙",
+        "primary_2": "龍"
+    },
+    {
+        "intermediate_1": "lou4",
+        "intermediate_2": "lòu",
+        "native_1": "to leak; to funnel; to let out",
+        "primary_1": "漏",
+        "primary_2": "漏"
+    },
+    {
+        "intermediate_1": "lu4di4",
+        "intermediate_2": "lùdì",
+        "native_1": "land; dry land (as opposed to the sea)",
+        "primary_1": "陆地",
+        "primary_2": "陸地"
+    },
+    {
+        "intermediate_1": "lu4xu4",
+        "intermediate_2": "lùxù",
+        "native_1": "in turn; successively; one after another",
+        "primary_1": "陆续",
+        "primary_2": "陸續"
+    },
+    {
+        "intermediate_1": "lu4qu3",
+        "intermediate_2": "lùqǔ",
+        "native_1": "recruit; enroll; matriculate",
+        "primary_1": "录取",
+        "primary_2": "錄取"
+    },
+    {
+        "intermediate_1": "lu4yin1",
+        "intermediate_2": "lùyīn",
+        "native_1": "sound recording; to record",
+        "primary_1": "录音",
+        "primary_2": "錄音"
+    },
+    {
+        "intermediate_1": "lun2liu2",
+        "intermediate_2": "lúnliú",
+        "native_1": "to alternate; take turns; rotate",
+        "primary_1": "轮流",
+        "primary_2": "輪流"
+    },
+    {
+        "intermediate_1": "lun4wen2",
+        "intermediate_2": "lùnwén",
+        "native_1": "thesis; paper; treatise",
+        "primary_1": "论文",
+        "primary_2": "論文"
+    },
+    {
+        "intermediate_1": "luo2ji",
+        "intermediate_2": "luóji",
+        "native_1": "logic",
+        "primary_1": "逻辑",
+        "primary_2": "邏輯"
+    },
+    {
+        "intermediate_1": "luo4hou4",
+        "intermediate_2": "luòhòu",
+        "native_1": "backward; to lag (in technology); to fall behind",
+        "primary_1": "落后",
+        "primary_2": "落後"
+    },
+    {
+        "intermediate_1": "ma4",
+        "intermediate_2": "mà",
+        "native_1": "scold; curse; condemn; verbally abuse",
+        "primary_1": "骂",
+        "primary_2": "罵"
+    },
+    {
+        "intermediate_1": "mai4ke4feng1",
+        "intermediate_2": "màikèfēng",
+        "native_1": "microphone",
+        "primary_1": "麦克风",
+        "primary_2": "麥克風"
+    },
+    {
+        "intermediate_1": "man2tou",
+        "intermediate_2": "mántou",
+        "native_1": "steamed bun/roll",
+        "primary_1": "馒头",
+        "primary_2": "饅頭"
+    },
+    {
+        "intermediate_1": "man3zu2",
+        "intermediate_2": "mǎnzú",
+        "native_1": "satisfy; meet (the needs of)",
+        "primary_1": "满足",
+        "primary_2": "滿足"
+    },
+    {
+        "intermediate_1": "mao2bing4",
+        "intermediate_2": "máobìng",
+        "native_1": "fault; bad habit; shortcoming",
+        "primary_1": "毛病",
+        "primary_2": "毛病"
+    },
+    {
+        "intermediate_1": "mao2dun4",
+        "intermediate_2": "máodùn",
+        "native_1": "contradiction; conflict",
+        "primary_1": "矛盾",
+        "primary_2": "矛盾"
+    },
+    {
+        "intermediate_1": "mao4xian3",
+        "intermediate_2": "màoxiǎn",
+        "native_1": "take a risk; take chances",
+        "primary_1": "冒险",
+        "primary_2": "冒險"
+    },
+    {
+        "intermediate_1": "mao4yi4",
+        "intermediate_2": "màoyì",
+        "native_1": "(commercial) trade",
+        "primary_1": "贸易",
+        "primary_2": "貿易"
+    },
+    {
+        "intermediate_1": "mei2mao",
+        "intermediate_2": "méimao",
+        "native_1": "eyebrow",
+        "primary_1": "眉毛",
+        "primary_2": "眉毛"
+    },
+    {
+        "intermediate_1": "mei2ti3",
+        "intermediate_2": "méitǐ",
+        "native_1": "(news) media; medium",
+        "primary_1": "媒体",
+        "primary_2": "媒體"
+    },
+    {
+        "intermediate_1": "mei2tan4",
+        "intermediate_2": "méitàn",
+        "native_1": "coal",
+        "primary_1": "煤炭",
+        "primary_2": "煤炭"
+    },
+    {
+        "intermediate_1": "mei3shu4",
+        "intermediate_2": "měishù",
+        "native_1": "the fine arts; art",
+        "primary_1": "美术",
+        "primary_2": "美術"
+    },
+    {
+        "intermediate_1": "mei4li4",
+        "intermediate_2": "mèilì",
+        "native_1": "charm; glamour; enchantment",
+        "primary_1": "魅力",
+        "primary_2": "魅力"
+    },
+    {
+        "intermediate_1": "meng4xiang3",
+        "intermediate_2": "mèngxiǎng",
+        "native_1": "dream of; wishful thinking",
+        "primary_1": "梦想",
+        "primary_2": "夢想"
+    },
+    {
+        "intermediate_1": "mi4mi4",
+        "intermediate_2": "mìmì",
+        "native_1": "a secret; confidential",
+        "primary_1": "秘密",
+        "primary_2": "秘密"
+    },
+    {
+        "intermediate_1": "mi4shu",
+        "intermediate_2": "mìshu",
+        "native_1": "secretary",
+        "primary_1": "秘书",
+        "primary_2": "秘書"
+    },
+    {
+        "intermediate_1": "mi4qie4",
+        "intermediate_2": "mìqiè",
+        "native_1": "close; familiar; intimate",
+        "primary_1": "密切",
+        "primary_2": "密切"
+    },
+    {
+        "intermediate_1": "mi4feng1",
+        "intermediate_2": "mìfēng",
+        "native_1": "bee; honeybee",
+        "primary_1": "蜜蜂",
+        "primary_2": "蜜蜂"
+    },
+    {
+        "intermediate_1": "mian4dui4",
+        "intermediate_2": "miànduì",
+        "native_1": "to face; confront",
+        "primary_1": "面对",
+        "primary_2": "面對"
+    },
+    {
+        "intermediate_1": "mian4ji1",
+        "intermediate_2": "miànjī",
+        "native_1": "(surface) area",
+        "primary_1": "面积",
+        "primary_2": "面積"
+    },
+    {
+        "intermediate_1": "mian4lin2",
+        "intermediate_2": "miànlín",
+        "native_1": "be faced with; be up against",
+        "primary_1": "面临",
+        "primary_2": "面臨"
+    },
+    {
+        "intermediate_1": "miao2tiao",
+        "intermediate_2": "miáotiao",
+        "native_1": "slim; slender",
+        "primary_1": "苗条",
+        "primary_2": "苗條"
+    },
+    {
+        "intermediate_1": "miao2xie3",
+        "intermediate_2": "miáoxiě",
+        "native_1": "to describe; to depict; to portray",
+        "primary_1": "描写",
+        "primary_2": "描寫"
+    },
+    {
+        "intermediate_1": "ming3an3",
+        "intermediate_2": "mǐngǎn",
+        "native_1": "sensitive; susceptible",
+        "primary_1": "敏感",
+        "primary_2": "敏感"
+    },
+    {
+        "intermediate_1": "ming2pai2",
+        "intermediate_2": "míngpái",
+        "native_1": "famous brand; name brand",
+        "primary_1": "名牌",
+        "primary_2": "名牌"
+    },
+    {
+        "intermediate_1": "ming2pian4",
+        "intermediate_2": "míngpiàn",
+        "native_1": "business card",
+        "primary_1": "名片",
+        "primary_2": "名片"
+    },
+    {
+        "intermediate_1": "ming2sheng4gu3ji4",
+        "intermediate_2": "míngshènggǔjì",
+        "native_1": "famous scenic spots and ancient historic sites",
+        "primary_1": "名胜古迹",
+        "primary_2": "名勝古迹"
+    },
+    {
+        "intermediate_1": "ming2que4",
+        "intermediate_2": "míngquè",
+        "native_1": "clear-cut; clearly; clarify",
+        "primary_1": "明确",
+        "primary_2": "明確"
+    },
+    {
+        "intermediate_1": "ming2xian3",
+        "intermediate_2": "míngxiǎn",
+        "native_1": "clear; obvious",
+        "primary_1": "明显",
+        "primary_2": "明顯"
+    },
+    {
+        "intermediate_1": "ming2xing1",
+        "intermediate_2": "míngxīng",
+        "native_1": "(movie, etc.) star; celebrity",
+        "primary_1": "明星",
+        "primary_2": "明星"
+    },
+    {
+        "intermediate_1": "ming4ling4",
+        "intermediate_2": "mìnglìng",
+        "native_1": "an order; a command",
+        "primary_1": "命令",
+        "primary_2": "命令"
+    },
+    {
+        "intermediate_1": "ming4yun4",
+        "intermediate_2": "mìngyùn",
+        "native_1": "fate; destiny",
+        "primary_1": "命运",
+        "primary_2": "命運"
+    },
+    {
+        "intermediate_1": "mo1",
+        "intermediate_2": "mō",
+        "native_1": "to touch; to stroke; fish out; feel out",
+        "primary_1": "摸",
+        "primary_2": "摸"
+    },
+    {
+        "intermediate_1": "mo2fang3",
+        "intermediate_2": "mófǎng",
+        "native_1": "imitate; to copy",
+        "primary_1": "模仿",
+        "primary_2": "模仿"
+    },
+    {
+        "intermediate_1": "mo2hu",
+        "intermediate_2": "móhu",
+        "native_1": "vague; indistinct; fuzzy; foggy",
+        "primary_1": "模糊",
+        "primary_2": "模糊"
+    },
+    {
+        "intermediate_1": "mo2te4",
+        "intermediate_2": "mótè",
+        "native_1": "(fashion) model",
+        "primary_1": "模特",
+        "primary_2": "模特"
+    },
+    {
+        "intermediate_1": "mo2tuo1che1",
+        "intermediate_2": "mótuōchē",
+        "native_1": "motorcycle; motorbike",
+        "primary_1": "摩托车",
+        "primary_2": "摩托車"
+    },
+    {
+        "intermediate_1": "mo4sheng1",
+        "intermediate_2": "mòshēng",
+        "native_1": "strange; unfamiliar",
+        "primary_1": "陌生",
+        "primary_2": "陌生"
+    },
+    {
+        "intermediate_1": "mou3",
+        "intermediate_2": "mǒu",
+        "native_1": "a certain; some",
+        "primary_1": "某",
+        "primary_2": "某"
+    },
+    {
+        "intermediate_1": "mu4tou",
+        "intermediate_2": "mùtou",
+        "native_1": "wood; log; timber",
+        "primary_1": "木头",
+        "primary_2": "木頭"
+    },
+    {
+        "intermediate_1": "mu4biao1",
+        "intermediate_2": "mùbiāo",
+        "native_1": "target; goal; objective",
+        "primary_1": "目标",
+        "primary_2": "目標"
+    },
+    {
+        "intermediate_1": "mu4lu4",
+        "intermediate_2": "mùlù",
+        "native_1": "catalog; table of contents; directory (on computer hard drive)",
+        "primary_1": "目录",
+        "primary_2": "目錄"
+    },
+    {
+        "intermediate_1": "mu4qian2",
+        "intermediate_2": "mùqián",
+        "native_1": "at present; now; for the moment",
+        "primary_1": "目前",
+        "primary_2": "目前"
+    },
+    {
+        "intermediate_1": "na3pa4",
+        "intermediate_2": "nǎpà",
+        "native_1": "even (if/though); no matter how",
+        "primary_1": "哪怕",
+        "primary_2": "哪怕"
+    },
+    {
+        "intermediate_1": "nang2uai4",
+        "intermediate_2": "nánguài",
+        "native_1": "no wonder",
+        "primary_1": "难怪",
+        "primary_2": "難怪"
+    },
+    {
+        "intermediate_1": "nan2mian3",
+        "intermediate_2": "nánmiǎn",
+        "native_1": "hard to avoid; difficult to escape from",
+        "primary_1": "难免",
+        "primary_2": "難免"
+    },
+    {
+        "intermediate_1": "nao3dai",
+        "intermediate_2": "nǎodai",
+        "native_1": "head; mental capability; brains",
+        "primary_1": "脑袋",
+        "primary_2": "腦袋"
+    },
+    {
+        "intermediate_1": "nei4bu4",
+        "intermediate_2": "nèibù",
+        "native_1": "internal; interior; inside (part, section)",
+        "primary_1": "内部",
+        "primary_2": "內部"
+    },
+    {
+        "intermediate_1": "nei4ke1",
+        "intermediate_2": "nèikē",
+        "native_1": "internal medicine",
+        "primary_1": "内科",
+        "primary_2": "內科"
+    },
+    {
+        "intermediate_1": "nen4",
+        "intermediate_2": "nèn",
+        "native_1": "tender; inexperienced",
+        "primary_1": "嫩",
+        "primary_2": "嫩"
+    },
+    {
+        "intermediate_1": "neng2gan4",
+        "intermediate_2": "nénggàn",
+        "native_1": "capable; competent",
+        "primary_1": "能干",
+        "primary_2": "能幹"
+    },
+    {
+        "intermediate_1": "neng2yuan2",
+        "intermediate_2": "néngyuán",
+        "native_1": "energy resources; power source",
+        "primary_1": "能源",
+        "primary_2": "能源"
+    },
+    {
+        "intermediate_1": "en1",
+        "intermediate_2": "ēn",
+        "native_1": "(interjection expressing what?, huh? hmm? why? ok, etc.)",
+        "primary_1": "嗯",
+        "primary_2": "嗯"
+    },
+    {
+        "intermediate_1": "nian2dai4",
+        "intermediate_2": "niándài",
+        "native_1": "decade; era",
+        "primary_1": "年代",
+        "primary_2": "年代"
+    },
+    {
+        "intermediate_1": "nian2ji4",
+        "intermediate_2": "niánjì",
+        "native_1": "age",
+        "primary_1": "年纪",
+        "primary_2": "年紀"
+    },
+    {
+        "intermediate_1": "nian4",
+        "intermediate_2": "niàn",
+        "native_1": "read aloud; to study; to miss or think of somebody",
+        "primary_1": "念",
+        "primary_2": "念"
+    },
+    {
+        "intermediate_1": "ning4ke3",
+        "intermediate_2": "nìngkě",
+        "native_1": "would rather; it is the lesser of two evils to",
+        "primary_1": "宁可",
+        "primary_2": "甯可"
+    },
+    {
+        "intermediate_1": "niu2zai3ku4",
+        "intermediate_2": "niúzǎikù",
+        "native_1": "jeans; cowboy pants",
+        "primary_1": "牛仔裤",
+        "primary_2": "牛仔褲"
+    },
+    {
+        "intermediate_1": "nong2cun1",
+        "intermediate_2": "nóngcūn",
+        "native_1": "rural area; countryside",
+        "primary_1": "农村",
+        "primary_2": "農村"
+    },
+    {
+        "intermediate_1": "nong2min2",
+        "intermediate_2": "nóngmín",
+        "native_1": "peasant",
+        "primary_1": "农民",
+        "primary_2": "農民"
+    },
+    {
+        "intermediate_1": "nong2ye4",
+        "intermediate_2": "nóngyè",
+        "native_1": "agriculture; farming",
+        "primary_1": "农业",
+        "primary_2": "農業"
+    },
+    {
+        "intermediate_1": "nong2",
+        "intermediate_2": "nóng",
+        "native_1": "concentrated; dense",
+        "primary_1": "浓",
+        "primary_2": "濃"
+    },
+    {
+        "intermediate_1": "nü3shi4",
+        "intermediate_2": "nǚshì",
+        "native_1": "lady; madam",
+        "primary_1": "女士",
+        "primary_2": "女士"
+    },
+    {
+        "intermediate_1": "Ōuzhou1",
+        "intermediate_2": "Ōuzhōu",
+        "native_1": "Europe",
+        "primary_1": "欧洲",
+        "primary_2": "歐洲"
+    },
+    {
+        "intermediate_1": "ou3ran2",
+        "intermediate_2": "ǒurán",
+        "native_1": "accidentally; occasional; fortuitous",
+        "primary_1": "偶然",
+        "primary_2": "偶然"
+    },
+    {
+        "intermediate_1": "pai1",
+        "intermediate_2": "pāi",
+        "native_1": "to clap; to pat; to shoot (pictures, a film); send (a telegram)",
+        "primary_1": "拍",
+        "primary_2": "拍"
+    },
+    {
+        "intermediate_1": "pai4",
+        "intermediate_2": "pài",
+        "native_1": "dispatch; (mw for political groups; schools of thought; etc.)",
+        "primary_1": "派",
+        "primary_2": "派"
+    },
+    {
+        "intermediate_1": "pan4wang4",
+        "intermediate_2": "pànwàng",
+        "native_1": "to hope for; look forward to",
+        "primary_1": "盼望",
+        "primary_2": "盼望"
+    },
+    {
+        "intermediate_1": "pei2xun4",
+        "intermediate_2": "péixùn",
+        "native_1": "cultivate; train",
+        "primary_1": "培训",
+        "primary_2": "培訓"
+    },
+    {
+        "intermediate_1": "pei2yang3",
+        "intermediate_2": "péiyǎng",
+        "native_1": "to train; cultivate; bring up",
+        "primary_1": "培养",
+        "primary_2": "培養"
+    },
+    {
+        "intermediate_1": "pei2chang2",
+        "intermediate_2": "péicháng",
+        "native_1": "compensate; pay for somebody else's loss",
+        "primary_1": "赔偿",
+        "primary_2": "賠償"
+    },
+    {
+        "intermediate_1": "pei4fu",
+        "intermediate_2": "pèifu",
+        "native_1": "admire; to respect",
+        "primary_1": "佩服",
+        "primary_2": "佩服"
+    },
+    {
+        "intermediate_1": "pei4he2",
+        "intermediate_2": "pèihé",
+        "native_1": "be harmoniously combined or arranged; matching; fitting in with; compatible with; to correspond; to fit; to conform to; rapport; to coordinate with; to act in concern with; to cooperate; to become man and wife; to combine parts of a machine",
+        "primary_1": "配合",
+        "primary_2": "配合"
+    },
+    {
+        "intermediate_1": "pen2",
+        "intermediate_2": "pén",
+        "native_1": "basin; (flower) pot",
+        "primary_1": "盆",
+        "primary_2": "盆"
+    },
+    {
+        "intermediate_1": "peng4",
+        "intermediate_2": "pèng",
+        "native_1": "to touch; to bump; to encounter",
+        "primary_1": "碰",
+        "primary_2": "碰"
+    },
+    {
+        "intermediate_1": "pi1",
+        "intermediate_2": "pī",
+        "native_1": "criticize; to comment; wholesale; (mw for batches, lots, etc.)",
+        "primary_1": "批",
+        "primary_2": "批"
+    },
+    {
+        "intermediate_1": "pi1zhun3",
+        "intermediate_2": "pīzhǔn",
+        "native_1": "approve; ratify",
+        "primary_1": "批准",
+        "primary_2": "批准"
+    },
+    {
+        "intermediate_1": "pi1",
+        "intermediate_2": "pī",
+        "native_1": "drape over one's shoulders; split open; open",
+        "primary_1": "披",
+        "primary_2": "披"
+    },
+    {
+        "intermediate_1": "pi2lao2",
+        "intermediate_2": "píláo",
+        "native_1": "fatigue; wearily; weariness; tired",
+        "primary_1": "疲劳",
+        "primary_2": "疲勞"
+    },
+    {
+        "intermediate_1": "pi3",
+        "intermediate_2": "pǐ",
+        "native_1": "ordinary person; (mw for horses, bolt of cloth)",
+        "primary_1": "匹",
+        "primary_2": "匹"
+    },
+    {
+        "intermediate_1": "pian4, pian1",
+        "intermediate_2": "piàn, piān",
+        "native_1": "(mw for pieces of things); a slice; a flake (Kangxi radical 91) | film; photo",
+        "primary_1": "片",
+        "primary_2": "片"
+    },
+    {
+        "intermediate_1": "pian4mian4",
+        "intermediate_2": "piànmiàn",
+        "native_1": "one-sided; unilateral",
+        "primary_1": "片面",
+        "primary_2": "片面"
+    },
+    {
+        "intermediate_1": "piao1",
+        "intermediate_2": "piāo",
+        "native_1": "to float; flutter",
+        "primary_1": "飘",
+        "primary_2": "飄"
+    },
+    {
+        "intermediate_1": "pin1yin1",
+        "intermediate_2": "pīnyīn",
+        "native_1": "pinyin; phonetic writing",
+        "primary_1": "拼音",
+        "primary_2": "拼音"
+    },
+    {
+        "intermediate_1": "pin2dao4",
+        "intermediate_2": "píndào",
+        "native_1": "frequency; (television) channel",
+        "primary_1": "频道",
+        "primary_2": "頻道"
+    },
+    {
+        "intermediate_1": "ping2",
+        "intermediate_2": "píng",
+        "native_1": "flat; level; equal; ordinary",
+        "primary_1": "平",
+        "primary_2": "平"
+    },
+    {
+        "intermediate_1": "ping2'an1",
+        "intermediate_2": "píng'ān",
+        "native_1": "safe and sound",
+        "primary_1": "平安",
+        "primary_2": "平安"
+    },
+    {
+        "intermediate_1": "ping2chang2",
+        "intermediate_2": "píngcháng",
+        "native_1": "ordinary; usually; common",
+        "primary_1": "平常",
+        "primary_2": "平常"
+    },
+    {
+        "intermediate_1": "ping2deng3",
+        "intermediate_2": "píngděng",
+        "native_1": "equal; equality",
+        "primary_1": "平等",
+        "primary_2": "平等"
+    },
+    {
+        "intermediate_1": "ping2fang1",
+        "intermediate_2": "píngfāng",
+        "native_1": "square (as in square foot, square mile, etc.)",
+        "primary_1": "平方",
+        "primary_2": "平方"
+    },
+    {
+        "intermediate_1": "ping2heng2",
+        "intermediate_2": "pínghéng",
+        "native_1": "balance; balanced; equilibrium",
+        "primary_1": "平衡",
+        "primary_2": "平衡"
+    },
+    {
+        "intermediate_1": "ping2jing4",
+        "intermediate_2": "píngjìng",
+        "native_1": "calm; peaceful; tranquil; serene",
+        "primary_1": "平静",
+        "primary_2": "平靜"
+    },
+    {
+        "intermediate_1": "ping2jun1",
+        "intermediate_2": "píngjūn",
+        "native_1": "average; to share equally",
+        "primary_1": "平均",
+        "primary_2": "平均"
+    },
+    {
+        "intermediate_1": "ping2jia4",
+        "intermediate_2": "píngjià",
+        "native_1": "to evaluate",
+        "primary_1": "评价",
+        "primary_2": "評價"
+    },
+    {
+        "intermediate_1": "ping2",
+        "intermediate_2": "píng",
+        "native_1": "lean against; evidence; proof; no matter (what/how/etc.)",
+        "primary_1": "凭",
+        "primary_2": "憑"
+    },
+    {
+        "intermediate_1": "po4qie4",
+        "intermediate_2": "pòqiè",
+        "native_1": "urgent; pressing",
+        "primary_1": "迫切",
+        "primary_2": "迫切"
+    },
+    {
+        "intermediate_1": "po4 chan3",
+        "intermediate_2": "pò chǎn",
+        "native_1": "go bankrupt; go broke; bankruptcy",
+        "primary_1": "破产",
+        "primary_2": "破産"
+    },
+    {
+        "intermediate_1": "po4huai4",
+        "intermediate_2": "pòhuài",
+        "native_1": "destroy; destruction; to wreck; to break",
+        "primary_1": "破坏",
+        "primary_2": "破壞"
+    },
+    {
+        "intermediate_1": "qi1dai4",
+        "intermediate_2": "qīdài",
+        "native_1": "look forward to; await; expectation",
+        "primary_1": "期待",
+        "primary_2": "期待"
+    },
+    {
+        "intermediate_1": "qi1jian1",
+        "intermediate_2": "qījiān",
+        "native_1": "period of time; time",
+        "primary_1": "期间",
+        "primary_2": "期間"
+    },
+    {
+        "intermediate_1": "qi2yu2",
+        "intermediate_2": "qíyú",
+        "native_1": "the others; the rest; remaining",
+        "primary_1": "其余",
+        "primary_2": "其余"
+    },
+    {
+        "intermediate_1": "qi2ji4",
+        "intermediate_2": "qíjì",
+        "native_1": "miracle; miraculous; marvel",
+        "primary_1": "奇迹",
+        "primary_2": "奇迹"
+    },
+    {
+        "intermediate_1": "qi3ye4",
+        "intermediate_2": "qǐyè",
+        "native_1": "company; business; firm",
+        "primary_1": "企业",
+        "primary_2": "企業"
+    },
+    {
+        "intermediate_1": "qi3fa1",
+        "intermediate_2": "qǐfā",
+        "native_1": "enlighten; inspire",
+        "primary_1": "启发",
+        "primary_2": "啓發"
+    },
+    {
+        "intermediate_1": "qi4fen1",
+        "intermediate_2": "qìfēn",
+        "native_1": "atmosphere; mood; ambience",
+        "primary_1": "气氛",
+        "primary_2": "氣氛"
+    },
+    {
+        "intermediate_1": "qi4you2",
+        "intermediate_2": "qìyóu",
+        "native_1": "gasoline; gas; petrol",
+        "primary_1": "汽油",
+        "primary_2": "汽油"
+    },
+    {
+        "intermediate_1": "qian1xu1",
+        "intermediate_2": "qiānxū",
+        "native_1": "modest",
+        "primary_1": "谦虚",
+        "primary_2": "謙虛"
+    },
+    {
+        "intermediate_1": "qian1",
+        "intermediate_2": "qiān",
+        "native_1": "bamboo used for drawing lots; toothpick; to sign (one's name)",
+        "primary_1": "签",
+        "primary_2": "簽"
+    },
+    {
+        "intermediate_1": "qian2tu2",
+        "intermediate_2": "qiántú",
+        "native_1": "future; prospects; outlook (for the future)",
+        "primary_1": "前途",
+        "primary_2": "前途"
+    },
+    {
+        "intermediate_1": "qian3",
+        "intermediate_2": "qiǎn",
+        "native_1": "shallow; simple; superficial; light (of colors)",
+        "primary_1": "浅",
+        "primary_2": "淺"
+    },
+    {
+        "intermediate_1": "qian4",
+        "intermediate_2": "qiàn",
+        "native_1": "yawn; to lack; owe (Kangxi radical 76)",
+        "primary_1": "欠",
+        "primary_2": "欠"
+    },
+    {
+        "intermediate_1": "qiang1",
+        "intermediate_2": "qiāng",
+        "native_1": "gun; spear",
+        "primary_1": "枪",
+        "primary_2": "槍"
+    },
+    {
+        "intermediate_1": "qiang2diao4",
+        "intermediate_2": "qiángdiào",
+        "native_1": "emphasize; to stress",
+        "primary_1": "强调",
+        "primary_2": "強調"
+    },
+    {
+        "intermediate_1": "qiang2lie4",
+        "intermediate_2": "qiángliè",
+        "native_1": "intense; strong; violent",
+        "primary_1": "强烈",
+        "primary_2": "強烈"
+    },
+    {
+        "intermediate_1": "qiang2",
+        "intermediate_2": "qiáng",
+        "native_1": "wall",
+        "primary_1": "墙",
+        "primary_2": "牆"
+    },
+    {
+        "intermediate_1": "qiang3, qiang1",
+        "intermediate_2": "qiǎng, qiāng",
+        "native_1": "fight over; vie for; grab; rush | bump against",
+        "primary_1": "抢",
+        "primary_2": "搶"
+    },
+    {
+        "intermediate_1": "qiao1qiao1",
+        "intermediate_2": "qiāoqiāo",
+        "native_1": "quietly",
+        "primary_1": "悄悄",
+        "primary_2": "悄悄"
+    },
+    {
+        "intermediate_1": "qiao2",
+        "intermediate_2": "qiáo",
+        "native_1": "look at; see (colloquial)",
+        "primary_1": "瞧",
+        "primary_2": "瞧"
+    },
+    {
+        "intermediate_1": "qiao3miao4",
+        "intermediate_2": "qiǎomiào",
+        "native_1": "ingenious; clever",
+        "primary_1": "巧妙",
+        "primary_2": "巧妙"
+    },
+    {
+        "intermediate_1": "qie1, qie4",
+        "intermediate_2": "qiē, qiè",
+        "native_1": "to cut; to chop | correspond to; absolutely; ardently",
+        "primary_1": "切",
+        "primary_2": "切"
+    },
+    {
+        "intermediate_1": "qin1'ai4",
+        "intermediate_2": "qīn'ài",
+        "native_1": "beloved; Dear ... (a way of starting a letter lovers, intimate friends or close relatives)",
+        "primary_1": "亲爱",
+        "primary_2": "親愛"
+    },
+    {
+        "intermediate_1": "qin1qie4",
+        "intermediate_2": "qīnqiè",
+        "native_1": "kind; amiable; cordial",
+        "primary_1": "亲切",
+        "primary_2": "親切"
+    },
+    {
+        "intermediate_1": "qin1zi4",
+        "intermediate_2": "qīnzì",
+        "native_1": "personally",
+        "primary_1": "亲自",
+        "primary_2": "親自"
+    },
+    {
+        "intermediate_1": "qin2fen4",
+        "intermediate_2": "qínfèn",
+        "native_1": "hardworking; diligent; industrious",
+        "primary_1": "勤奋",
+        "primary_2": "勤奮"
+    },
+    {
+        "intermediate_1": "qing1",
+        "intermediate_2": "qīng",
+        "native_1": "blue; green; young (Kangxi radical 174); Qinghai province (abbr.)",
+        "primary_1": "青",
+        "primary_2": "青"
+    },
+    {
+        "intermediate_1": "qing1chun1",
+        "intermediate_2": "qīngchūn",
+        "native_1": "youth; youthfulness; fresh spring",
+        "primary_1": "青春",
+        "primary_2": "青春"
+    },
+    {
+        "intermediate_1": "qing1shao4nian2",
+        "intermediate_2": "qīngshàonián",
+        "native_1": "teenager",
+        "primary_1": "青少年",
+        "primary_2": "青少年"
+    },
+    {
+        "intermediate_1": "qing1shi4",
+        "intermediate_2": "qīngshì",
+        "native_1": "contempt; to scorn; scornful",
+        "primary_1": "轻视",
+        "primary_2": "輕視"
+    },
+    {
+        "intermediate_1": "qing1yi4",
+        "intermediate_2": "qīngyì",
+        "native_1": "easily; lightly; rashly",
+        "primary_1": "轻易",
+        "primary_2": "輕易"
+    },
+    {
+        "intermediate_1": "qing1dan4",
+        "intermediate_2": "qīngdàn",
+        "native_1": "light (of food, not greasy or strongly flavored) ; insipid;  slack (sales)",
+        "primary_1": "清淡",
+        "primary_2": "清淡"
+    },
+    {
+        "intermediate_1": "qing2jing3",
+        "intermediate_2": "qíngjǐng",
+        "native_1": "scene; sight; circumstances",
+        "primary_1": "情景",
+        "primary_2": "情景"
+    },
+    {
+        "intermediate_1": "qing2xu4",
+        "intermediate_2": "qíngxù",
+        "native_1": "emotion; sentiment; mood; morale",
+        "primary_1": "情绪",
+        "primary_2": "情緒"
+    },
+    {
+        "intermediate_1": "qing3qiu2",
+        "intermediate_2": "qǐngqiú",
+        "native_1": "to request; ask",
+        "primary_1": "请求",
+        "primary_2": "請求"
+    },
+    {
+        "intermediate_1": "qing4zhu4",
+        "intermediate_2": "qìngzhù",
+        "native_1": "celebrate",
+        "primary_1": "庆祝",
+        "primary_2": "慶祝"
+    },
+    {
+        "intermediate_1": "qiu2mi2",
+        "intermediate_2": "qiúmí",
+        "native_1": "fan (of ball games: basketball, football, etc.)",
+        "primary_1": "球迷",
+        "primary_2": "球迷"
+    },
+    {
+        "intermediate_1": "qu1shi4",
+        "intermediate_2": "qūshì",
+        "native_1": "trend; tendency",
+        "primary_1": "趋势",
+        "primary_2": "趨勢"
+    },
+    {
+        "intermediate_1": "qu3xiao1",
+        "intermediate_2": "qǔxiāo",
+        "native_1": "cancel; cancellation; abolish",
+        "primary_1": "取消",
+        "primary_2": "取消"
+    },
+    {
+        "intermediate_1": "qu3",
+        "intermediate_2": "qǔ",
+        "native_1": "marry (a wife); take a wife",
+        "primary_1": "娶",
+        "primary_2": "娶"
+    },
+    {
+        "intermediate_1": "qu4shi4",
+        "intermediate_2": "qùshì",
+        "native_1": "pass away; die",
+        "primary_1": "去世",
+        "primary_2": "去世"
+    },
+    {
+        "intermediate_1": "quan1",
+        "intermediate_2": "quān",
+        "native_1": "circle; ring; (mw for loops, orbits, etc.)",
+        "primary_1": "圈",
+        "primary_2": "圈"
+    },
+    {
+        "intermediate_1": "quan2li4",
+        "intermediate_2": "quánlì",
+        "native_1": "power; authority",
+        "primary_1": "权力",
+        "primary_2": "權力"
+    },
+    {
+        "intermediate_1": "quan2li4",
+        "intermediate_2": "quánlì",
+        "native_1": "right; privilege",
+        "primary_1": "权利",
+        "primary_2": "權利"
+    },
+    {
+        "intermediate_1": "quan2mian4",
+        "intermediate_2": "quánmiàn",
+        "native_1": "all-around; comprehensive; fully",
+        "primary_1": "全面",
+        "primary_2": "全面"
+    },
+    {
+        "intermediate_1": "quan4",
+        "intermediate_2": "quàn",
+        "native_1": "advise; to urge; persuade",
+        "primary_1": "劝",
+        "primary_2": "勸"
+    },
+    {
+        "intermediate_1": "que1fa2",
+        "intermediate_2": "quēfá",
+        "native_1": "shortage; to lack; be short of",
+        "primary_1": "缺乏",
+        "primary_2": "缺乏"
+    },
+    {
+        "intermediate_1": "que4ding4",
+        "intermediate_2": "quèdìng",
+        "native_1": "definite; certain; fixed; determine",
+        "primary_1": "确定",
+        "primary_2": "確定"
+    },
+    {
+        "intermediate_1": "quer4en4",
+        "intermediate_2": "quèrèn",
+        "native_1": "confirm; confirmation; verify",
+        "primary_1": "确认",
+        "primary_2": "確認"
+    },
+    {
+        "intermediate_1": "qun2",
+        "intermediate_2": "qún",
+        "native_1": "crowd; group; (mw for groups, flocks, or swarms)",
+        "primary_1": "群",
+        "primary_2": "群"
+    },
+    {
+        "intermediate_1": "ran2shao1",
+        "intermediate_2": "ránshāo",
+        "native_1": "combustion; burn; kindle",
+        "primary_1": "燃烧",
+        "primary_2": "燃燒"
+    },
+    {
+        "intermediate_1": "rao4",
+        "intermediate_2": "rào",
+        "native_1": "to wind; to coil; move round",
+        "primary_1": "绕",
+        "primary_2": "繞"
+    },
+    {
+        "intermediate_1": "re4'ai4",
+        "intermediate_2": "rè'ài",
+        "native_1": "love ardently; adore; passion",
+        "primary_1": "热爱",
+        "primary_2": "熱愛"
+    },
+    {
+        "intermediate_1": "re4lie4",
+        "intermediate_2": "rèliè",
+        "native_1": "warm; enthusiastic",
+        "primary_1": "热烈",
+        "primary_2": "熱烈"
+    },
+    {
+        "intermediate_1": "re4xin1",
+        "intermediate_2": "rèxīn",
+        "native_1": "enthusiastic; zealous; warmhearted",
+        "primary_1": "热心",
+        "primary_2": "熱心"
+    },
+    {
+        "intermediate_1": "ren2cai2",
+        "intermediate_2": "réncái",
+        "native_1": "talent; talented person",
+        "primary_1": "人才",
+        "primary_2": "人才"
+    },
+    {
+        "intermediate_1": "ren2kou3",
+        "intermediate_2": "rénkǒu",
+        "native_1": "population; the populace",
+        "primary_1": "人口",
+        "primary_2": "人口"
+    },
+    {
+        "intermediate_1": "ren2lei4",
+        "intermediate_2": "rénlèi",
+        "native_1": "humanity; human race; mankind",
+        "primary_1": "人类",
+        "primary_2": "人類"
+    },
+    {
+        "intermediate_1": "ren2min2bi4",
+        "intermediate_2": "rénmínbì",
+        "native_1": "(currency) renminbi (RMB)",
+        "primary_1": "人民币",
+        "primary_2": "人民幣"
+    },
+    {
+        "intermediate_1": "ren2sheng1",
+        "intermediate_2": "rénshēng",
+        "native_1": "human life",
+        "primary_1": "人生",
+        "primary_2": "人生"
+    },
+    {
+        "intermediate_1": "ren2shi4",
+        "intermediate_2": "rénshì",
+        "native_1": "personnel",
+        "primary_1": "人事",
+        "primary_2": "人事"
+    },
+    {
+        "intermediate_1": "ren2wu4",
+        "intermediate_2": "rénwù",
+        "native_1": "figure; personage; character (in a play, story, etc.)",
+        "primary_1": "人物",
+        "primary_2": "人物"
+    },
+    {
+        "intermediate_1": "ren2yuan2",
+        "intermediate_2": "rényuán",
+        "native_1": "staff; crew; personnel",
+        "primary_1": "人员",
+        "primary_2": "人員"
+    },
+    {
+        "intermediate_1": "ren3 bu zhu4",
+        "intermediate_2": "rěn bu zhù",
+        "native_1": "cannot help but; unable to bear",
+        "primary_1": "忍不住",
+        "primary_2": "忍不住"
+    },
+    {
+        "intermediate_1": "ri4chang2",
+        "intermediate_2": "rìcháng",
+        "native_1": "daily; everyday",
+        "primary_1": "日常",
+        "primary_2": "日常"
+    },
+    {
+        "intermediate_1": "ri4cheng2",
+        "intermediate_2": "rìchéng",
+        "native_1": "schedule; itinerary",
+        "primary_1": "日程",
+        "primary_2": "日程"
+    },
+    {
+        "intermediate_1": "ri4li4",
+        "intermediate_2": "rìlì",
+        "native_1": "calendar",
+        "primary_1": "日历",
+        "primary_2": "日曆"
+    },
+    {
+        "intermediate_1": "ri4qi1",
+        "intermediate_2": "rìqī",
+        "native_1": "date",
+        "primary_1": "日期",
+        "primary_2": "日期"
+    },
+    {
+        "intermediate_1": "ri4yong4pin3",
+        "intermediate_2": "rìyòngpǐn",
+        "native_1": "daily necessities",
+        "primary_1": "日用品",
+        "primary_2": "日用品"
+    },
+    {
+        "intermediate_1": "ri4zi",
+        "intermediate_2": "rìzi",
+        "native_1": "days; date; time; life",
+        "primary_1": "日子",
+        "primary_2": "日子"
+    },
+    {
+        "intermediate_1": "ru2he2",
+        "intermediate_2": "rúhé",
+        "native_1": "how; what; what way",
+        "primary_1": "如何",
+        "primary_2": "如何"
+    },
+    {
+        "intermediate_1": "ru2jin1",
+        "intermediate_2": "rújīn",
+        "native_1": "nowadays",
+        "primary_1": "如今",
+        "primary_2": "如今"
+    },
+    {
+        "intermediate_1": "ruan3",
+        "intermediate_2": "ruǎn",
+        "native_1": "soft",
+        "primary_1": "软",
+        "primary_2": "軟"
+    },
+    {
+        "intermediate_1": "ruan3jian4",
+        "intermediate_2": "ruǎnjiàn",
+        "native_1": "(computer) software",
+        "primary_1": "软件",
+        "primary_2": "軟件"
+    },
+    {
+        "intermediate_1": "ruo4",
+        "intermediate_2": "ruò",
+        "native_1": "weak; feeble; young",
+        "primary_1": "弱",
+        "primary_2": "弱"
+    },
+    {
+        "intermediate_1": "sa3",
+        "intermediate_2": "sǎ",
+        "native_1": "to sprinkle; to spray; to spill",
+        "primary_1": "洒",
+        "primary_2": "灑"
+    },
+    {
+        "intermediate_1": "sang3zi",
+        "intermediate_2": "sǎngzi",
+        "native_1": "throat; voice",
+        "primary_1": "嗓子",
+        "primary_2": "嗓子"
+    },
+    {
+        "intermediate_1": "se4cai3",
+        "intermediate_2": "sècǎi",
+        "native_1": "tint; color; hue",
+        "primary_1": "色彩",
+        "primary_2": "色彩"
+    },
+    {
+        "intermediate_1": "sha1",
+        "intermediate_2": "shā",
+        "native_1": "to kill; to murder",
+        "primary_1": "杀",
+        "primary_2": "殺"
+    },
+    {
+        "intermediate_1": "sha1mo4",
+        "intermediate_2": "shāmò",
+        "native_1": "desert",
+        "primary_1": "沙漠",
+        "primary_2": "沙漠"
+    },
+    {
+        "intermediate_1": "sha1tan1",
+        "intermediate_2": "shātān",
+        "native_1": "sand bar; sand beach",
+        "primary_1": "沙滩",
+        "primary_2": "沙灘"
+    },
+    {
+        "intermediate_1": "sha3",
+        "intermediate_2": "shǎ",
+        "native_1": "foolish; fool",
+        "primary_1": "傻",
+        "primary_2": "傻"
+    },
+    {
+        "intermediate_1": "shai4",
+        "intermediate_2": "shài",
+        "native_1": "to dry in the sun; shine upon; to sun; bask",
+        "primary_1": "晒",
+        "primary_2": "曬"
+    },
+    {
+        "intermediate_1": "shan1chu2",
+        "intermediate_2": "shānchú",
+        "native_1": "to delete",
+        "primary_1": "删除",
+        "primary_2": "刪除"
+    },
+    {
+        "intermediate_1": "shan3dian4",
+        "intermediate_2": "shǎndiàn",
+        "native_1": "lightning",
+        "primary_1": "闪电",
+        "primary_2": "閃電"
+    },
+    {
+        "intermediate_1": "shan4zi",
+        "intermediate_2": "shànzi",
+        "native_1": "fan (for waving)",
+        "primary_1": "扇子",
+        "primary_2": "扇子"
+    },
+    {
+        "intermediate_1": "shan4liang2",
+        "intermediate_2": "shànliáng",
+        "native_1": "good and honest; kind-hearted",
+        "primary_1": "善良",
+        "primary_2": "善良"
+    },
+    {
+        "intermediate_1": "shan4yu2",
+        "intermediate_2": "shànyú",
+        "native_1": "be good at; excel at",
+        "primary_1": "善于",
+        "primary_2": "善于"
+    },
+    {
+        "intermediate_1": "shang1hai4",
+        "intermediate_2": "shānghài",
+        "native_1": "injure; to harm; wound",
+        "primary_1": "伤害",
+        "primary_2": "傷害"
+    },
+    {
+        "intermediate_1": "shang1pin3",
+        "intermediate_2": "shāngpǐn",
+        "native_1": "goods; commodity; merchandise",
+        "primary_1": "商品",
+        "primary_2": "商品"
+    },
+    {
+        "intermediate_1": "shang1wu4",
+        "intermediate_2": "shāngwù",
+        "native_1": "business; commercial affairs",
+        "primary_1": "商务",
+        "primary_2": "商務"
+    },
+    {
+        "intermediate_1": "shang1ye4",
+        "intermediate_2": "shāngyè",
+        "native_1": "business; commerce; trade",
+        "primary_1": "商业",
+        "primary_2": "商業"
+    },
+    {
+        "intermediate_1": "shang4 dang4",
+        "intermediate_2": "shàng dàng",
+        "native_1": "be fooled; be duped; be taken in",
+        "primary_1": "上当",
+        "primary_2": "上當"
+    },
+    {
+        "intermediate_1": "she2",
+        "intermediate_2": "shé",
+        "native_1": "snake; serpent",
+        "primary_1": "蛇",
+        "primary_2": "蛇"
+    },
+    {
+        "intermediate_1": "she3bude",
+        "intermediate_2": "shěbude",
+        "native_1": "hate to part with; begrudge doing something",
+        "primary_1": "舍不得",
+        "primary_2": "舍不得"
+    },
+    {
+        "intermediate_1": "she4bei4",
+        "intermediate_2": "shèbèi",
+        "native_1": "equipment; facilities; installations",
+        "primary_1": "设备",
+        "primary_2": "設備"
+    },
+    {
+        "intermediate_1": "she4ji4",
+        "intermediate_2": "shèjì",
+        "native_1": "plan; design",
+        "primary_1": "设计",
+        "primary_2": "設計"
+    },
+    {
+        "intermediate_1": "she4shi1",
+        "intermediate_2": "shèshī",
+        "native_1": "facilities; installation",
+        "primary_1": "设施",
+        "primary_2": "設施"
+    },
+    {
+        "intermediate_1": "she4ji1",
+        "intermediate_2": "shèjī",
+        "native_1": "to shoot; to fire (a gun)",
+        "primary_1": "射击",
+        "primary_2": "射擊"
+    },
+    {
+        "intermediate_1": "she4 ying3",
+        "intermediate_2": "shè yǐng",
+        "native_1": "take a photograph; shoot a film",
+        "primary_1": "摄影",
+        "primary_2": "攝影"
+    },
+    {
+        "intermediate_1": "shen1",
+        "intermediate_2": "shēn",
+        "native_1": "to stretch; extend",
+        "primary_1": "伸",
+        "primary_2": "伸"
+    },
+    {
+        "intermediate_1": "shen1cai2",
+        "intermediate_2": "shēncái",
+        "native_1": "stature; figure; build",
+        "primary_1": "身材",
+        "primary_2": "身材"
+    },
+    {
+        "intermediate_1": "shen1fen4",
+        "intermediate_2": "shēnfèn",
+        "native_1": "identity; status; dignity",
+        "primary_1": "身份",
+        "primary_2": "身份"
+    },
+    {
+        "intermediate_1": "shen1ke4",
+        "intermediate_2": "shēnkè",
+        "native_1": "profound; deep",
+        "primary_1": "深刻",
+        "primary_2": "深刻"
+    },
+    {
+        "intermediate_1": "shen2hua4",
+        "intermediate_2": "shénhuà",
+        "native_1": "mythology; fairy tale",
+        "primary_1": "神话",
+        "primary_2": "神話"
+    },
+    {
+        "intermediate_1": "shen2mi4",
+        "intermediate_2": "shénmì",
+        "native_1": "mysterious; mystical",
+        "primary_1": "神秘",
+        "primary_2": "神秘"
+    },
+    {
+        "intermediate_1": "sheng1",
+        "intermediate_2": "shēng",
+        "native_1": "rise; hoist; promote; liter",
+        "primary_1": "升",
+        "primary_2": "升"
+    },
+    {
+        "intermediate_1": "sheng1chan3",
+        "intermediate_2": "shēngchǎn",
+        "native_1": "to produce; manufacture; give birth to a child",
+        "primary_1": "生产",
+        "primary_2": "生産"
+    },
+    {
+        "intermediate_1": "sheng1dong4",
+        "intermediate_2": "shēngdòng",
+        "native_1": "vivid; lively",
+        "primary_1": "生动",
+        "primary_2": "生動"
+    },
+    {
+        "intermediate_1": "sheng1zhang3",
+        "intermediate_2": "shēngzhǎng",
+        "native_1": "grow; grow up",
+        "primary_1": "生长",
+        "primary_2": "生長"
+    },
+    {
+        "intermediate_1": "sheng1diao4",
+        "intermediate_2": "shēngdiào",
+        "native_1": "tone; note",
+        "primary_1": "声调",
+        "primary_2": "聲調"
+    },
+    {
+        "intermediate_1": "sheng2zi",
+        "intermediate_2": "shéngzi",
+        "native_1": "cord; string; rope",
+        "primary_1": "绳子",
+        "primary_2": "繩子"
+    },
+    {
+        "intermediate_1": "sheng3lüe4",
+        "intermediate_2": "shěnglüè",
+        "native_1": "to omit; to leave out; abbreviate",
+        "primary_1": "省略",
+        "primary_2": "省略"
+    },
+    {
+        "intermediate_1": "sheng4li4",
+        "intermediate_2": "shènglì",
+        "native_1": "victory; triumph",
+        "primary_1": "胜利",
+        "primary_2": "勝利"
+    },
+    {
+        "intermediate_1": "shi1mian2",
+        "intermediate_2": "shīmián",
+        "native_1": "lose sleep; insomnia",
+        "primary_1": "失眠",
+        "primary_2": "失眠"
+    },
+    {
+        "intermediate_1": "shi1qu4",
+        "intermediate_2": "shīqù",
+        "native_1": "to lose (time, an opportunity, work, etc.)",
+        "primary_1": "失去",
+        "primary_2": "失去"
+    },
+    {
+        "intermediate_1": "shi1 ye4",
+        "intermediate_2": "shī yè",
+        "native_1": "lose one's job; unemployment",
+        "primary_1": "失业",
+        "primary_2": "失業"
+    },
+    {
+        "intermediate_1": "shi1",
+        "intermediate_2": "shī",
+        "native_1": "poem; poetry; verse",
+        "primary_1": "诗",
+        "primary_2": "詩"
+    },
+    {
+        "intermediate_1": "shi1zi",
+        "intermediate_2": "shīzi",
+        "native_1": "lion",
+        "primary_1": "狮子",
+        "primary_2": "獅子"
+    },
+    {
+        "intermediate_1": "shi1run4",
+        "intermediate_2": "shīrùn",
+        "native_1": "moist; humid",
+        "primary_1": "湿润",
+        "primary_2": "濕潤"
+    },
+    {
+        "intermediate_1": "shi2tou",
+        "intermediate_2": "shítou",
+        "native_1": "stone; rock",
+        "primary_1": "石头",
+        "primary_2": "石頭"
+    },
+    {
+        "intermediate_1": "shi2cha1",
+        "intermediate_2": "shíchā",
+        "native_1": "jetlag; time difference",
+        "primary_1": "时差",
+        "primary_2": "時差"
+    },
+    {
+        "intermediate_1": "shi2dai4",
+        "intermediate_2": "shídài",
+        "native_1": "age; era; period",
+        "primary_1": "时代",
+        "primary_2": "時代"
+    },
+    {
+        "intermediate_1": "shi2ke4",
+        "intermediate_2": "shíkè",
+        "native_1": "moment; constantly",
+        "primary_1": "时刻",
+        "primary_2": "時刻"
+    },
+    {
+        "intermediate_1": "shi2mao2",
+        "intermediate_2": "shímáo",
+        "native_1": "fashionable",
+        "primary_1": "时髦",
+        "primary_2": "時髦"
+    },
+    {
+        "intermediate_1": "shi2qi1",
+        "intermediate_2": "shíqī",
+        "native_1": "period in time or history; period; time",
+        "primary_1": "时期",
+        "primary_2": "時期"
+    },
+    {
+        "intermediate_1": "shi2shang4",
+        "intermediate_2": "shíshàng",
+        "native_1": "fashion; fad",
+        "primary_1": "时尚",
+        "primary_2": "時尚"
+    },
+    {
+        "intermediate_1": "shi2hua4",
+        "intermediate_2": "shíhuà",
+        "native_1": "truth",
+        "primary_1": "实话",
+        "primary_2": "實話"
+    },
+    {
+        "intermediate_1": "shi2jian4",
+        "intermediate_2": "shíjiàn",
+        "native_1": "practice; put into practice; carry out",
+        "primary_1": "实践",
+        "primary_2": "實踐"
+    },
+    {
+        "intermediate_1": "shi2xi2",
+        "intermediate_2": "shíxí",
+        "native_1": "to practice; field work; work as an intern",
+        "primary_1": "实习",
+        "primary_2": "實習"
+    },
+    {
+        "intermediate_1": "shi2xian4",
+        "intermediate_2": "shíxiàn",
+        "native_1": "achieve; to implement",
+        "primary_1": "实现",
+        "primary_2": "實現"
+    },
+    {
+        "intermediate_1": "shi2yan4",
+        "intermediate_2": "shíyàn",
+        "native_1": "experiment; test",
+        "primary_1": "实验",
+        "primary_2": "實驗"
+    },
+    {
+        "intermediate_1": "shi2yong4",
+        "intermediate_2": "shíyòng",
+        "native_1": "practical; pragmatic; functional",
+        "primary_1": "实用",
+        "primary_2": "實用"
+    },
+    {
+        "intermediate_1": "shi2wu4",
+        "intermediate_2": "shíwù",
+        "native_1": "food",
+        "primary_1": "食物",
+        "primary_2": "食物"
+    },
+    {
+        "intermediate_1": "shi3jin4r",
+        "intermediate_2": "shǐjìnr",
+        "native_1": "exert all one's strength",
+        "primary_1": "使劲儿",
+        "primary_2": "使勁兒"
+    },
+    {
+        "intermediate_1": "shi3zhong1",
+        "intermediate_2": "shǐzhōng",
+        "native_1": "from beginning to end; all along",
+        "primary_1": "始终",
+        "primary_2": "始終"
+    },
+    {
+        "intermediate_1": "shi4bing1",
+        "intermediate_2": "shìbīng",
+        "native_1": "soldier",
+        "primary_1": "士兵",
+        "primary_2": "士兵"
+    },
+    {
+        "intermediate_1": "shi4chang3",
+        "intermediate_2": "shìchǎng",
+        "native_1": "market",
+        "primary_1": "市场",
+        "primary_2": "市場"
+    },
+    {
+        "intermediate_1": "shi4de",
+        "intermediate_2": "shìde",
+        "native_1": "seems as if; rather like",
+        "primary_1": "似的",
+        "primary_2": "似的"
+    },
+    {
+        "intermediate_1": "shi4shi2",
+        "intermediate_2": "shìshí",
+        "native_1": "fact; in fact",
+        "primary_1": "事实",
+        "primary_2": "事實"
+    },
+    {
+        "intermediate_1": "shi4wu4",
+        "intermediate_2": "shìwù",
+        "native_1": "thing; object",
+        "primary_1": "事物",
+        "primary_2": "事物"
+    },
+    {
+        "intermediate_1": "shi4xian1",
+        "intermediate_2": "shìxiān",
+        "native_1": "in advance; beforehand; prior",
+        "primary_1": "事先",
+        "primary_2": "事先"
+    },
+    {
+        "intermediate_1": "shi4juan4",
+        "intermediate_2": "shìjuàn",
+        "native_1": "exam paper; test paper",
+        "primary_1": "试卷",
+        "primary_2": "試卷"
+    },
+    {
+        "intermediate_1": "shou1huo4",
+        "intermediate_2": "shōuhuò",
+        "native_1": "harvest; acquisition; gain",
+        "primary_1": "收获",
+        "primary_2": "收獲"
+    },
+    {
+        "intermediate_1": "shou1ju4",
+        "intermediate_2": "shōujù",
+        "native_1": "receipt",
+        "primary_1": "收据",
+        "primary_2": "收據"
+    },
+    {
+        "intermediate_1": "shou3gong1",
+        "intermediate_2": "shǒugōng",
+        "native_1": "hand-made; handicraft; manual",
+        "primary_1": "手工",
+        "primary_2": "手工"
+    },
+    {
+        "intermediate_1": "shou3shu4",
+        "intermediate_2": "shǒushù",
+        "native_1": "surgery; operation",
+        "primary_1": "手术",
+        "primary_2": "手術"
+    },
+    {
+        "intermediate_1": "shou3tao4",
+        "intermediate_2": "shǒutào",
+        "native_1": "glove; mitten",
+        "primary_1": "手套",
+        "primary_2": "手套"
+    },
+    {
+        "intermediate_1": "shou3xu4",
+        "intermediate_2": "shǒuxù",
+        "native_1": "formalities; procedure",
+        "primary_1": "手续",
+        "primary_2": "手續"
+    },
+    {
+        "intermediate_1": "shou3zhi3",
+        "intermediate_2": "shǒuzhǐ",
+        "native_1": "finger",
+        "primary_1": "手指",
+        "primary_2": "手指"
+    },
+    {
+        "intermediate_1": "shou3",
+        "intermediate_2": "shǒu",
+        "native_1": "head; chief; first; (mw for poems and songs) (Kangxi radical 185)",
+        "primary_1": "首",
+        "primary_2": "首"
+    },
+    {
+        "intermediate_1": "shou4ming4",
+        "intermediate_2": "shòumìng",
+        "native_1": "life span; life expectancy",
+        "primary_1": "寿命",
+        "primary_2": "壽命"
+    },
+    {
+        "intermediate_1": "shou4 shang1",
+        "intermediate_2": "shòu shāng",
+        "native_1": "sustain injuries (in an accident, etc.); be injured",
+        "primary_1": "受伤",
+        "primary_2": "受傷"
+    },
+    {
+        "intermediate_1": "shu1jia4",
+        "intermediate_2": "shūjià",
+        "native_1": "bookshelf",
+        "primary_1": "书架",
+        "primary_2": "書架"
+    },
+    {
+        "intermediate_1": "shu1zi",
+        "intermediate_2": "shūzi",
+        "native_1": "comb; hairbrush",
+        "primary_1": "梳子",
+        "primary_2": "梳子"
+    },
+    {
+        "intermediate_1": "shu1shi4",
+        "intermediate_2": "shūshì",
+        "native_1": "cozy; comfortable; snug",
+        "primary_1": "舒适",
+        "primary_2": "舒適"
+    },
+    {
+        "intermediate_1": "shu1ru4",
+        "intermediate_2": "shūrù",
+        "native_1": "input; enter; import",
+        "primary_1": "输入",
+        "primary_2": "輸入"
+    },
+    {
+        "intermediate_1": "shu1cai4",
+        "intermediate_2": "shūcài",
+        "native_1": "vegetables; produce",
+        "primary_1": "蔬菜",
+        "primary_2": "蔬菜"
+    },
+    {
+        "intermediate_1": "shu2lian4",
+        "intermediate_2": "shúliàn",
+        "native_1": "practiced; proficient; skilled",
+        "primary_1": "熟练",
+        "primary_2": "熟練"
+    },
+    {
+        "intermediate_1": "shu3yu2",
+        "intermediate_2": "shǔyú",
+        "native_1": "belong to; be part of",
+        "primary_1": "属于",
+        "primary_2": "屬于"
+    },
+    {
+        "intermediate_1": "shu3 biao1",
+        "intermediate_2": "shǔ biāo",
+        "native_1": "mouse (computer)",
+        "primary_1": "鼠标",
+        "primary_2": "鼠標"
+    },
+    {
+        "intermediate_1": "shu4, shu3",
+        "intermediate_2": "shù, shǔ",
+        "native_1": "number | to count; to rank",
+        "primary_1": "数",
+        "primary_2": "數"
+    },
+    {
+        "intermediate_1": "shu4ju4",
+        "intermediate_2": "shùjù",
+        "native_1": "data; numbers; digital",
+        "primary_1": "数据",
+        "primary_2": "數據"
+    },
+    {
+        "intermediate_1": "shu4ma3",
+        "intermediate_2": "shùmǎ",
+        "native_1": "numeral; number; amount; digital",
+        "primary_1": "数码",
+        "primary_2": "數碼"
+    },
+    {
+        "intermediate_1": "shuai1dao3",
+        "intermediate_2": "shuāidǎo",
+        "native_1": "fall down; slip and fall; tumble; trip",
+        "primary_1": "摔倒",
+        "primary_2": "摔倒"
+    },
+    {
+        "intermediate_1": "shuai3",
+        "intermediate_2": "shuǎi",
+        "native_1": "to throw; to fling; to swing; cast off",
+        "primary_1": "甩",
+        "primary_2": "甩"
+    },
+    {
+        "intermediate_1": "shuang1fang1",
+        "intermediate_2": "shuāngfāng",
+        "native_1": "bilateral; both sides; both parties involved",
+        "primary_1": "双方",
+        "primary_2": "雙方"
+    },
+    {
+        "intermediate_1": "shui4",
+        "intermediate_2": "shuì",
+        "native_1": "tax",
+        "primary_1": "税",
+        "primary_2": "稅"
+    },
+    {
+        "intermediate_1": "shuo1buding4",
+        "intermediate_2": "shuōbudìng",
+        "native_1": "can't say for sure; perhaps; maybe",
+        "primary_1": "说不定",
+        "primary_2": "說不定"
+    },
+    {
+        "intermediate_1": "shuo1 fu2",
+        "intermediate_2": "shuō fú",
+        "native_1": "persuade; convince",
+        "primary_1": "说服",
+        "primary_2": "說服"
+    },
+    {
+        "intermediate_1": "si1chou2",
+        "intermediate_2": "sīchóu",
+        "native_1": "silk",
+        "primary_1": "丝绸",
+        "primary_2": "絲綢"
+    },
+    {
+        "intermediate_1": "si1hao2",
+        "intermediate_2": "sīháo",
+        "native_1": "the slightest amount or degree; a very little bit",
+        "primary_1": "丝毫",
+        "primary_2": "絲毫"
+    },
+    {
+        "intermediate_1": "si1ren2",
+        "intermediate_2": "sīrén",
+        "native_1": "private (citizen); personal; individual",
+        "primary_1": "私人",
+        "primary_2": "私人"
+    },
+    {
+        "intermediate_1": "si1kao3",
+        "intermediate_2": "sīkǎo",
+        "native_1": "reflect on; ponder; consider",
+        "primary_1": "思考",
+        "primary_2": "思考"
+    },
+    {
+        "intermediate_1": "si1xiang3",
+        "intermediate_2": "sīxiǎng",
+        "native_1": "thought; thinking; idea; ideology",
+        "primary_1": "思想",
+        "primary_2": "思想"
+    },
+    {
+        "intermediate_1": "si1",
+        "intermediate_2": "sī",
+        "native_1": "to tear (something)",
+        "primary_1": "撕",
+        "primary_2": "撕"
+    },
+    {
+        "intermediate_1": "si4hu1",
+        "intermediate_2": "sìhū",
+        "native_1": "it seems; as if; seemingly",
+        "primary_1": "似乎",
+        "primary_2": "似乎"
+    },
+    {
+        "intermediate_1": "sou1suo3",
+        "intermediate_2": "sōusuǒ",
+        "native_1": "search; look for something; scour",
+        "primary_1": "搜索",
+        "primary_2": "搜索"
+    },
+    {
+        "intermediate_1": "su4she4",
+        "intermediate_2": "sùshè",
+        "native_1": "dormitory; living quarters; hostel",
+        "primary_1": "宿舍",
+        "primary_2": "宿舍"
+    },
+    {
+        "intermediate_1": "sui2shen1",
+        "intermediate_2": "suíshēn",
+        "native_1": "carry on one's person; bring with one",
+        "primary_1": "随身",
+        "primary_2": "隨身"
+    },
+    {
+        "intermediate_1": "sui2shi2",
+        "intermediate_2": "suíshí",
+        "native_1": "at any time; whenever necessary",
+        "primary_1": "随时",
+        "primary_2": "隨時"
+    },
+    {
+        "intermediate_1": "sui2shou3",
+        "intermediate_2": "suíshǒu",
+        "native_1": "convenient; without extra trouble",
+        "primary_1": "随手",
+        "primary_2": "隨手"
+    },
+    {
+        "intermediate_1": "sui4",
+        "intermediate_2": "suì",
+        "native_1": "broken; break into pieces",
+        "primary_1": "碎",
+        "primary_2": "碎"
+    },
+    {
+        "intermediate_1": "sun3shi1",
+        "intermediate_2": "sǔnshī",
+        "native_1": "loss (financial); lose",
+        "primary_1": "损失",
+        "primary_2": "損失"
+    },
+    {
+        "intermediate_1": "suo1duan3",
+        "intermediate_2": "suōduǎn",
+        "native_1": "shorten; cut down; curtail",
+        "primary_1": "缩短",
+        "primary_2": "縮短"
+    },
+    {
+        "intermediate_1": "suo3",
+        "intermediate_2": "suǒ",
+        "native_1": "place; that which; (mw for houses, buildings)",
+        "primary_1": "所",
+        "primary_2": "所"
+    },
+    {
+        "intermediate_1": "suo3",
+        "intermediate_2": "suǒ",
+        "native_1": "lock",
+        "primary_1": "锁",
+        "primary_2": "鎖"
+    },
+    {
+        "intermediate_1": "tai2jie1",
+        "intermediate_2": "táijiē",
+        "native_1": "flight of steps; sidestep; fig. way out of an embarrassing situation",
+        "primary_1": "台阶",
+        "primary_2": "台階"
+    },
+    {
+        "intermediate_1": "tai4ji2quan2",
+        "intermediate_2": "tàijíquán",
+        "native_1": "Tai chi, a Chinese martial art",
+        "primary_1": "太极拳",
+        "primary_2": "太極拳"
+    },
+    {
+        "intermediate_1": "tai4tai",
+        "intermediate_2": "tàitai",
+        "native_1": "wife; married woman; Madame; Mrs.",
+        "primary_1": "太太",
+        "primary_2": "太太"
+    },
+    {
+        "intermediate_1": "tan2pan4",
+        "intermediate_2": "tánpàn",
+        "native_1": "negotiate; negotiation; conference",
+        "primary_1": "谈判",
+        "primary_2": "談判"
+    },
+    {
+        "intermediate_1": "tan3shuai4",
+        "intermediate_2": "tǎnshuài",
+        "native_1": "frank",
+        "primary_1": "坦率",
+        "primary_2": "坦率"
+    },
+    {
+        "intermediate_1": "tang4",
+        "intermediate_2": "tàng",
+        "native_1": "to scald; to burn; scalding hot; to iron",
+        "primary_1": "烫",
+        "primary_2": "燙"
+    },
+    {
+        "intermediate_1": "tao2",
+        "intermediate_2": "táo",
+        "native_1": "to escape; run away; flee",
+        "primary_1": "逃",
+        "primary_2": "逃"
+    },
+    {
+        "intermediate_1": "tao2bi4",
+        "intermediate_2": "táobì",
+        "native_1": "to escape; evade; shirk",
+        "primary_1": "逃避",
+        "primary_2": "逃避"
+    },
+    {
+        "intermediate_1": "tao2",
+        "intermediate_2": "táo",
+        "native_1": "peach",
+        "primary_1": "桃",
+        "primary_2": "桃"
+    },
+    {
+        "intermediate_1": "tao2qi4",
+        "intermediate_2": "táoqì",
+        "native_1": "naughty; bad",
+        "primary_1": "淘气",
+        "primary_2": "淘氣"
+    },
+    {
+        "intermediate_1": "tao3 jia4 huan2 jia4",
+        "intermediate_2": "tǎo jià huán jià",
+        "native_1": "bargaining; haggling over price",
+        "primary_1": "讨价还价",
+        "primary_2": "討價還價"
+    },
+    {
+        "intermediate_1": "tao4",
+        "intermediate_2": "tào",
+        "native_1": "cover; (mw for sets of things); tie together",
+        "primary_1": "套",
+        "primary_2": "套"
+    },
+    {
+        "intermediate_1": "te4se4",
+        "intermediate_2": "tèsè",
+        "native_1": "characteristic; distinguishing feature",
+        "primary_1": "特色",
+        "primary_2": "特色"
+    },
+    {
+        "intermediate_1": "te4shu1",
+        "intermediate_2": "tèshū",
+        "native_1": "special; particular; extraordinary; unusual",
+        "primary_1": "特殊",
+        "primary_2": "特殊"
+    },
+    {
+        "intermediate_1": "te4zheng1",
+        "intermediate_2": "tèzhēng",
+        "native_1": "characteristics; distinctive features; trait",
+        "primary_1": "特征",
+        "primary_2": "特征"
+    },
+    {
+        "intermediate_1": "teng2 ai4",
+        "intermediate_2": "téng ài",
+        "native_1": "love dearly; be very fond of",
+        "primary_1": "疼爱",
+        "primary_2": "疼愛"
+    },
+    {
+        "intermediate_1": "ti2chang4",
+        "intermediate_2": "tíchàng",
+        "native_1": "promote; to advocate; proposal",
+        "primary_1": "提倡",
+        "primary_2": "提倡"
+    },
+    {
+        "intermediate_1": "ti2gang1",
+        "intermediate_2": "tígāng",
+        "native_1": "outline; the key point",
+        "primary_1": "提纲",
+        "primary_2": "提綱"
+    },
+    {
+        "intermediate_1": "ti2wen4",
+        "intermediate_2": "tíwèn",
+        "native_1": "put questions to; to quiz",
+        "primary_1": "提问",
+        "primary_2": "提問"
+    },
+    {
+        "intermediate_1": "ti2mu4",
+        "intermediate_2": "tímù",
+        "native_1": "subject; title; topic",
+        "primary_1": "题目",
+        "primary_2": "題目"
+    },
+    {
+        "intermediate_1": "ti3hui4",
+        "intermediate_2": "tǐhuì",
+        "native_1": "know from experience; learn through experience; realize; understanding; experience",
+        "primary_1": "体会",
+        "primary_2": "體會"
+    },
+    {
+        "intermediate_1": "ti3tie1",
+        "intermediate_2": "tǐtiē",
+        "native_1": "show consideration for; thoughtful",
+        "primary_1": "体贴",
+        "primary_2": "體貼"
+    },
+    {
+        "intermediate_1": "ti3xian4",
+        "intermediate_2": "tǐxiàn",
+        "native_1": "embody; incarnate; reflect; to manifest",
+        "primary_1": "体现",
+        "primary_2": "體現"
+    },
+    {
+        "intermediate_1": "ti3yan4",
+        "intermediate_2": "tǐyàn",
+        "native_1": "experience for oneself; to personally experience (usually a kind of life)",
+        "primary_1": "体验",
+        "primary_2": "體驗"
+    },
+    {
+        "intermediate_1": "tian1kong1",
+        "intermediate_2": "tiānkōng",
+        "native_1": "sky; space; heavens",
+        "primary_1": "天空",
+        "primary_2": "天空"
+    },
+    {
+        "intermediate_1": "tian1zhen1",
+        "intermediate_2": "tiānzhēn",
+        "native_1": "naïve; innocent; artless",
+        "primary_1": "天真",
+        "primary_2": "天真"
+    },
+    {
+        "intermediate_1": "tiao2pi2",
+        "intermediate_2": "tiáopí",
+        "native_1": "naughty; mischievous; unruly",
+        "primary_1": "调皮",
+        "primary_2": "調皮"
+    },
+    {
+        "intermediate_1": "tiao2zheng3",
+        "intermediate_2": "tiáozhěng",
+        "native_1": "adjustment; revision",
+        "primary_1": "调整",
+        "primary_2": "調整"
+    },
+    {
+        "intermediate_1": "tiao3zhan4",
+        "intermediate_2": "tiǎozhàn",
+        "native_1": "challenge",
+        "primary_1": "挑战",
+        "primary_2": "挑戰"
+    },
+    {
+        "intermediate_1": "tong1chang2",
+        "intermediate_2": "tōngcháng",
+        "native_1": "regular; usual; normal; ordinary",
+        "primary_1": "通常",
+        "primary_2": "通常"
+    },
+    {
+        "intermediate_1": "tong3yi1",
+        "intermediate_2": "tǒngyī",
+        "native_1": "unify; unite; integrate; universal",
+        "primary_1": "统一",
+        "primary_2": "統一"
+    },
+    {
+        "intermediate_1": "tong4ku3",
+        "intermediate_2": "tòngkǔ",
+        "native_1": "pain; suffering; agony",
+        "primary_1": "痛苦",
+        "primary_2": "痛苦"
+    },
+    {
+        "intermediate_1": "tong4kuai",
+        "intermediate_2": "tòngkuai",
+        "native_1": "joyful; delighted; very happy; jolly",
+        "primary_1": "痛快",
+        "primary_2": "痛快"
+    },
+    {
+        "intermediate_1": "tou1",
+        "intermediate_2": "tōu",
+        "native_1": "steal; pilfer",
+        "primary_1": "偷",
+        "primary_2": "偷"
+    },
+    {
+        "intermediate_1": "tou2ru4",
+        "intermediate_2": "tóurù",
+        "native_1": "put into operation; throw into; to invest",
+        "primary_1": "投入",
+        "primary_2": "投入"
+    },
+    {
+        "intermediate_1": "tou2 zi1",
+        "intermediate_2": "tóu zī",
+        "native_1": "investment",
+        "primary_1": "投资",
+        "primary_2": "投資"
+    },
+    {
+        "intermediate_1": "tou4ming2",
+        "intermediate_2": "tòumíng",
+        "native_1": "transparent; open (non-secretive)",
+        "primary_1": "透明",
+        "primary_2": "透明"
+    },
+    {
+        "intermediate_1": "tu1chu1",
+        "intermediate_2": "tūchū",
+        "native_1": "prominent; stand out; give prominence to",
+        "primary_1": "突出",
+        "primary_2": "突出"
+    },
+    {
+        "intermediate_1": "tu3di4",
+        "intermediate_2": "tǔdì",
+        "native_1": "land; territory; soil",
+        "primary_1": "土地",
+        "primary_2": "土地"
+    },
+    {
+        "intermediate_1": "tu3dou4",
+        "intermediate_2": "tǔdòu",
+        "native_1": "potato",
+        "primary_1": "土豆",
+        "primary_2": "土豆"
+    },
+    {
+        "intermediate_1": "tu3, tu4",
+        "intermediate_2": "tǔ, tù",
+        "native_1": "to spit | to vomit; throw up",
+        "primary_1": "吐",
+        "primary_2": "吐"
+    },
+    {
+        "intermediate_1": "tu4zi",
+        "intermediate_2": "tùzi",
+        "native_1": "rabbit; hare",
+        "primary_1": "兔子",
+        "primary_2": "兔子"
+    },
+    {
+        "intermediate_1": "tuan2",
+        "intermediate_2": "tuán",
+        "native_1": "round; ball; group; unite; dumpling; (mw for ball-like things)",
+        "primary_1": "团",
+        "primary_2": "團"
+    },
+    {
+        "intermediate_1": "tui1ci2",
+        "intermediate_2": "tuīcí",
+        "native_1": "to decline; turn down",
+        "primary_1": "推辞",
+        "primary_2": "推辭"
+    },
+    {
+        "intermediate_1": "tui1guang3",
+        "intermediate_2": "tuīguǎng",
+        "native_1": "popularize; to spread",
+        "primary_1": "推广",
+        "primary_2": "推廣"
+    },
+    {
+        "intermediate_1": "tui1jian4",
+        "intermediate_2": "tuījiàn",
+        "native_1": "recommend; recommendation",
+        "primary_1": "推荐",
+        "primary_2": "推薦"
+    },
+    {
+        "intermediate_1": "tui4",
+        "intermediate_2": "tuì",
+        "native_1": "to retreat; decline; withdraw",
+        "primary_1": "退",
+        "primary_2": "退"
+    },
+    {
+        "intermediate_1": "tui4bu4",
+        "intermediate_2": "tuìbù",
+        "native_1": "to degenerate; to regress",
+        "primary_1": "退步",
+        "primary_2": "退步"
+    },
+    {
+        "intermediate_1": "tui4xiu1",
+        "intermediate_2": "tuìxiū",
+        "native_1": "retirement (from work); retire",
+        "primary_1": "退休",
+        "primary_2": "退休"
+    },
+    {
+        "intermediate_1": "wai1",
+        "intermediate_2": "wāi",
+        "native_1": "askew; crooked; devious; recline to take a rest (colloquial)",
+        "primary_1": "歪",
+        "primary_2": "歪"
+    },
+    {
+        "intermediate_1": "wai4gong1",
+        "intermediate_2": "wàigōng",
+        "native_1": "maternal grandfather",
+        "primary_1": "外公",
+        "primary_2": "外公"
+    },
+    {
+        "intermediate_1": "wai4jiao1",
+        "intermediate_2": "wàijiāo",
+        "native_1": "diplomacy; foreign affairs",
+        "primary_1": "外交",
+        "primary_2": "外交"
+    },
+    {
+        "intermediate_1": "wan2mei3",
+        "intermediate_2": "wánměi",
+        "native_1": "perfect",
+        "primary_1": "完美",
+        "primary_2": "完美"
+    },
+    {
+        "intermediate_1": "wan2shan4",
+        "intermediate_2": "wánshàn",
+        "native_1": "perfect; make perfect; improve",
+        "primary_1": "完善",
+        "primary_2": "完善"
+    },
+    {
+        "intermediate_1": "wan2zheng3",
+        "intermediate_2": "wánzhěng",
+        "native_1": "complete; intact",
+        "primary_1": "完整",
+        "primary_2": "完整"
+    },
+    {
+        "intermediate_1": "wan2ju4",
+        "intermediate_2": "wánjù",
+        "native_1": "plaything; toy",
+        "primary_1": "玩具",
+        "primary_2": "玩具"
+    },
+    {
+        "intermediate_1": "wan4yi1",
+        "intermediate_2": "wànyī",
+        "native_1": "just in case; if by any chance",
+        "primary_1": "万一",
+        "primary_2": "萬一"
+    },
+    {
+        "intermediate_1": "wang2zi3",
+        "intermediate_2": "wángzǐ",
+        "native_1": "prince; son of a king",
+        "primary_1": "王子",
+        "primary_2": "王子"
+    },
+    {
+        "intermediate_1": "wang3luo4",
+        "intermediate_2": "wǎngluò",
+        "native_1": "network",
+        "primary_1": "网络",
+        "primary_2": "網絡"
+    },
+    {
+        "intermediate_1": "wang3fan3",
+        "intermediate_2": "wǎngfǎn",
+        "native_1": "go back and forth; go to and fro",
+        "primary_1": "往返",
+        "primary_2": "往返"
+    },
+    {
+        "intermediate_1": "wei1hai4",
+        "intermediate_2": "wēihài",
+        "native_1": "endanger; jeopardize; to harm",
+        "primary_1": "危害",
+        "primary_2": "危害"
+    },
+    {
+        "intermediate_1": "wei1xie2",
+        "intermediate_2": "wēixié",
+        "native_1": "threaten; to menace",
+        "primary_1": "威胁",
+        "primary_2": "威脅"
+    },
+    {
+        "intermediate_1": "wei1xiao4",
+        "intermediate_2": "wēixiào",
+        "native_1": "smile",
+        "primary_1": "微笑",
+        "primary_2": "微笑"
+    },
+    {
+        "intermediate_1": "wei2fan3",
+        "intermediate_2": "wéifǎn",
+        "native_1": "violate (a law)",
+        "primary_1": "违反",
+        "primary_2": "違反"
+    },
+    {
+        "intermediate_1": "wei2jin1",
+        "intermediate_2": "wéijīn",
+        "native_1": "scarf; shawl",
+        "primary_1": "围巾",
+        "primary_2": "圍巾"
+    },
+    {
+        "intermediate_1": "wei2rao4",
+        "intermediate_2": "wéirào",
+        "native_1": "revolve around; center on (an issue)",
+        "primary_1": "围绕",
+        "primary_2": "圍繞"
+    },
+    {
+        "intermediate_1": "wei2yi1",
+        "intermediate_2": "wéiyī",
+        "native_1": "only; sole",
+        "primary_1": "唯一",
+        "primary_2": "唯一"
+    },
+    {
+        "intermediate_1": "wei2xiu1",
+        "intermediate_2": "wéixiū",
+        "native_1": "maintain (of equipment); to mend; repair",
+        "primary_1": "维修",
+        "primary_2": "維修"
+    },
+    {
+        "intermediate_1": "wei3da4",
+        "intermediate_2": "wěidà",
+        "native_1": "great; mighty; large",
+        "primary_1": "伟大",
+        "primary_2": "偉大"
+    },
+    {
+        "intermediate_1": "wei3ba",
+        "intermediate_2": "wěiba",
+        "native_1": "tail",
+        "primary_1": "尾巴",
+        "primary_2": "尾巴"
+    },
+    {
+        "intermediate_1": "wei3qu",
+        "intermediate_2": "wěiqu",
+        "native_1": "feel wronged; nurse a grievance",
+        "primary_1": "委屈",
+        "primary_2": "委屈"
+    },
+    {
+        "intermediate_1": "wei4bi4",
+        "intermediate_2": "wèibì",
+        "native_1": "not necessarily; need not",
+        "primary_1": "未必",
+        "primary_2": "未必"
+    },
+    {
+        "intermediate_1": "wei4lai2",
+        "intermediate_2": "wèilái",
+        "native_1": "future",
+        "primary_1": "未来",
+        "primary_2": "未來"
+    },
+    {
+        "intermediate_1": "wei4yu2",
+        "intermediate_2": "wèiyú",
+        "native_1": "be located at",
+        "primary_1": "位于",
+        "primary_2": "位于"
+    },
+    {
+        "intermediate_1": "wei4zhi",
+        "intermediate_2": "wèizhi",
+        "native_1": "position; place; seat",
+        "primary_1": "位置",
+        "primary_2": "位置"
+    },
+    {
+        "intermediate_1": "wei4",
+        "intermediate_2": "wèi",
+        "native_1": "stomach",
+        "primary_1": "胃",
+        "primary_2": "胃"
+    },
+    {
+        "intermediate_1": "wei4kou3",
+        "intermediate_2": "wèikǒu",
+        "native_1": "appetite",
+        "primary_1": "胃口",
+        "primary_2": "胃口"
+    },
+    {
+        "intermediate_1": "wen1nuan3",
+        "intermediate_2": "wēnnuǎn",
+        "native_1": "warm",
+        "primary_1": "温暖",
+        "primary_2": "溫暖"
+    },
+    {
+        "intermediate_1": "wen1rou2",
+        "intermediate_2": "wēnróu",
+        "native_1": "gentle and soft; tender; gentle",
+        "primary_1": "温柔",
+        "primary_2": "溫柔"
+    },
+    {
+        "intermediate_1": "wen2jian4",
+        "intermediate_2": "wénjiàn",
+        "native_1": "document; file",
+        "primary_1": "文件",
+        "primary_2": "文件"
+    },
+    {
+        "intermediate_1": "wen2ju4",
+        "intermediate_2": "wénjù",
+        "native_1": "stationery; writing supplies",
+        "primary_1": "文具",
+        "primary_2": "文具"
+    },
+    {
+        "intermediate_1": "wen2ming2",
+        "intermediate_2": "wénmíng",
+        "native_1": "civilization; civilized; culture",
+        "primary_1": "文明",
+        "primary_2": "文明"
+    },
+    {
+        "intermediate_1": "wen2xue2",
+        "intermediate_2": "wénxué",
+        "native_1": "literature",
+        "primary_1": "文学",
+        "primary_2": "文學"
+    },
+    {
+        "intermediate_1": "wen2zi4",
+        "intermediate_2": "wénzì",
+        "native_1": "characters; script; writing",
+        "primary_1": "文字",
+        "primary_2": "文字"
+    },
+    {
+        "intermediate_1": "wen2",
+        "intermediate_2": "wén",
+        "native_1": "hear; to smell; news; reputation",
+        "primary_1": "闻",
+        "primary_2": "聞"
+    },
+    {
+        "intermediate_1": "wen3",
+        "intermediate_2": "wěn",
+        "native_1": "kiss; lips",
+        "primary_1": "吻",
+        "primary_2": "吻"
+    },
+    {
+        "intermediate_1": "wen3ding4",
+        "intermediate_2": "wěndìng",
+        "native_1": "stable; steady",
+        "primary_1": "稳定",
+        "primary_2": "穩定"
+    },
+    {
+        "intermediate_1": "wen4hou4",
+        "intermediate_2": "wènhòu",
+        "native_1": "send a greeting; send one's regards to",
+        "primary_1": "问候",
+        "primary_2": "問候"
+    },
+    {
+        "intermediate_1": "wo4shi4",
+        "intermediate_2": "wòshì",
+        "native_1": "bedroom",
+        "primary_1": "卧室",
+        "primary_2": "臥室"
+    },
+    {
+        "intermediate_1": "wo4 shou3",
+        "intermediate_2": "wò shǒu",
+        "native_1": "to shake hands",
+        "primary_1": "握手",
+        "primary_2": "握手"
+    },
+    {
+        "intermediate_1": "wu1zi",
+        "intermediate_2": "wūzi",
+        "native_1": "room; house",
+        "primary_1": "屋子",
+        "primary_2": "屋子"
+    },
+    {
+        "intermediate_1": "wun2ai4",
+        "intermediate_2": "wúnài",
+        "native_1": "can't help but; have no choice",
+        "primary_1": "无奈",
+        "primary_2": "無奈"
+    },
+    {
+        "intermediate_1": "wu2shu4",
+        "intermediate_2": "wúshù",
+        "native_1": "countless; innumerable",
+        "primary_1": "无数",
+        "primary_2": "無數"
+    },
+    {
+        "intermediate_1": "wu2suo3wei4",
+        "intermediate_2": "wúsuǒwèi",
+        "native_1": "doesn't matter; be indifferent",
+        "primary_1": "无所谓",
+        "primary_2": "無所謂"
+    },
+    {
+        "intermediate_1": "wu3shu4",
+        "intermediate_2": "wǔshù",
+        "native_1": "martial arts",
+        "primary_1": "武术",
+        "primary_2": "武術"
+    },
+    {
+        "intermediate_1": "wu4",
+        "intermediate_2": "wù",
+        "native_1": "not; do not",
+        "primary_1": "勿",
+        "primary_2": "勿"
+    },
+    {
+        "intermediate_1": "wu4li3",
+        "intermediate_2": "wùlǐ",
+        "native_1": "physics; physical",
+        "primary_1": "物理",
+        "primary_2": "物理"
+    },
+    {
+        "intermediate_1": "wu4zhi4",
+        "intermediate_2": "wùzhì",
+        "native_1": "matter; substance; material",
+        "primary_1": "物质",
+        "primary_2": "物質"
+    },
+    {
+        "intermediate_1": "wu4",
+        "intermediate_2": "wù",
+        "native_1": "fog; mist",
+        "primary_1": "雾",
+        "primary_2": "霧"
+    },
+    {
+        "intermediate_1": "xi1qu3",
+        "intermediate_2": "xīqǔ",
+        "native_1": "absorb; assimilate",
+        "primary_1": "吸取",
+        "primary_2": "吸取"
+    },
+    {
+        "intermediate_1": "xi1shou1",
+        "intermediate_2": "xīshōu",
+        "native_1": "absorb; ingest",
+        "primary_1": "吸收",
+        "primary_2": "吸收"
+    },
+    {
+        "intermediate_1": "xi4ju4",
+        "intermediate_2": "xìjù",
+        "native_1": "drama; play; theater",
+        "primary_1": "戏剧",
+        "primary_2": "戲劇"
+    },
+    {
+        "intermediate_1": "xi4, ji4",
+        "intermediate_2": "xì, jì",
+        "native_1": "be; relate to; system; fasten; department; faculty; connect | to tie",
+        "primary_1": "系",
+        "primary_2": "系"
+    },
+    {
+        "intermediate_1": "xi4tong3",
+        "intermediate_2": "xìtǒng",
+        "native_1": "system",
+        "primary_1": "系统",
+        "primary_2": "系統"
+    },
+    {
+        "intermediate_1": "xi4jie2",
+        "intermediate_2": "xìjié",
+        "native_1": "details; particulars",
+        "primary_1": "细节",
+        "primary_2": "細節"
+    },
+    {
+        "intermediate_1": "xia1",
+        "intermediate_2": "xiā",
+        "native_1": "blind",
+        "primary_1": "瞎",
+        "primary_2": "瞎"
+    },
+    {
+        "intermediate_1": "xia4zai3",
+        "intermediate_2": "xiàzǎi",
+        "native_1": "to download",
+        "primary_1": "下载",
+        "primary_2": "下載"
+    },
+    {
+        "intermediate_1": "xia4",
+        "intermediate_2": "xià",
+        "native_1": "frighten; to scare; intimidate",
+        "primary_1": "吓",
+        "primary_2": "嚇"
+    },
+    {
+        "intermediate_1": "xia4ling4ying2",
+        "intermediate_2": "xiàlìngyíng",
+        "native_1": "summer camp",
+        "primary_1": "夏令营",
+        "primary_2": "夏令營"
+    },
+    {
+        "intermediate_1": "xian1yan4",
+        "intermediate_2": "xiānyàn",
+        "native_1": "bright-colored",
+        "primary_1": "鲜艳",
+        "primary_2": "鮮豔"
+    },
+    {
+        "intermediate_1": "xian3de",
+        "intermediate_2": "xiǎnde",
+        "native_1": "appear; seem; to look",
+        "primary_1": "显得",
+        "primary_2": "顯得"
+    },
+    {
+        "intermediate_1": "xian3ran2",
+        "intermediate_2": "xiǎnrán",
+        "native_1": "clear; evidently; obviously",
+        "primary_1": "显然",
+        "primary_2": "顯然"
+    },
+    {
+        "intermediate_1": "xian3shi4",
+        "intermediate_2": "xiǎnshì",
+        "native_1": "display, illustrate, to show",
+        "primary_1": "显示",
+        "primary_2": "顯示"
+    },
+    {
+        "intermediate_1": "xian4",
+        "intermediate_2": "xiàn",
+        "native_1": "county; district",
+        "primary_1": "县",
+        "primary_2": "縣"
+    },
+    {
+        "intermediate_1": "xian4dai4",
+        "intermediate_2": "xiàndài",
+        "native_1": "modern times; modern age",
+        "primary_1": "现代",
+        "primary_2": "現代"
+    },
+    {
+        "intermediate_1": "xian4shi2",
+        "intermediate_2": "xiànshí",
+        "native_1": "reality; actuality; practical",
+        "primary_1": "现实",
+        "primary_2": "現實"
+    },
+    {
+        "intermediate_1": "xian4xiang4",
+        "intermediate_2": "xiànxiàng",
+        "native_1": "appearance; phenomenon",
+        "primary_1": "现象",
+        "primary_2": "現象"
+    },
+    {
+        "intermediate_1": "xian4zhi4",
+        "intermediate_2": "xiànzhì",
+        "native_1": "restrictions; to limit; to bound",
+        "primary_1": "限制",
+        "primary_2": "限制"
+    },
+    {
+        "intermediate_1": "xiang1chu3",
+        "intermediate_2": "xiāngchǔ",
+        "native_1": "get along; interact",
+        "primary_1": "相处",
+        "primary_2": "相處"
+    },
+    {
+        "intermediate_1": "xiang1dang1",
+        "intermediate_2": "xiāngdāng",
+        "native_1": "equivalent to; appropriate; considerably; quite",
+        "primary_1": "相当",
+        "primary_2": "相當"
+    },
+    {
+        "intermediate_1": "xiang1dui4",
+        "intermediate_2": "xiāngduì",
+        "native_1": "opposite; relatively; to resist",
+        "primary_1": "相对",
+        "primary_2": "相對"
+    },
+    {
+        "intermediate_1": "xiang1guan1",
+        "intermediate_2": "xiāngguān",
+        "native_1": "correlation; interrelated; dependence",
+        "primary_1": "相关",
+        "primary_2": "相關"
+    },
+    {
+        "intermediate_1": "xiang1si4",
+        "intermediate_2": "xiāngsì",
+        "native_1": "similar; resemble; like",
+        "primary_1": "相似",
+        "primary_2": "相似"
+    },
+    {
+        "intermediate_1": "xiang1chang2",
+        "intermediate_2": "xiāngcháng",
+        "native_1": "sausage",
+        "primary_1": "香肠",
+        "primary_2": "香腸"
+    },
+    {
+        "intermediate_1": "xiang3shou4",
+        "intermediate_2": "xiǎngshòu",
+        "native_1": "enjoy",
+        "primary_1": "享受",
+        "primary_2": "享受"
+    },
+    {
+        "intermediate_1": "xiang3nian4",
+        "intermediate_2": "xiǎngniàn",
+        "native_1": "to miss; remember with longing; long to see again",
+        "primary_1": "想念",
+        "primary_2": "想念"
+    },
+    {
+        "intermediate_1": "xiang3xiang4",
+        "intermediate_2": "xiǎngxiàng",
+        "native_1": "imagine; visualize",
+        "primary_1": "想象",
+        "primary_2": "想象"
+    },
+    {
+        "intermediate_1": "xiang4",
+        "intermediate_2": "xiàng",
+        "native_1": "nape (of the neck); sum (of money); mw item",
+        "primary_1": "项",
+        "primary_2": "項"
+    },
+    {
+        "intermediate_1": "xiang4lian4",
+        "intermediate_2": "xiàngliàn",
+        "native_1": "necklace",
+        "primary_1": "项链",
+        "primary_2": "項鏈"
+    },
+    {
+        "intermediate_1": "xiang4mu4",
+        "intermediate_2": "xiàngmù",
+        "native_1": "program; item; project",
+        "primary_1": "项目",
+        "primary_2": "項目"
+    },
+    {
+        "intermediate_1": "xiang4qi2",
+        "intermediate_2": "xiàngqí",
+        "native_1": "chess; Chinese chess",
+        "primary_1": "象棋",
+        "primary_2": "象棋"
+    },
+    {
+        "intermediate_1": "xiang4zheng1",
+        "intermediate_2": "xiàngzhēng",
+        "native_1": "symbol; symbolize; signify",
+        "primary_1": "象征",
+        "primary_2": "象征"
+    },
+    {
+        "intermediate_1": "xiao1fei4",
+        "intermediate_2": "xiāofèi",
+        "native_1": "consumption; spending",
+        "primary_1": "消费",
+        "primary_2": "消費"
+    },
+    {
+        "intermediate_1": "xiao1hua4",
+        "intermediate_2": "xiāohuà",
+        "native_1": "to digest",
+        "primary_1": "消化",
+        "primary_2": "消化"
+    },
+    {
+        "intermediate_1": "xiao1ji2",
+        "intermediate_2": "xiāojí",
+        "native_1": "passive; negative; demoralized",
+        "primary_1": "消极",
+        "primary_2": "消極"
+    },
+    {
+        "intermediate_1": "xiao1shi1",
+        "intermediate_2": "xiāoshī",
+        "native_1": "disappear; fade away; dissolve",
+        "primary_1": "消失",
+        "primary_2": "消失"
+    },
+    {
+        "intermediate_1": "xiao1shou4",
+        "intermediate_2": "xiāoshòu",
+        "native_1": "to sell; to market; sales",
+        "primary_1": "销售",
+        "primary_2": "銷售"
+    },
+    {
+        "intermediate_1": "xiao3mai4",
+        "intermediate_2": "xiǎomài",
+        "native_1": "wheat",
+        "primary_1": "小麦",
+        "primary_2": "小麥"
+    },
+    {
+        "intermediate_1": "xiao3qi4",
+        "intermediate_2": "xiǎoqì",
+        "native_1": "stingy; petty",
+        "primary_1": "小气",
+        "primary_2": "小氣"
+    },
+    {
+        "intermediate_1": "xiao4shun4",
+        "intermediate_2": "xiàoshùn",
+        "native_1": "filial piety",
+        "primary_1": "孝顺",
+        "primary_2": "孝順"
+    },
+    {
+        "intermediate_1": "xiao4lü4",
+        "intermediate_2": "xiàolǜ",
+        "native_1": "efficiency",
+        "primary_1": "效率",
+        "primary_2": "效率"
+    },
+    {
+        "intermediate_1": "xie1",
+        "intermediate_2": "xiē",
+        "native_1": "to rest; to go to bed; to take a break",
+        "primary_1": "歇",
+        "primary_2": "歇"
+    },
+    {
+        "intermediate_1": "xie2",
+        "intermediate_2": "xié",
+        "native_1": "slanting; tilted",
+        "primary_1": "斜",
+        "primary_2": "斜"
+    },
+    {
+        "intermediate_1": "xie3zuo4",
+        "intermediate_2": "xiězuò",
+        "native_1": "writing; composition; written works",
+        "primary_1": "写作",
+        "primary_2": "寫作"
+    },
+    {
+        "intermediate_1": "xue4",
+        "intermediate_2": "xuè",
+        "native_1": "blood (Kangxi radical 143)",
+        "primary_1": "血",
+        "primary_2": "血"
+    },
+    {
+        "intermediate_1": "xin1li3",
+        "intermediate_2": "xīnlǐ",
+        "native_1": "psychology; psychological; mental",
+        "primary_1": "心理",
+        "primary_2": "心理"
+    },
+    {
+        "intermediate_1": "xin1zang4",
+        "intermediate_2": "xīnzàng",
+        "native_1": "heart",
+        "primary_1": "心脏",
+        "primary_2": "心髒"
+    },
+    {
+        "intermediate_1": "xin1shang3",
+        "intermediate_2": "xīnshǎng",
+        "native_1": "appreciate; enjoy; admire",
+        "primary_1": "欣赏",
+        "primary_2": "欣賞"
+    },
+    {
+        "intermediate_1": "xin4hao4",
+        "intermediate_2": "xìnhào",
+        "native_1": "signal",
+        "primary_1": "信号",
+        "primary_2": "信號"
+    },
+    {
+        "intermediate_1": "xin4ren4",
+        "intermediate_2": "xìnrèn",
+        "native_1": "to trust; have confidence in",
+        "primary_1": "信任",
+        "primary_2": "信任"
+    },
+    {
+        "intermediate_1": "xing2dong4",
+        "intermediate_2": "xíngdòng",
+        "native_1": "to move; get around; action",
+        "primary_1": "行动",
+        "primary_2": "行動"
+    },
+    {
+        "intermediate_1": "xing2ren2",
+        "intermediate_2": "xíngrén",
+        "native_1": "pedestrian",
+        "primary_1": "行人",
+        "primary_2": "行人"
+    },
+    {
+        "intermediate_1": "xing2wei2",
+        "intermediate_2": "xíngwéi",
+        "native_1": "action; behavior; conduct",
+        "primary_1": "行为",
+        "primary_2": "行爲"
+    },
+    {
+        "intermediate_1": "xing2cheng2",
+        "intermediate_2": "xíngchéng",
+        "native_1": "take shape; form",
+        "primary_1": "形成",
+        "primary_2": "形成"
+    },
+    {
+        "intermediate_1": "xing2rong2",
+        "intermediate_2": "xíngróng",
+        "native_1": "describe; appearance; look",
+        "primary_1": "形容",
+        "primary_2": "形容"
+    },
+    {
+        "intermediate_1": "xing2shi4",
+        "intermediate_2": "xíngshì",
+        "native_1": "form; shape; situation",
+        "primary_1": "形式",
+        "primary_2": "形式"
+    },
+    {
+        "intermediate_1": "xing2shi4",
+        "intermediate_2": "xíngshì",
+        "native_1": "circumstances; situation; terrain",
+        "primary_1": "形势",
+        "primary_2": "形勢"
+    },
+    {
+        "intermediate_1": "xing2xiang4",
+        "intermediate_2": "xíngxiàng",
+        "native_1": "image; form; figure",
+        "primary_1": "形象",
+        "primary_2": "形象"
+    },
+    {
+        "intermediate_1": "xing2zhuang4",
+        "intermediate_2": "xíngzhuàng",
+        "native_1": "form; figure; shape",
+        "primary_1": "形状",
+        "primary_2": "形狀"
+    },
+    {
+        "intermediate_1": "xing4kui1",
+        "intermediate_2": "xìngkuī",
+        "native_1": "fortunately; luckily",
+        "primary_1": "幸亏",
+        "primary_2": "幸虧"
+    },
+    {
+        "intermediate_1": "xing4yun4",
+        "intermediate_2": "xìngyùn",
+        "native_1": "luck; fortune",
+        "primary_1": "幸运",
+        "primary_2": "幸運"
+    },
+    {
+        "intermediate_1": "xing4zhi4",
+        "intermediate_2": "xìngzhì",
+        "native_1": "nature; characteristic; quality",
+        "primary_1": "性质",
+        "primary_2": "性質"
+    },
+    {
+        "intermediate_1": "xiong1di4",
+        "intermediate_2": "xiōngdì",
+        "native_1": "brothers; younger brother; brethren",
+        "primary_1": "兄弟",
+        "primary_2": "兄弟"
+    },
+    {
+        "intermediate_1": "xiong1",
+        "intermediate_2": "xiōng",
+        "native_1": "chest; bosom; heart",
+        "primary_1": "胸",
+        "primary_2": "胸"
+    },
+    {
+        "intermediate_1": "xiu1xian2",
+        "intermediate_2": "xiūxián",
+        "native_1": "recreation; leisure",
+        "primary_1": "休闲",
+        "primary_2": "休閑"
+    },
+    {
+        "intermediate_1": "xiu1gai3",
+        "intermediate_2": "xiūgǎi",
+        "native_1": "amend; modify; revise; alter",
+        "primary_1": "修改",
+        "primary_2": "修改"
+    },
+    {
+        "intermediate_1": "xu1xin1",
+        "intermediate_2": "xūxīn",
+        "native_1": "modest; open-minded",
+        "primary_1": "虚心",
+        "primary_2": "虛心"
+    },
+    {
+        "intermediate_1": "xu4shu4",
+        "intermediate_2": "xùshù",
+        "native_1": "retell; narrate",
+        "primary_1": "叙述",
+        "primary_2": "敘述"
+    },
+    {
+        "intermediate_1": "xuan1bu4",
+        "intermediate_2": "xuānbù",
+        "native_1": "announce; declare; proclaim",
+        "primary_1": "宣布",
+        "primary_2": "宣布"
+    },
+    {
+        "intermediate_1": "xuan1chuan2",
+        "intermediate_2": "xuānchuán",
+        "native_1": "propaganda; to propagate; to give publicity to",
+        "primary_1": "宣传",
+        "primary_2": "宣傳"
+    },
+    {
+        "intermediate_1": "xue2li4",
+        "intermediate_2": "xuélì",
+        "native_1": "educational background; school record",
+        "primary_1": "学历",
+        "primary_2": "學曆"
+    },
+    {
+        "intermediate_1": "xue2shu4",
+        "intermediate_2": "xuéshù",
+        "native_1": "learning; science; academic",
+        "primary_1": "学术",
+        "primary_2": "學術"
+    },
+    {
+        "intermediate_1": "xue2wen",
+        "intermediate_2": "xuéwen",
+        "native_1": "learning; knowledge",
+        "primary_1": "学问",
+        "primary_2": "學問"
+    },
+    {
+        "intermediate_1": "xun2zhao3",
+        "intermediate_2": "xúnzhǎo",
+        "native_1": "seek; look for; quest",
+        "primary_1": "寻找",
+        "primary_2": "尋找"
+    },
+    {
+        "intermediate_1": "xun2wen4",
+        "intermediate_2": "xúnwèn",
+        "native_1": "inquire about",
+        "primary_1": "询问",
+        "primary_2": "詢問"
+    },
+    {
+        "intermediate_1": "xun4lian4",
+        "intermediate_2": "xùnliàn",
+        "native_1": "to train; to drill; to exercise; training",
+        "primary_1": "训练",
+        "primary_2": "訓練"
+    },
+    {
+        "intermediate_1": "xun4su4",
+        "intermediate_2": "xùnsù",
+        "native_1": "fast; quick; rapid",
+        "primary_1": "迅速",
+        "primary_2": "迅速"
+    },
+    {
+        "intermediate_1": "ya1jin1",
+        "intermediate_2": "yājīn",
+        "native_1": "security deposit; down payment",
+        "primary_1": "押金",
+        "primary_2": "押金"
+    },
+    {
+        "intermediate_1": "ya2chi3",
+        "intermediate_2": "yáchǐ",
+        "native_1": "tooth",
+        "primary_1": "牙齿",
+        "primary_2": "牙齒"
+    },
+    {
+        "intermediate_1": "yan2chang2",
+        "intermediate_2": "yáncháng",
+        "native_1": "extend; prolong; lengthen",
+        "primary_1": "延长",
+        "primary_2": "延長"
+    },
+    {
+        "intermediate_1": "yan2su4",
+        "intermediate_2": "yánsù",
+        "native_1": "solemn; serious; earnest",
+        "primary_1": "严肃",
+        "primary_2": "嚴肅"
+    },
+    {
+        "intermediate_1": "yan3jiang3",
+        "intermediate_2": "yǎnjiǎng",
+        "native_1": "give a lecture; make a speech",
+        "primary_1": "演讲",
+        "primary_2": "演講"
+    },
+    {
+        "intermediate_1": "yan4hui4",
+        "intermediate_2": "yànhuì",
+        "native_1": "banquet; feast; dinner party",
+        "primary_1": "宴会",
+        "primary_2": "宴會"
+    },
+    {
+        "intermediate_1": "yang2tai2",
+        "intermediate_2": "yángtái",
+        "native_1": "balcony",
+        "primary_1": "阳台",
+        "primary_2": "陽台"
+    },
+    {
+        "intermediate_1": "yang3",
+        "intermediate_2": "yǎng",
+        "native_1": "to itch; itchy",
+        "primary_1": "痒",
+        "primary_2": "癢"
+    },
+    {
+        "intermediate_1": "yang4shi4",
+        "intermediate_2": "yàngshì",
+        "native_1": "type; style; form",
+        "primary_1": "样式",
+        "primary_2": "樣式"
+    },
+    {
+        "intermediate_1": "yao1",
+        "intermediate_2": "yāo",
+        "native_1": "waist; lower back; pocket",
+        "primary_1": "腰",
+        "primary_2": "腰"
+    },
+    {
+        "intermediate_1": "yao2",
+        "intermediate_2": "yáo",
+        "native_1": "to shake; to rock",
+        "primary_1": "摇",
+        "primary_2": "搖"
+    },
+    {
+        "intermediate_1": "yao3",
+        "intermediate_2": "yǎo",
+        "native_1": "to bite; to nip",
+        "primary_1": "咬",
+        "primary_2": "咬"
+    },
+    {
+        "intermediate_1": "yao4bu4",
+        "intermediate_2": "yàobù",
+        "native_1": "otherwise; or else; how about",
+        "primary_1": "要不",
+        "primary_2": "要不"
+    },
+    {
+        "intermediate_1": "ye4wu4",
+        "intermediate_2": "yèwù",
+        "native_1": "business; profession",
+        "primary_1": "业务",
+        "primary_2": "業務"
+    },
+    {
+        "intermediate_1": "ye4yu2",
+        "intermediate_2": "yèyú",
+        "native_1": "spare time; amateur",
+        "primary_1": "业余",
+        "primary_2": "業余"
+    },
+    {
+        "intermediate_1": "ye4",
+        "intermediate_2": "yè",
+        "native_1": "night; darkness",
+        "primary_1": "夜",
+        "primary_2": "夜"
+    },
+    {
+        "intermediate_1": "yi2bei4zi",
+        "intermediate_2": "yíbèizi",
+        "native_1": "(for) a lifetime; all one's life",
+        "primary_1": "一辈子",
+        "primary_2": "一輩子"
+    },
+    {
+        "intermediate_1": "yi2dan4",
+        "intermediate_2": "yídàn",
+        "native_1": "in case (something happens); once (sth. has happened ... then); in one day",
+        "primary_1": "一旦",
+        "primary_2": "一旦"
+    },
+    {
+        "intermediate_1": "yi2lü4",
+        "intermediate_2": "yílǜ",
+        "native_1": "same; uniformly; all; without exception",
+        "primary_1": "一律",
+        "primary_2": "一律"
+    },
+    {
+        "intermediate_1": "yi2zai4",
+        "intermediate_2": "yízài",
+        "native_1": "repeatedly; again and again",
+        "primary_1": "一再",
+        "primary_2": "一再"
+    },
+    {
+        "intermediate_1": "yi2zhi4",
+        "intermediate_2": "yízhì",
+        "native_1": "unanimous; identical (views or opinions); consistent",
+        "primary_1": "一致",
+        "primary_2": "一致"
+    },
+    {
+        "intermediate_1": "yi1ran2",
+        "intermediate_2": "yīrán",
+        "native_1": "still; as before",
+        "primary_1": "依然",
+        "primary_2": "依然"
+    },
+    {
+        "intermediate_1": "yi2dong4",
+        "intermediate_2": "yídòng",
+        "native_1": "to move",
+        "primary_1": "移动",
+        "primary_2": "移動"
+    },
+    {
+        "intermediate_1": "yi2min2",
+        "intermediate_2": "yímín",
+        "native_1": "immigrate; emigrate; migrate",
+        "primary_1": "移民",
+        "primary_2": "移民"
+    },
+    {
+        "intermediate_1": "yi2han4",
+        "intermediate_2": "yíhàn",
+        "native_1": "regret; pity; sorry",
+        "primary_1": "遗憾",
+        "primary_2": "遺憾"
+    },
+    {
+        "intermediate_1": "yi2wen4",
+        "intermediate_2": "yíwèn",
+        "native_1": "doubt; question; to query",
+        "primary_1": "疑问",
+        "primary_2": "疑問"
+    },
+    {
+        "intermediate_1": "yi3",
+        "intermediate_2": "yǐ",
+        "native_1": "two; twist (2nd Heavenly Stem) (Kangxi radical 5)",
+        "primary_1": "乙",
+        "primary_2": "乙"
+    },
+    {
+        "intermediate_1": "yi3ji2",
+        "intermediate_2": "yǐjí",
+        "native_1": "as well as; too; (formal) and",
+        "primary_1": "以及",
+        "primary_2": "以及"
+    },
+    {
+        "intermediate_1": "yi3lai2",
+        "intermediate_2": "yǐlái",
+        "native_1": "since (a previous event)",
+        "primary_1": "以来",
+        "primary_2": "以來"
+    },
+    {
+        "intermediate_1": "yi4",
+        "intermediate_2": "yì",
+        "native_1": "one hundred million (100,000,000)",
+        "primary_1": "亿",
+        "primary_2": "億"
+    },
+    {
+        "intermediate_1": "yi4wu4",
+        "intermediate_2": "yìwù",
+        "native_1": "duty; obligation; volunteer duty",
+        "primary_1": "义务",
+        "primary_2": "義務"
+    },
+    {
+        "intermediate_1": "yi4lun4",
+        "intermediate_2": "yìlùn",
+        "native_1": "discuss; to comment; talk about",
+        "primary_1": "议论",
+        "primary_2": "議論"
+    },
+    {
+        "intermediate_1": "yi4wai4",
+        "intermediate_2": "yìwài",
+        "native_1": "unexpected; accident; mishap",
+        "primary_1": "意外",
+        "primary_2": "意外"
+    },
+    {
+        "intermediate_1": "yi4yi4",
+        "intermediate_2": "yìyì",
+        "native_1": "meaning; significance",
+        "primary_1": "意义",
+        "primary_2": "意義"
+    },
+    {
+        "intermediate_1": "yin1'er2",
+        "intermediate_2": "yīn'ér",
+        "native_1": "therefore; as a result; thus",
+        "primary_1": "因而",
+        "primary_2": "因而"
+    },
+    {
+        "intermediate_1": "yin1su4",
+        "intermediate_2": "yīnsù",
+        "native_1": "element; factor",
+        "primary_1": "因素",
+        "primary_2": "因素"
+    },
+    {
+        "intermediate_1": "yin2",
+        "intermediate_2": "yín",
+        "native_1": "silver (the element)",
+        "primary_1": "银",
+        "primary_2": "銀"
+    },
+    {
+        "intermediate_1": "yin4shua1",
+        "intermediate_2": "yìnshuā",
+        "native_1": "print",
+        "primary_1": "印刷",
+        "primary_2": "印刷"
+    },
+    {
+        "intermediate_1": "ying1jun4",
+        "intermediate_2": "yīngjùn",
+        "native_1": "handsome",
+        "primary_1": "英俊",
+        "primary_2": "英俊"
+    },
+    {
+        "intermediate_1": "ying1xiong2",
+        "intermediate_2": "yīngxióng",
+        "native_1": "hero",
+        "primary_1": "英雄",
+        "primary_2": "英雄"
+    },
+    {
+        "intermediate_1": "ying2jie1",
+        "intermediate_2": "yíngjiē",
+        "native_1": "meet; greet; to welcome",
+        "primary_1": "迎接",
+        "primary_2": "迎接"
+    },
+    {
+        "intermediate_1": "ying2yang3",
+        "intermediate_2": "yíngyǎng",
+        "native_1": "nutrition; nourishment; sustenance",
+        "primary_1": "营养",
+        "primary_2": "營養"
+    },
+    {
+        "intermediate_1": "ying2ye4",
+        "intermediate_2": "yíngyè",
+        "native_1": "do business; to trade",
+        "primary_1": "营业",
+        "primary_2": "營業"
+    },
+    {
+        "intermediate_1": "ying3zi",
+        "intermediate_2": "yǐngzi",
+        "native_1": "shadow; reflection",
+        "primary_1": "影子",
+        "primary_2": "影子"
+    },
+    {
+        "intermediate_1": "ying4fu",
+        "intermediate_2": "yìngfu",
+        "native_1": "to cope with; deal with; handle; do sth. perfunctorily; do sth. after a fashion; make do",
+        "primary_1": "应付",
+        "primary_2": "應付"
+    },
+    {
+        "intermediate_1": "ying4yong4",
+        "intermediate_2": "yìngyòng",
+        "native_1": "to apply; to use; application",
+        "primary_1": "应用",
+        "primary_2": "應用"
+    },
+    {
+        "intermediate_1": "ying4",
+        "intermediate_2": "yìng",
+        "native_1": "hard; stiff; obstinately",
+        "primary_1": "硬",
+        "primary_2": "硬"
+    },
+    {
+        "intermediate_1": "ying4jian4",
+        "intermediate_2": "yìngjiàn",
+        "native_1": "hardware",
+        "primary_1": "硬件",
+        "primary_2": "硬件"
+    },
+    {
+        "intermediate_1": "yong1bao4",
+        "intermediate_2": "yōngbào",
+        "native_1": "embrace; to hug",
+        "primary_1": "拥抱",
+        "primary_2": "擁抱"
+    },
+    {
+        "intermediate_1": "yong1ji3",
+        "intermediate_2": "yōngjǐ",
+        "native_1": "to crowd; to push; to squeeze",
+        "primary_1": "拥挤",
+        "primary_2": "擁擠"
+    },
+    {
+        "intermediate_1": "yong3qi4",
+        "intermediate_2": "yǒngqì",
+        "native_1": "courage; valor",
+        "primary_1": "勇气",
+        "primary_2": "勇氣"
+    },
+    {
+        "intermediate_1": "yong4 gong1",
+        "intermediate_2": "yòng gōng",
+        "native_1": "diligent; industrious; hardworking",
+        "primary_1": "用功",
+        "primary_2": "用功"
+    },
+    {
+        "intermediate_1": "yong4tu2",
+        "intermediate_2": "yòngtú",
+        "native_1": "use; application; purpose",
+        "primary_1": "用途",
+        "primary_2": "用途"
+    },
+    {
+        "intermediate_1": "you1hui4",
+        "intermediate_2": "yōuhuì",
+        "native_1": "preferential; favorable",
+        "primary_1": "优惠",
+        "primary_2": "優惠"
+    },
+    {
+        "intermediate_1": "you1mei3",
+        "intermediate_2": "yōuměi",
+        "native_1": "graceful; fine; elegant",
+        "primary_1": "优美",
+        "primary_2": "優美"
+    },
+    {
+        "intermediate_1": "you1shi4",
+        "intermediate_2": "yōushì",
+        "native_1": "advantage; superiority; dominant position",
+        "primary_1": "优势",
+        "primary_2": "優勢"
+    },
+    {
+        "intermediate_1": "you1jiu3",
+        "intermediate_2": "yōujiǔ",
+        "native_1": "established; long; longstanding",
+        "primary_1": "悠久",
+        "primary_2": "悠久"
+    },
+    {
+        "intermediate_1": "you2yu4",
+        "intermediate_2": "yóuyù",
+        "native_1": "hesitate; hesitant; undecided",
+        "primary_1": "犹豫",
+        "primary_2": "猶豫"
+    },
+    {
+        "intermediate_1": "you2zha2",
+        "intermediate_2": "yóuzhá",
+        "native_1": "deep fry",
+        "primary_1": "油炸",
+        "primary_2": "油炸"
+    },
+    {
+        "intermediate_1": "you2lan3",
+        "intermediate_2": "yóulǎn",
+        "native_1": "go sight-seeing; tour",
+        "primary_1": "游览",
+        "primary_2": "遊覽"
+    },
+    {
+        "intermediate_1": "you3li4",
+        "intermediate_2": "yǒulì",
+        "native_1": "advantageous; beneficial",
+        "primary_1": "有利",
+        "primary_2": "有利"
+    },
+    {
+        "intermediate_1": "you4'er2yuan2",
+        "intermediate_2": "yòu'éryuán",
+        "native_1": "kindergarten; nursery school",
+        "primary_1": "幼儿园",
+        "primary_2": "幼兒園"
+    },
+    {
+        "intermediate_1": "yu2le4",
+        "intermediate_2": "yúlè",
+        "native_1": "entertain; amuse; entertainment",
+        "primary_1": "娱乐",
+        "primary_2": "娛樂"
+    },
+    {
+        "intermediate_1": "yu3qi2",
+        "intermediate_2": "yǔqí",
+        "native_1": "rather than; better than",
+        "primary_1": "与其",
+        "primary_2": "與其"
+    },
+    {
+        "intermediate_1": "yu3qi4",
+        "intermediate_2": "yǔqì",
+        "native_1": "tone; manner of speaking; mood",
+        "primary_1": "语气",
+        "primary_2": "語氣"
+    },
+    {
+        "intermediate_1": "yu4mi3",
+        "intermediate_2": "yùmǐ",
+        "native_1": "corn; maize",
+        "primary_1": "玉米",
+        "primary_2": "玉米"
+    },
+    {
+        "intermediate_1": "yu4bao4",
+        "intermediate_2": "yùbào",
+        "native_1": "to predict; forecast",
+        "primary_1": "预报",
+        "primary_2": "預報"
+    },
+    {
+        "intermediate_1": "yu4ding4",
+        "intermediate_2": "yùdìng",
+        "native_1": "place an order; book ahead; subscribe for",
+        "primary_1": "预订",
+        "primary_2": "預訂"
+    },
+    {
+        "intermediate_1": "yu4fang2",
+        "intermediate_2": "yùfáng",
+        "native_1": "prevent; take precautions against",
+        "primary_1": "预防",
+        "primary_2": "預防"
+    },
+    {
+        "intermediate_1": "yuan2dan4",
+        "intermediate_2": "yuándàn",
+        "native_1": "New Year's Day",
+        "primary_1": "元旦",
+        "primary_2": "元旦"
+    },
+    {
+        "intermediate_1": "yuang2ong1",
+        "intermediate_2": "yuángōng",
+        "native_1": "employee; staff; personnel",
+        "primary_1": "员工",
+        "primary_2": "員工"
+    },
+    {
+        "intermediate_1": "yuan2liao4",
+        "intermediate_2": "yuánliào",
+        "native_1": "raw material; ingredients",
+        "primary_1": "原料",
+        "primary_2": "原料"
+    },
+    {
+        "intermediate_1": "yuan2ze2",
+        "intermediate_2": "yuánzé",
+        "native_1": "principle; doctrine",
+        "primary_1": "原则",
+        "primary_2": "原則"
+    },
+    {
+        "intermediate_1": "yuan2",
+        "intermediate_2": "yuán",
+        "native_1": "round; circular; formal unit of Chinese currency",
+        "primary_1": "圆",
+        "primary_2": "圓"
+    },
+    {
+        "intermediate_1": "yuan4wang4",
+        "intermediate_2": "yuànwàng",
+        "native_1": "desire; wish; aspiration",
+        "primary_1": "愿望",
+        "primary_2": "願望"
+    },
+    {
+        "intermediate_1": "yue4qi4",
+        "intermediate_2": "yuèqì",
+        "native_1": "musical instrument",
+        "primary_1": "乐器",
+        "primary_2": "樂器"
+    },
+    {
+        "intermediate_1": "yun1",
+        "intermediate_2": "yūn",
+        "native_1": "dizzy; to fain",
+        "primary_1": "晕",
+        "primary_2": "暈"
+    },
+    {
+        "intermediate_1": "yun4qi",
+        "intermediate_2": "yùnqi",
+        "native_1": "luck",
+        "primary_1": "运气",
+        "primary_2": "運氣"
+    },
+    {
+        "intermediate_1": "yun4shu1",
+        "intermediate_2": "yùnshū",
+        "native_1": "transport; transportation",
+        "primary_1": "运输",
+        "primary_2": "運輸"
+    },
+    {
+        "intermediate_1": "yun4yong4",
+        "intermediate_2": "yùnyòng",
+        "native_1": "to use; apply",
+        "primary_1": "运用",
+        "primary_2": "運用"
+    },
+    {
+        "intermediate_1": "zai1hai4",
+        "intermediate_2": "zāihài",
+        "native_1": "disaster; calamity",
+        "primary_1": "灾害",
+        "primary_2": "災害"
+    },
+    {
+        "intermediate_1": "zai4san1",
+        "intermediate_2": "zàisān",
+        "native_1": "over and over again; repeatedly",
+        "primary_1": "再三",
+        "primary_2": "再三"
+    },
+    {
+        "intermediate_1": "zai4hu",
+        "intermediate_2": "zàihu",
+        "native_1": "care about; be determined by; to mind",
+        "primary_1": "在乎",
+        "primary_2": "在乎"
+    },
+    {
+        "intermediate_1": "zai4yu2",
+        "intermediate_2": "zàiyú",
+        "native_1": "lie in; be in; rest with; depend on",
+        "primary_1": "在于",
+        "primary_2": "在于"
+    },
+    {
+        "intermediate_1": "zan4cheng2",
+        "intermediate_2": "zànchéng",
+        "native_1": "approve; endorse",
+        "primary_1": "赞成",
+        "primary_2": "贊成"
+    },
+    {
+        "intermediate_1": "zan4mei3",
+        "intermediate_2": "zànměi",
+        "native_1": "admire; applause; to praise",
+        "primary_1": "赞美",
+        "primary_2": "贊美"
+    },
+    {
+        "intermediate_1": "zao1gao1",
+        "intermediate_2": "zāogāo",
+        "native_1": "terrible; too bad; how terrible; what bad luck; what a mess",
+        "primary_1": "糟糕",
+        "primary_2": "糟糕"
+    },
+    {
+        "intermediate_1": "zao4cheng2",
+        "intermediate_2": "zàochéng",
+        "native_1": "to cause; make; bring out",
+        "primary_1": "造成",
+        "primary_2": "造成"
+    },
+    {
+        "intermediate_1": "ze2",
+        "intermediate_2": "zé",
+        "native_1": "standard; regulation; however; in that case",
+        "primary_1": "则",
+        "primary_2": "則"
+    },
+    {
+        "intermediate_1": "ze2bei4",
+        "intermediate_2": "zébèi",
+        "native_1": "to blame; criticize (sb.); accuse",
+        "primary_1": "责备",
+        "primary_2": "責備"
+    },
+    {
+        "intermediate_1": "zhai1",
+        "intermediate_2": "zhāi",
+        "native_1": "to pick (flowers, fruit, etc.); to pluck; to take; to borrow",
+        "primary_1": "摘",
+        "primary_2": "摘"
+    },
+    {
+        "intermediate_1": "zhai3",
+        "intermediate_2": "zhǎi",
+        "native_1": "narrow; petty; hard-up",
+        "primary_1": "窄",
+        "primary_2": "窄"
+    },
+    {
+        "intermediate_1": "zhan1tie1",
+        "intermediate_2": "zhāntiē",
+        "native_1": "to paste",
+        "primary_1": "粘贴",
+        "primary_2": "粘貼"
+    },
+    {
+        "intermediate_1": "zhan3 kai1",
+        "intermediate_2": "zhǎn kāi",
+        "native_1": "spread out; unfold; carry out; in full swing",
+        "primary_1": "展开",
+        "primary_2": "展開"
+    },
+    {
+        "intermediate_1": "zhan3lan3",
+        "intermediate_2": "zhǎnlǎn",
+        "native_1": "put on display; to exhibit; exhibition",
+        "primary_1": "展览",
+        "primary_2": "展覽"
+    },
+    {
+        "intermediate_1": "zhan4",
+        "intermediate_2": "zhàn",
+        "native_1": "occupy; seize; to constitute",
+        "primary_1": "占",
+        "primary_2": "占"
+    },
+    {
+        "intermediate_1": "zhan4zheng1",
+        "intermediate_2": "zhànzhēng",
+        "native_1": "war; conflict",
+        "primary_1": "战争",
+        "primary_2": "戰爭"
+    },
+    {
+        "intermediate_1": "zhang3bei4",
+        "intermediate_2": "zhǎngbèi",
+        "native_1": "an elder; an elder generation",
+        "primary_1": "长辈",
+        "primary_2": "長輩"
+    },
+    {
+        "intermediate_1": "zhang3, zhang4",
+        "intermediate_2": "zhǎng, zhàng",
+        "native_1": "to rise (of prices, rivers); to go up | to swell; to bloat",
+        "primary_1": "涨",
+        "primary_2": "漲"
+    },
+    {
+        "intermediate_1": "zhang3wo4",
+        "intermediate_2": "zhǎngwò",
+        "native_1": "to grasp; to master; to control",
+        "primary_1": "掌握",
+        "primary_2": "掌握"
+    },
+    {
+        "intermediate_1": "zhang4hu4",
+        "intermediate_2": "zhànghù",
+        "native_1": "bank account",
+        "primary_1": "账户",
+        "primary_2": "賬戶"
+    },
+    {
+        "intermediate_1": "zhao1dai4",
+        "intermediate_2": "zhāodài",
+        "native_1": "receive (guests); entertain; reception",
+        "primary_1": "招待",
+        "primary_2": "招待"
+    },
+    {
+        "intermediate_1": "zhao2huo3",
+        "intermediate_2": "zháohuǒ",
+        "native_1": "catch fire; ignite",
+        "primary_1": "着火",
+        "primary_2": "著火"
+    },
+    {
+        "intermediate_1": "zhao2 liang2",
+        "intermediate_2": "zháo liáng",
+        "native_1": "catch a cold",
+        "primary_1": "着凉",
+        "primary_2": "著涼"
+    },
+    {
+        "intermediate_1": "zhao4kai1",
+        "intermediate_2": "zhàokāi",
+        "native_1": "convene (a conference or meeting); call together",
+        "primary_1": "召开",
+        "primary_2": "召開"
+    },
+    {
+        "intermediate_1": "zhao4chang2",
+        "intermediate_2": "zhàocháng",
+        "native_1": "as usual; normal",
+        "primary_1": "照常",
+        "primary_2": "照常"
+    },
+    {
+        "intermediate_1": "zhe2xue2",
+        "intermediate_2": "zhéxué",
+        "native_1": "philosophy",
+        "primary_1": "哲学",
+        "primary_2": "哲學"
+    },
+    {
+        "intermediate_1": "zhen1dui4",
+        "intermediate_2": "zhēnduì",
+        "native_1": "in connection with; directed towards",
+        "primary_1": "针对",
+        "primary_2": "針對"
+    },
+    {
+        "intermediate_1": "zhen1xi1",
+        "intermediate_2": "zhēnxī",
+        "native_1": "to treasure; cherish; to value",
+        "primary_1": "珍惜",
+        "primary_2": "珍惜"
+    },
+    {
+        "intermediate_1": "zhen1shi2",
+        "intermediate_2": "zhēnshí",
+        "native_1": "true; real; authentic",
+        "primary_1": "真实",
+        "primary_2": "真實"
+    },
+    {
+        "intermediate_1": "zhen3duan4",
+        "intermediate_2": "zhěnduàn",
+        "native_1": "diagnosis; diagnose",
+        "primary_1": "诊断",
+        "primary_2": "診斷"
+    },
+    {
+        "intermediate_1": "zhen4",
+        "intermediate_2": "zhèn",
+        "native_1": "short period; disposition of troops; wave",
+        "primary_1": "阵",
+        "primary_2": "陣"
+    },
+    {
+        "intermediate_1": "zhen4dong4",
+        "intermediate_2": "zhèndòng",
+        "native_1": "vibrate; vibration",
+        "primary_1": "振动",
+        "primary_2": "振動"
+    },
+    {
+        "intermediate_1": "zheng1lun4",
+        "intermediate_2": "zhēnglùn",
+        "native_1": "argue; to dispute; contend; argument",
+        "primary_1": "争论",
+        "primary_2": "爭論"
+    },
+    {
+        "intermediate_1": "zheng1qu3",
+        "intermediate_2": "zhēngqǔ",
+        "native_1": "fight for; compete for; strive",
+        "primary_1": "争取",
+        "primary_2": "爭取"
+    },
+    {
+        "intermediate_1": "zheng1qiu2",
+        "intermediate_2": "zhēngqiú",
+        "native_1": "solicit; seek; ask for; to request",
+        "primary_1": "征求",
+        "primary_2": "征求"
+    },
+    {
+        "intermediate_1": "zheng1",
+        "intermediate_2": "zhēng",
+        "native_1": "to open (eyes)",
+        "primary_1": "睁",
+        "primary_2": "睜"
+    },
+    {
+        "intermediate_1": "zheng3ge4",
+        "intermediate_2": "zhěnggè",
+        "native_1": "whole; entire; total",
+        "primary_1": "整个",
+        "primary_2": "整個"
+    },
+    {
+        "intermediate_1": "zheng3qi2",
+        "intermediate_2": "zhěngqí",
+        "native_1": "tidy; neat; in good order",
+        "primary_1": "整齐",
+        "primary_2": "整齊"
+    },
+    {
+        "intermediate_1": "zheng3ti3",
+        "intermediate_2": "zhěngtǐ",
+        "native_1": "whole; entirety",
+        "primary_1": "整体",
+        "primary_2": "整體"
+    },
+    {
+        "intermediate_1": "zheng4",
+        "intermediate_2": "zhèng",
+        "native_1": "straight; currently; correct; just (right); pure; precisely",
+        "primary_1": "正",
+        "primary_2": "正"
+    },
+    {
+        "intermediate_1": "zheng4jian4",
+        "intermediate_2": "zhèngjiàn",
+        "native_1": "paperwork; credentials; papers; certificates",
+        "primary_1": "证件",
+        "primary_2": "證件"
+    },
+    {
+        "intermediate_1": "zheng4ju4",
+        "intermediate_2": "zhèngjù",
+        "native_1": "evidence; proof; testimony",
+        "primary_1": "证据",
+        "primary_2": "證據"
+    },
+    {
+        "intermediate_1": "zheng4fu3",
+        "intermediate_2": "zhèngfǔ",
+        "native_1": "government",
+        "primary_1": "政府",
+        "primary_2": "政府"
+    },
+    {
+        "intermediate_1": "zheng4zhi4",
+        "intermediate_2": "zhèngzhì",
+        "native_1": "politics",
+        "primary_1": "政治",
+        "primary_2": "政治"
+    },
+    {
+        "intermediate_1": "zheng4, zheng1",
+        "intermediate_2": "zhèng, zhēng",
+        "native_1": "to earn | to struggle",
+        "primary_1": "挣",
+        "primary_2": "掙"
+    },
+    {
+        "intermediate_1": "zhi1",
+        "intermediate_2": "zhī",
+        "native_1": "branch; support; put up; (mw for long; narrow objects) (Kangxi radical 65)",
+        "primary_1": "支",
+        "primary_2": "支"
+    },
+    {
+        "intermediate_1": "zhi1piao4",
+        "intermediate_2": "zhīpiào",
+        "native_1": "(bank) check",
+        "primary_1": "支票",
+        "primary_2": "支票"
+    },
+    {
+        "intermediate_1": "zhi2zhao4",
+        "intermediate_2": "zhízhào",
+        "native_1": "a license; a permit",
+        "primary_1": "执照",
+        "primary_2": "執照"
+    },
+    {
+        "intermediate_1": "zhi2",
+        "intermediate_2": "zhí",
+        "native_1": "straight; vertical; frank; directly; continuously",
+        "primary_1": "直",
+        "primary_2": "直"
+    },
+    {
+        "intermediate_1": "zhi3dao3",
+        "intermediate_2": "zhǐdǎo",
+        "native_1": "to guide; give directions",
+        "primary_1": "指导",
+        "primary_2": "指導"
+    },
+    {
+        "intermediate_1": "zhi3hui1",
+        "intermediate_2": "zhǐhuī",
+        "native_1": "to command; to conduct; commander",
+        "primary_1": "指挥",
+        "primary_2": "指揮"
+    },
+    {
+        "intermediate_1": "zhi4 jin1",
+        "intermediate_2": "zhì jīn",
+        "native_1": "up to now; so far",
+        "primary_1": "至今",
+        "primary_2": "至今"
+    },
+    {
+        "intermediate_1": "zhi4yu2",
+        "intermediate_2": "zhìyú",
+        "native_1": "as for; go so far as to",
+        "primary_1": "至于",
+        "primary_2": "至于"
+    },
+    {
+        "intermediate_1": "zhi4yuan4zhe3",
+        "intermediate_2": "zhìyuànzhě",
+        "native_1": "volunteer",
+        "primary_1": "志愿者",
+        "primary_2": "志願者"
+    },
+    {
+        "intermediate_1": "zhi4ding4",
+        "intermediate_2": "zhìdìng",
+        "native_1": "formulate; lay down (a plan or policy); to draft",
+        "primary_1": "制定",
+        "primary_2": "制定"
+    },
+    {
+        "intermediate_1": "zhi4du4",
+        "intermediate_2": "zhìdù",
+        "native_1": "system; institution",
+        "primary_1": "制度",
+        "primary_2": "制度"
+    },
+    {
+        "intermediate_1": "zhi4zao4",
+        "intermediate_2": "zhìzào",
+        "native_1": "manufacture; make",
+        "primary_1": "制造",
+        "primary_2": "制造"
+    },
+    {
+        "intermediate_1": "zhi4zuo4",
+        "intermediate_2": "zhìzuò",
+        "native_1": "make; manufacture",
+        "primary_1": "制作",
+        "primary_2": "制作"
+    },
+    {
+        "intermediate_1": "zhi4liao2",
+        "intermediate_2": "zhìliáo",
+        "native_1": "to treat; to cure; medical treatment",
+        "primary_1": "治疗",
+        "primary_2": "治療"
+    },
+    {
+        "intermediate_1": "zhi4xu4",
+        "intermediate_2": "zhìxù",
+        "native_1": "order; sequence",
+        "primary_1": "秩序",
+        "primary_2": "秩序"
+    },
+    {
+        "intermediate_1": "zhi4hui4",
+        "intermediate_2": "zhìhuì",
+        "native_1": "wisdom; knowledge",
+        "primary_1": "智慧",
+        "primary_2": "智慧"
+    },
+    {
+        "intermediate_1": "zhong1jie4",
+        "intermediate_2": "zhōngjiè",
+        "native_1": "agent; act as an intermediary",
+        "primary_1": "中介",
+        "primary_2": "中介"
+    },
+    {
+        "intermediate_1": "zhong1xin1",
+        "intermediate_2": "zhōngxīn",
+        "native_1": "center; heart; core",
+        "primary_1": "中心",
+        "primary_2": "中心"
+    },
+    {
+        "intermediate_1": "zhong1xun2",
+        "intermediate_2": "zhōngxún",
+        "native_1": "middle third of a month",
+        "primary_1": "中旬",
+        "primary_2": "中旬"
+    },
+    {
+        "intermediate_1": "zhong3lei4",
+        "intermediate_2": "zhǒnglèi",
+        "native_1": "kind; category; class",
+        "primary_1": "种类",
+        "primary_2": "種類"
+    },
+    {
+        "intermediate_1": "zhong4da4",
+        "intermediate_2": "zhòngdà",
+        "native_1": "great; important; major",
+        "primary_1": "重大",
+        "primary_2": "重大"
+    },
+    {
+        "intermediate_1": "zhong4liang4",
+        "intermediate_2": "zhòngliàng",
+        "native_1": "weight",
+        "primary_1": "重量",
+        "primary_2": "重量"
+    },
+    {
+        "intermediate_1": "zhou1dao4",
+        "intermediate_2": "zhōudào",
+        "native_1": "thoughtful; considerate; thorough",
+        "primary_1": "周到",
+        "primary_2": "周到"
+    },
+    {
+        "intermediate_1": "zhu1",
+        "intermediate_2": "zhū",
+        "native_1": "pig",
+        "primary_1": "猪",
+        "primary_2": "豬"
+    },
+    {
+        "intermediate_1": "zhu2zi",
+        "intermediate_2": "zhúzi",
+        "native_1": "bamboo",
+        "primary_1": "竹子",
+        "primary_2": "竹子"
+    },
+    {
+        "intermediate_1": "zhu2bu4",
+        "intermediate_2": "zhúbù",
+        "native_1": "step by step; gradually",
+        "primary_1": "逐步",
+        "primary_2": "逐步"
+    },
+    {
+        "intermediate_1": "zhu2jian4",
+        "intermediate_2": "zhújiàn",
+        "native_1": "gradually; by degrees",
+        "primary_1": "逐渐",
+        "primary_2": "逐漸"
+    },
+    {
+        "intermediate_1": "zhu3chi2",
+        "intermediate_2": "zhǔchí",
+        "native_1": "preside over; manage; to direct",
+        "primary_1": "主持",
+        "primary_2": "主持"
+    },
+    {
+        "intermediate_1": "zhu3dong4",
+        "intermediate_2": "zhǔdòng",
+        "native_1": "to take initiative; voluntary",
+        "primary_1": "主动",
+        "primary_2": "主動"
+    },
+    {
+        "intermediate_1": "zhu3guan1",
+        "intermediate_2": "zhǔguān",
+        "native_1": "subjective",
+        "primary_1": "主观",
+        "primary_2": "主觀"
+    },
+    {
+        "intermediate_1": "zhu3ren2",
+        "intermediate_2": "zhǔrén",
+        "native_1": "master; host; owner",
+        "primary_1": "主人",
+        "primary_2": "主人"
+    },
+    {
+        "intermediate_1": "zhu3ren4",
+        "intermediate_2": "zhǔrèn",
+        "native_1": "director; head; chief",
+        "primary_1": "主任",
+        "primary_2": "主任"
+    },
+    {
+        "intermediate_1": "zhu3ti2",
+        "intermediate_2": "zhǔtí",
+        "native_1": "theme; subject; topic",
+        "primary_1": "主题",
+        "primary_2": "主題"
+    },
+    {
+        "intermediate_1": "zhu3xi2",
+        "intermediate_2": "zhǔxí",
+        "native_1": "chairperson; president",
+        "primary_1": "主席",
+        "primary_2": "主席"
+    },
+    {
+        "intermediate_1": "zhu3zhang1",
+        "intermediate_2": "zhǔzhāng",
+        "native_1": "to advocate; viewpoint; position",
+        "primary_1": "主张",
+        "primary_2": "主張"
+    },
+    {
+        "intermediate_1": "zhu3",
+        "intermediate_2": "zhǔ",
+        "native_1": "to boil; to cook",
+        "primary_1": "煮",
+        "primary_2": "煮"
+    },
+    {
+        "intermediate_1": "zhu4ce4",
+        "intermediate_2": "zhùcè",
+        "native_1": "register; registration; enroll",
+        "primary_1": "注册",
+        "primary_2": "注冊"
+    },
+    {
+        "intermediate_1": "zhu4fu2",
+        "intermediate_2": "zhùfú",
+        "native_1": "blessings; wish well",
+        "primary_1": "祝福",
+        "primary_2": "祝福"
+    },
+    {
+        "intermediate_1": "zhua1",
+        "intermediate_2": "zhuā",
+        "native_1": "to carry in your hand holding strongly; catch; arrest",
+        "primary_1": "抓",
+        "primary_2": "抓"
+    },
+    {
+        "intermediate_1": "zhua1 jin3",
+        "intermediate_2": "zhuā jǐn",
+        "native_1": "to grasp firmly; to pay close or special attention to; to rush in; to make the most of",
+        "primary_1": "抓紧",
+        "primary_2": "抓緊"
+    },
+    {
+        "intermediate_1": "zhuan1jia1",
+        "intermediate_2": "zhuānjiā",
+        "native_1": "expert; specialist",
+        "primary_1": "专家",
+        "primary_2": "專家"
+    },
+    {
+        "intermediate_1": "zhuan1xin1",
+        "intermediate_2": "zhuānxīn",
+        "native_1": "be absorbed; concentrate; attentive",
+        "primary_1": "专心",
+        "primary_2": "專心"
+    },
+    {
+        "intermediate_1": "zhuan3bian4",
+        "intermediate_2": "zhuǎnbiàn",
+        "native_1": "to change; to transform",
+        "primary_1": "转变",
+        "primary_2": "轉變"
+    },
+    {
+        "intermediate_1": "zhuang3ao4",
+        "intermediate_2": "zhuǎngào",
+        "native_1": "pass on; to communicate; to transmit",
+        "primary_1": "转告",
+        "primary_2": "轉告"
+    },
+    {
+        "intermediate_1": "zhuang1",
+        "intermediate_2": "zhuāng",
+        "native_1": "to load; dress up; pretend; clothing; to install",
+        "primary_1": "装",
+        "primary_2": "裝"
+    },
+    {
+        "intermediate_1": "zhuang1shi4",
+        "intermediate_2": "zhuāngshì",
+        "native_1": "decorate",
+        "primary_1": "装饰",
+        "primary_2": "裝飾"
+    },
+    {
+        "intermediate_1": "zhuang1xiu1",
+        "intermediate_2": "zhuāngxiū",
+        "native_1": "renovate; to fit up",
+        "primary_1": "装修",
+        "primary_2": "裝修"
+    },
+    {
+        "intermediate_1": "zhuang4kuang4",
+        "intermediate_2": "zhuàngkuàng",
+        "native_1": "condition; state; situation",
+        "primary_1": "状况",
+        "primary_2": "狀況"
+    },
+    {
+        "intermediate_1": "zhuang4tai4",
+        "intermediate_2": "zhuàngtài",
+        "native_1": "state of affairs; condition; state",
+        "primary_1": "状态",
+        "primary_2": "狀態"
+    },
+    {
+        "intermediate_1": "zhuang4",
+        "intermediate_2": "zhuàng",
+        "native_1": "to hit; collide; run into",
+        "primary_1": "撞",
+        "primary_2": "撞"
+    },
+    {
+        "intermediate_1": "zhui1",
+        "intermediate_2": "zhuī",
+        "native_1": "pursue; chase",
+        "primary_1": "追",
+        "primary_2": "追"
+    },
+    {
+        "intermediate_1": "zhui1qiu2",
+        "intermediate_2": "zhuīqiú",
+        "native_1": "pursue; seek",
+        "primary_1": "追求",
+        "primary_2": "追求"
+    },
+    {
+        "intermediate_1": "zi1xun2",
+        "intermediate_2": "zīxún",
+        "native_1": "request information; consultant; advisory",
+        "primary_1": "咨询",
+        "primary_2": "咨詢"
+    },
+    {
+        "intermediate_1": "zi1shi4",
+        "intermediate_2": "zīshì",
+        "native_1": "posture; position; pose",
+        "primary_1": "姿势",
+        "primary_2": "姿勢"
+    },
+    {
+        "intermediate_1": "zi1ge2",
+        "intermediate_2": "zīgé",
+        "native_1": "qualifications; seniority",
+        "primary_1": "资格",
+        "primary_2": "資格"
+    },
+    {
+        "intermediate_1": "zi1jin1",
+        "intermediate_2": "zījīn",
+        "native_1": "funds; funding",
+        "primary_1": "资金",
+        "primary_2": "資金"
+    },
+    {
+        "intermediate_1": "zi1liao4",
+        "intermediate_2": "zīliào",
+        "native_1": "data; material; resources; information",
+        "primary_1": "资料",
+        "primary_2": "資料"
+    },
+    {
+        "intermediate_1": "zi1yuan2",
+        "intermediate_2": "zīyuán",
+        "native_1": "natural resource; resource",
+        "primary_1": "资源",
+        "primary_2": "資源"
+    },
+    {
+        "intermediate_1": "zi3",
+        "intermediate_2": "zǐ",
+        "native_1": "purple",
+        "primary_1": "紫",
+        "primary_2": "紫"
+    },
+    {
+        "intermediate_1": "zi4cong2",
+        "intermediate_2": "zìcóng",
+        "native_1": "since; ever since",
+        "primary_1": "自从",
+        "primary_2": "自從"
+    },
+    {
+        "intermediate_1": "zi4dong4",
+        "intermediate_2": "zìdòng",
+        "native_1": "automatic",
+        "primary_1": "自动",
+        "primary_2": "自動"
+    },
+    {
+        "intermediate_1": "zi4hao2",
+        "intermediate_2": "zìháo",
+        "native_1": "(feel a sense of) pride",
+        "primary_1": "自豪",
+        "primary_2": "自豪"
+    },
+    {
+        "intermediate_1": "zi4jue2",
+        "intermediate_2": "zìjué",
+        "native_1": "conscious; be aware of; self-motivated",
+        "primary_1": "自觉",
+        "primary_2": "自覺"
+    },
+    {
+        "intermediate_1": "zi4si1",
+        "intermediate_2": "zìsī",
+        "native_1": "selfish",
+        "primary_1": "自私",
+        "primary_2": "自私"
+    },
+    {
+        "intermediate_1": "zi4you2",
+        "intermediate_2": "zìyóu",
+        "native_1": "freedom; free; liberty",
+        "primary_1": "自由",
+        "primary_2": "自由"
+    },
+    {
+        "intermediate_1": "zi4yuan4",
+        "intermediate_2": "zìyuàn",
+        "native_1": "voluntary",
+        "primary_1": "自愿",
+        "primary_2": "自願"
+    },
+    {
+        "intermediate_1": "zi4mu3",
+        "intermediate_2": "zìmǔ",
+        "native_1": "letter (of the alphabet)",
+        "primary_1": "字母",
+        "primary_2": "字母"
+    },
+    {
+        "intermediate_1": "zi4mu4",
+        "intermediate_2": "zìmù",
+        "native_1": "subtitles; captions",
+        "primary_1": "字幕",
+        "primary_2": "字幕"
+    },
+    {
+        "intermediate_1": "zong1he2",
+        "intermediate_2": "zōnghé",
+        "native_1": "synthesized; composite; summarize",
+        "primary_1": "综合",
+        "primary_2": "綜合"
+    },
+    {
+        "intermediate_1": "zong3cai2",
+        "intermediate_2": "zǒngcái",
+        "native_1": "director-general; president",
+        "primary_1": "总裁",
+        "primary_2": "總裁"
+    },
+    {
+        "intermediate_1": "zong3gong4",
+        "intermediate_2": "zǒnggòng",
+        "native_1": "altogether; in sum; in all; in total",
+        "primary_1": "总共",
+        "primary_2": "總共"
+    },
+    {
+        "intermediate_1": "zong3li3",
+        "intermediate_2": "zǒnglǐ",
+        "native_1": "premier; prime minister",
+        "primary_1": "总理",
+        "primary_2": "總理"
+    },
+    {
+        "intermediate_1": "zong3suan4",
+        "intermediate_2": "zǒngsuàn",
+        "native_1": "at long last; finally; on the whole",
+        "primary_1": "总算",
+        "primary_2": "總算"
+    },
+    {
+        "intermediate_1": "zong3tong3",
+        "intermediate_2": "zǒngtǒng",
+        "native_1": "president (of a country)",
+        "primary_1": "总统",
+        "primary_2": "總統"
+    },
+    {
+        "intermediate_1": "zong3zhi1",
+        "intermediate_2": "zǒngzhī",
+        "native_1": "in a word; in short; in brief / anyway; anyhow",
+        "primary_1": "总之",
+        "primary_2": "總之"
+    },
+    {
+        "intermediate_1": "zu3zhi3",
+        "intermediate_2": "zǔzhǐ",
+        "native_1": "prevent; to block",
+        "primary_1": "阻止",
+        "primary_2": "阻止"
+    },
+    {
+        "intermediate_1": "zu3",
+        "intermediate_2": "zǔ",
+        "native_1": "compose; team up; group",
+        "primary_1": "组",
+        "primary_2": "組"
+    },
+    {
+        "intermediate_1": "zu3cheng2",
+        "intermediate_2": "zǔchéng",
+        "native_1": "to form; part; element; constitute",
+        "primary_1": "组成",
+        "primary_2": "組成"
+    },
+    {
+        "intermediate_1": "zu3he2",
+        "intermediate_2": "zǔhé",
+        "native_1": "assemble; combination",
+        "primary_1": "组合",
+        "primary_2": "組合"
+    },
+    {
+        "intermediate_1": "zu3zhi1",
+        "intermediate_2": "zǔzhī",
+        "native_1": "organize; organization",
+        "primary_1": "组织",
+        "primary_2": "組織"
+    },
+    {
+        "intermediate_1": "zui4chu1",
+        "intermediate_2": "zuìchū",
+        "native_1": "first; primary; initial",
+        "primary_1": "最初",
+        "primary_2": "最初"
+    },
+    {
+        "intermediate_1": "zui4",
+        "intermediate_2": "zuì",
+        "native_1": "intoxicated; become drunk",
+        "primary_1": "醉",
+        "primary_2": "醉"
+    },
+    {
+        "intermediate_1": "zun1jing4",
+        "intermediate_2": "zūnjìng",
+        "native_1": "respect; revere",
+        "primary_1": "尊敬",
+        "primary_2": "尊敬"
+    },
+    {
+        "intermediate_1": "zun1shou3",
+        "intermediate_2": "zūnshǒu",
+        "native_1": "observe; abide by; comply with; keep (commandments); to respect (an agreement)",
+        "primary_1": "遵守",
+        "primary_2": "遵守"
+    },
+    {
+        "intermediate_1": "zuo4pin3",
+        "intermediate_2": "zuòpǐn",
+        "native_1": "works (of literature and art)",
+        "primary_1": "作品",
+        "primary_2": "作品"
+    },
+    {
+        "intermediate_1": "zuo4wei2",
+        "intermediate_2": "zuòwéi",
+        "native_1": "regard as; act as; action; deed",
+        "primary_1": "作为",
+        "primary_2": "作爲"
+    },
+    {
+        "intermediate_1": "zuo4 wen2",
+        "intermediate_2": "zuò wén",
+        "native_1": "write an essay; essay",
+        "primary_1": "作文",
+        "primary_2": "作文"
+    }
+]

--- a/vocab/mandarin/hsk/6/vocab.csv
+++ b/vocab/mandarin/hsk/6/vocab.csv
@@ -1,0 +1,2501 @@
+PRIMARY	PRIMARY	INTERMEDIATE	INTERMEDIATE	NATIVE
+挨	挨	ai1	āi	get close to; in sequence
+癌症	癌症	ai2zheng4	áizhèng	cancer
+爱不释手	愛不釋手	ai4bu2shi4shou3	àibúshìshǒu	love something too much to part with it
+爱戴	愛戴	ai4dai4	àidài	love and respect
+暧昧	暧昧	ai4mei4	àimèi	ambiguous; shady
+安宁	安甯	an1ning2	ānníng	peaceful; calm; tranquil; composed
+安详	安詳	an1xiang2	ānxiáng	serene; composed
+安置	安置	an1zhi4	ānzhì	find a place for; help settle down; arrange for
+按摩	按摩	an4mo2	ànmó	massage
+案件	案件	an4jian4	ànjiàn	legal case; judicial case
+案例	案例	an4li4	ànlì	(Law) case
+暗示	暗示	an4shi4	ànshì	drop a hint; suggest
+昂贵	昂貴	ang2gui4	ángguì	expensive; costly
+凹凸	凹凸	ao1tu1	āotū	(of a surface) uneven; bumpy
+熬	熬	ao2	áo	endure; to boil
+奥秘	奧秘	ao4mi4	àomì	mystery; enigma; profound; deep
+巴不得	巴不得	ba1bu4de2	bābùdé	eagerly look forward to; earnestly wish; be only too anxious to
+巴结	巴結	ba1jie	bājie	to fawn on; curry favor with
+扒	扒	ba1	bā	dig up; pull down; take off
+疤	疤	ba1	bā	scar
+拔苗助长	拔苗助長	ba2miao2zhu4zhang3	bámiáozhùzhǎng	(literally) help shoots grow by pulling them out; spoil things by excessive enthusiasm
+把关	把關	ba3 guan1	bǎ guān	guard a pass; check on
+把手	把手	ba3shou	bǎshou	knob; handle; grip
+罢工	罷工	ba4 gong1	bà gōng	to strike; go on strike
+霸道	霸道	ba4dao4	bàdào	overbearing; despotic hegemony; rule by force; (of liquor, medicine, etc.) strong
+掰	掰	bai1	bāi	break with both hands
+摆脱	擺脫	bai3tuo1	bǎituō	break away; free oneself from; cast off
+败坏	敗壞	bai4huai4	bàihuài	ruin; corrupt; undermine
+拜访	拜訪	bai4fang3	bàifǎng	pay a visit; call on
+拜年	拜年	bai4 nian2	bài nián	congratulate the New Year; wish sb. a Happy New Year
+拜托	拜托	bai4tuo1	bàituō	ask a favor; request; please!
+颁布	頒布	ban1bu4	bānbù	promulgate; to issue; publish (e.g a decree)
+颁发	頒發	ban1fa1	bānfā	issue; promulgate; award
+斑	斑	ban1	bān	variety; speckled; spot; colored patch; stripe
+版本	版本	ban3ben3	bǎnběn	edition
+半途而废	半途而廢	ban4 tu2 er2 fei4	bàn tú ér fèi	give up halfway; leave sth. unfinished
+扮演	扮演	ban4yan3	bànyǎn	play the part of; act
+伴侣	伴侶	ban4lü3	bànlǚ	companion; partner; mate
+伴随	伴隨	ban4sui2	bànsuí	accompany; go with; follow
+绑架	綁架	bang3jia4	bǎngjià	kidnap; staking
+榜样	榜樣	bang3yang4	bǎngyàng	example; model
+磅	磅	bang4	bàng	pound; weigh; scale
+包庇	包庇	bao1bi4	bāobì	to shield; to harbor; cover up
+包袱	包袱	bao1fu	bāofu	bundle wrapped in cloth; cloth-wrapper
+包围	包圍	bao1wei2	bāowéi	surround; encircle; hem in
+包装	包裝	bao1zhuang1	bāozhuāng	to pack; package; make up
+饱和	飽和	bao3he2	bǎohé	saturation
+饱经沧桑	飽經滄桑	bao3jing1cang1sang1	bǎojīngcāngsāng	experienced many changes
+保管	保管	bao3guan3	bǎoguǎn	assure; take care of; surely
+保密	保密	bao3 mi4	bǎo mì	keep secret/confidential
+保姆	保姆	bao3mu3	bǎomǔ	nanny; housekeeper
+保守	保守	bao3shou3	bǎoshǒu	conservative (ideas, estimates, politically, etc.); to guard; to keep
+保卫	保衛	bao3wei4	bǎowèi	defend; to safeguard
+保养	保養	bao3yang3	bǎoyǎng	take good care of (or conserve) one's health; keep in good repair
+保障	保障	bao3zhang4	bǎozhàng	ensure; to guarantee; protect
+保重	保重	bao3zhong4	bǎozhòng	take care (of oneself)
+报仇	報仇	bao4chou2	bàochóu	retaliate; to revenge; avenge
+报酬	報酬	bao4chou	bàochou	reward; remuneration
+报答	報答	bao4da2	bàodá	repay; requite
+报复	報複	bao4fu	bàofu	retaliate; revenge
+报警	報警	bao4jing3	bàojǐng	report (an incident) to the police
+报销	報銷	bao4xiao1	bàoxiāo	submit an expense account; apply for reimbursement; write off
+抱负	抱負	bao4fu4	bàofù	aspiration; ambition
+暴力	暴力	bao4li4	bàolì	violence; (use) force
+暴露	暴露	bao4lu4	bàolù	expose; reveal; lay bare
+曝光	曝光	bao4guang1	bàoguāng	to expose; to make public
+爆发	爆發	bao4fa1	bàofā	break out; erupt; explode
+爆炸	爆炸	bao4zha4	bàozhà	explode; explosion; blow up
+卑鄙	卑鄙	bei1bi3	bēibǐ	base; mean; despicable; contemptible; unprincipled
+悲哀	悲哀	bei1'ai1	bēi'āi	grieved; sorrowful; sad
+悲惨	悲慘	bei1can3	bēicǎn	miserable; tragic
+北极	北極	bei3ji2	běijí	the North Pole
+贝壳	貝殼	bei4ke2	bèiké	shell; conch; cowry
+备份	備份	bei4fen4	bèifèn	to back up; a backup
+备忘录	備忘錄	bei4wang4lu4	bèiwànglù	memorandum; aide-memoire; diplomacy memorandum; memorandum book
+背叛	背叛	bei4pan4	bèipàn	betray; forsake
+背诵	背誦	bei4song4	bèisòng	recite
+被动	被動	bei4dong4	bèidòng	passive
+被告	被告	bei4gao4	bèigào	defendant
+奔波	奔波	ben1bo1	bēnbō	rush about; be busy running about
+奔驰	奔馳	ben1chi2	bēnchí	run quickly; speed; Mercedes-Benz (German vehicle manufacturer)
+本能	本能	ben3neng2	běnnéng	instinct
+本钱	本錢	ben3qian2	běnqián	capital (financial)
+本人	本人	ben3ren2	běnrén	I; me; myself; oneself; in person
+本身	本身	ben3shen1	běnshēn	itself; in itself; per se
+本事	本事	ben3shi	běnshi	ability; skill; capability; (-shì: this matter; literary source)
+笨拙	笨拙	ben4zhuo1	bènzhuō	clumsy; awkward; stupid
+崩溃	崩潰	beng1kui4	bēngkuì	collapse; crumble; fall apart
+甭	甭	beng2	béng	need not; (contraction of 不 and 用)
+迸发	迸發	beng4fa1	bèngfā	burst forth; burst out
+蹦	蹦	beng4	bèng	jump; bounce; hop
+逼迫	逼迫	bi1po4	bīpò	to force; compel; coerce
+鼻涕	鼻涕	bi2ti4	bítì	nasal mucus; snivel
+比方	比方	bi3fang	bǐfang	instance; analogy; example
+比喻	比喻	bi3yu4	bǐyù	metaphor; analogy; figure of speech
+比重	比重	bi3zhong4	bǐzhòng	proportion; specific gravity
+鄙视	鄙視	bi3shi4	bǐshì	despise; disdain; look down upon
+闭塞	閉塞	bi4se4	bìsè	stop up; shelter from; hard to get to; unenlightened
+弊病	弊病	bi4bing4	bìbìng	malady; evil; malpractice; drawback
+弊端	弊端	bi4duan1	bìduān	malpractice; abuse; corrupt practice
+臂	臂	bi4	bì	arm
+边疆	邊疆	bian1jiang1	biānjiāng	border area; borderland; frontier; frontier region
+边界	邊界	bian1jie4	biānjiè	boundary; border
+边境	邊境	bian1jing4	biānjìng	frontier
+边缘	邊緣	bian1yuan2	biānyuán	edge; fringe; verge; brink
+编织	編織	bian1zhi1	biānzhī	to weave; to knit; to plait; to braid; to crochet
+鞭策	鞭策	bian1ce4	biāncè	spur on; urge on
+贬低	貶低	bian3di1	biǎndī	to belittle; depreciate; disparage
+贬义	貶義	bian3yi4	biǎnyì	negative connotation; derogatory sense
+扁	扁	bian3	biǎn	flat
+变故	變故	biang4u4	biàngù	unforeseen event; accident
+变迁	變遷	bian4qian1	biànqiān	changes; vicissitude
+变质	變質	bian4 zhi4	biàn zhì	go bad; deteriorate; metamorphism
+便利	便利	bian4li4	biànlì	convenient; easy; facilitate
+便条	便條	bian4tiao2	biàntiáo	informal note
+便于	便于	bian4yu2	biànyú	be easy; be convenient for
+遍布	遍布	bian4bu4	biànbù	to cover the whole (area); found everywhere; spread all over
+辨认	辨認	bian4ren4	biànrèn	distinguish; identify; recognize
+辩护	辯護	bian4hu4	biànhù	speak in defense of; argue in favor of; defend
+辩解	辯解	bian4jie3	biànjiě	explain; justify; defend (a point of view, etc.)
+辩证	辯證	bian4zheng4	biànzhèng	investigate; dialectical
+辫子	辮子	bian4zi	biànzi	plait; braid; pigtail
+标本	標本	biao1ben3	biāoběn	specimen; sample; the root cause and symptoms of a disease
+标记	標記	biao1ji4	biāojì	sign; mark; symbol
+标题	標題	biao1ti2	biāotí	title; header; headline; caption
+表决	表決	biao3jue2	biǎojué	decide by vote; vote
+表态	表態	biao3tai4	biǎotài	make known one's position; declare where one stands
+表彰	表彰	biao3zhang1	biǎozhāng	cite (in dispatches); commend
+憋	憋	bie1	biē	hold in (urine); hold (breath); choke
+别墅	別墅	bie2shu4	biéshù	villa
+别致	別致	bie2zhi4	biézhì	unique; unconventional; fancy
+别扭	別扭	bien4iu	bièniu	awkward; unnatural
+濒临	瀕臨	bin1lin2	bīnlín	on the verge of
+冰雹	冰雹	bing1bao2	bīngbáo	hail
+丙	丙	bing3	bǐng	bright; fire (3rd Heavenly Stem)
+并非	並非	bing4fei1	bìngfēi	really isn't
+并列	並列	bing4lie4	bìngliè	stand side by side; be juxtaposed
+拨	撥	bo1	bō	to dial; move with a hand/foot; stir; poke; allocate (money)
+波浪	波浪	bo1lang4	bōlàng	wave
+波涛	波濤	bo1tao1	bōtāo	great waves; billows
+剥削	剝削	bo1xue1	bōxuē	to exploit
+播种	播種	bo1zhong3	bōzhǒng	sow seeds; sowing; seed
+伯母	伯母	bo2mu3	bómǔ	aunt; wife of father's older brother
+博大精深	博大精深	bo2da4jing1shen1	bódàjīngshēn	broad and profound
+博览会	博覽會	bo2lan3hui4	bólǎnhuì	(international) exhibition
+搏斗	搏鬥	bo2dou4	bódòu	fight; struggle; wrestle
+薄弱	薄弱	bo2ruo4	bóruò	weak; frail
+补偿	補償	bu3chang2	bǔcháng	compensation; make up
+补救	補救	bu3jiu4	bǔjiù	remedy; repair
+补贴	補貼	bu3tie1	bǔtiē	subsidy; allowance
+捕捉	捕捉	bu3zhuo1	bǔzhuō	catch; to seize
+哺乳	哺乳	bu3ru3	bǔrǔ	breast-feeding; to suckle
+不得已	不得已	bu4de2yi3	bùdéyǐ	act against one's will; have no alternative
+不妨	不妨	bu4fang2	bùfáng	there is no harm in; might as well
+不敢当	不敢當	bu4 gan3dang1	bù gǎndāng	(literally) I dare not accept the honor; you flatter me
+不顾	不顧	bu2gu4	búgù	in spite of; regardless of; to disregard
+不禁	不禁	bu4jin1	bùjīn	cannot help; can't refrain from
+不堪	不堪	bu4kan1	bùkān	cannot bear/stand; utterly
+不可思议	不可思議	bu4ke3si1yi4	bùkěsīyì	unimaginable; inconceivable
+不愧	不愧	bu2kui4	búkuì	be worthy of; deserve to be called; prove oneself to be
+不料	不料	bu2liao4	búliào	unexpectedly; to one's surprise
+不免	不免	bu4mian3	bùmiǎn	unavoidable
+不时	不時	bu4shi2	bùshí	frequently; often; at any time
+不惜	不惜	bu4xi1	bùxī	to not hesitate; not spare
+不相上下	不相上下	bu4 xiang1 shang4 xia4	bù xiāng shàng xià	equally matched; about the same
+不像话	不像話	bu2xiang4hua4	búxiànghuà	unreasonable; absurd; outrageous
+不屑一顾	不屑一顧	bu2xie4yi2gu4	búxièyígù	not worth seeing; disdain as beneath contempt
+不言而喻	不言而喻	bu4yan2'er2yu4	bùyán'éryù	it goes without saying; it is self-evident
+不由得	不由得	bu4you2de	bùyóude	can't help; cannot but
+不择手段	不擇手段	bu4ze2shou3duan4	bùzéshǒuduàn	by fair means or foul
+不止	不止	bu4zhi3	bùzhǐ	incessantly; more than
+布告	布告	bu4gao4	bùgào	notice; bulletin
+布局	布局	bu4ju2	bùjú	arrangement; composition; layout
+布置	布置	bu4zhi4	bùzhì	arrange; decorate; decoration
+步伐	步伐	bu4fa2	bùfá	pace; (measured) step; march
+部署	部署	bu4shu3	bùshǔ	dispose; deploy
+部位	部位	bu4wei4	bùwèi	position; place
+才干	才幹	cai2gan4	cáigàn	ability; competence
+财富	財富	cai2fu4	cáifù	wealth; riches; fortune
+财务	財務	cai2wu4	cáiwù	financial affairs
+财政	財政	cai2zheng4	cáizhèng	public finances; financial
+裁缝	裁縫	cai2feng	cáifeng	tailor; dressmaker
+裁判	裁判	cai2pan4	cáipàn	judge; to referee; judgment
+裁员	裁員	cai2yuan2	cáiyuán	cut staff; lay off employees
+采购	采購	cai3gou4	cǎigòu	make purchases for an organization; go shopping
+采集	采集	cai3ji2	cǎijí	gather; collect
+采纳	采納	cai3na4	cǎinà	accept; adopt
+彩票	彩票	cai3piao4	cǎipiào	lottery; lottery ticket
+参谋	參謀	can1mou2	cānmóu	advisor; give advice
+参照	參照	can1zhao4	cānzhào	consult a reference; refer to (another document)
+残疾	殘疾	can2ji	cánji	deformity; handicapped; crippled
+残酷	殘酷	can2ku4	cánkù	cruel
+残留	殘留	can2liu2	cánliú	to remain; be left over; surplus; remnant
+残忍	殘忍	can2ren3	cánrěn	brutal; bloody; merciless
+灿烂	燦爛	can4lan4	cànlàn	to glitter; brilliant; splendid
+仓促	倉促	cang1cu4	cāngcù	hurried
+仓库	倉庫	cang1ku4	cāngkù	depot; storehouse; warehouse
+苍白	蒼白	cang1bai2	cāngbái	pale; wan; pallid
+舱	艙	cang1	cāng	cabin; hold (of a ship or airplane)
+操劳	操勞	cao1lao2	cāoláo	work hard; look after
+操练	操練	cao1lian4	cāoliàn	to drill; to practice
+操纵	操縱	cao1zong4	cāozòng	operate; control; manipulation
+操作	操作	cao1zuo4	cāozuò	operate; manipulate
+嘈杂	嘈雜	cao2za2	cáozá	noisy; raucous
+草案	草案	cao3'an4	cǎo'àn	draft (legislation, proposal, etc.)
+草率	草率	cao3shuai4	cǎoshuài	cursory; careless; negligent; sloppy; not serious
+侧面	側面	ce4mian4	cèmiàn	side; profile; flank; face in profile
+测量	測量	ce4liang2	cèliáng	to survey; to measure
+策划	策劃	ce4hua4	cèhuà	plot; scheme; bring about
+策略	策略	ce4lüe4	cèlüè	tactics; plot
+层出不穷	層出不窮	ceng2 chu1 bu4 qiong2	céng chū bù qióng	(idiom) emerge more and more; innumerable succession; breeding like flies
+层次	層次	ceng2ci4	céngcì	level; rank order; standing; layer
+差别	差別	cha1bie2	chābié	difference; disparity
+插座	插座	cha1zuo4	chāzuò	power socket
+查获	查獲	cha2huo4	cháhuò	investigate and capture a criminal; discover
+岔	岔	cha4	chà	fork in the road; turn off; diverge
+刹那	刹那	chan4a4	chànà	an instant (Sanskrit: ksana); split second
+诧异	詫異	cha4yi4	chàyì	flabbergasted; astonished
+柴油	柴油	chai2you2	cháiyóu	diesel fuel; kerosene
+搀	攙	chan1	chān	assist by the arm; mix; support; sustain
+馋	饞	chan2	chán	gluttonous; greedy
+缠绕	纏繞	chan2rao4	chánrào	bind; wind; twirl; twist; intertwine
+产业	産業	chan3ye4	chǎnyè	industry; estate; property
+阐述	闡述	chan3shu4	chǎnshù	expound (a position); elaborate (on a topic)
+颤抖	顫抖	chan4dou3	chàndǒu	tremble; to shiver; to shake
+昌盛	昌盛	chang1sheng4	chāngshèng	prosperous
+尝试	嘗試	chang2shi4	chángshì	to try; attempt
+偿还	償還	chang2huan2	chánghuán	repay; reimburse
+场合	場合	chang3he2	chǎnghé	occasion; situation
+场面	場面	chang3mian4	chǎngmiàn	scene; occasion
+场所	場所	chang3suo3	chǎngsuǒ	location; place
+敞开	敞開	chang3kai1	chǎngkāi	open wide
+畅通	暢通	chang4tong1	chàngtōng	unimpeded; unclogged; free-flowing; straight path; to expedite
+畅销	暢銷	chang4xiao1	chàngxiāo	best seller; chart-topping; very marketable
+倡导	倡導	chang4dao3	chàngdǎo	to advocate; propose
+倡议	倡議	chang4yi4	chàngyì	suggest; propose
+钞票	鈔票	chao1piao4	chāopiào	paper money; bill
+超越	超越	chao1yue4	chāoyuè	surpass; exceed; transcend
+巢穴	巢穴	chao2xue2	cháoxué	lair; nest; den; hideout
+朝代	朝代	chao2dai4	cháodài	dynasty; reign (of a king)
+嘲笑	嘲笑	chao2xiao4	cháoxiào	jeer; mock; scoff
+潮流	潮流	chao2liu2	cháoliú	tide; current; trend
+撤退	撤退	che4tui4	chètuì	retreat
+撤销	撤銷	che4xiao1	chèxiāo	repeal
+沉淀	沈澱	chen2dian4	chéndiàn	to precipitate (solid sediment out of a solution); to settle
+沉闷	沈悶	chen2men4	chénmèn	oppressive (of weather); heavy; depressed; not happy
+沉思	沈思	chen2si1	chénsī	ponder; contemplate; meditation
+沉重	沈重	chen2zhong4	chénzhòng	heavy; hard; serious
+沉着	沈著	chen2zhuo2	chénzhuó	calm and collected; not nervous
+陈旧	陳舊	chen2jiu4	chénjiù	old fashioned; outmoded; obsolete
+陈列	陳列	chen2lie4	chénliè	to display; to exhibit
+陈述	陳述	chen2shu4	chénshù	allegation; assertation; to declare; to state
+衬托	襯托	chen4tuo1	chèntuō	to set off; serve as a foil to
+称心如意	稱心如意	chen4xin1ru2yi4	chènxīnrúyì	find sth. satisfactory
+称号	稱號	cheng1hao4	chēnghào	title; term of address
+成本	成本	cheng2ben3	chéngběn	cost (manufacturing, production, etc.)
+成交	成交	cheng2jiao1	chéngjiāo	complete a contract; clinch a deal; to seal
+成天	成天	cheng2tian1	chéngtiān	all day long; all the time
+成效	成效	cheng2xiao4	chéngxiào	effect; result
+成心	成心	cheng2xin1	chéngxīn	intentional; deliberate; with prior intent
+成员	成員	cheng2yuan2	chéngyuán	member
+呈现	呈現	cheng2xian4	chéngxiàn	appear; emerge; present (a certain appearance)
+诚挚	誠摯	cheng2zhi4	chéngzhì	sincere; cordial; earnest
+承办	承辦	cheng2ban4	chéngbàn	undertake; accept an assignment
+承包	承包	cheng2bao1	chéngbāo	to contract (to undertake a job)
+承诺	承諾	cheng2nuo4	chéngnuò	to promise
+城堡	城堡	cheng2bao3	chéngbǎo	castle
+乘	乘	cheng2	chéng	to ride; to mount; make use of; multiply
+盛	盛	cheng2, sheng4	chéng, shèng	contain; to ladle; to fill | flourishing; grand; abundant
+惩罚	懲罰	cheng2fa2	chéngfá	penalty; punishment; to punish; to penalize
+澄清	澄清	cheng2qing1	chéngqīng	(of liquid) settle; become clear; (Chem.) precipitate
+橙	橙	cheng2	chéng	orange (color); orange (fruit, tree)
+秤	秤	cheng4	chèng	balance; scale; steelyard
+吃苦	吃苦	chi1 ku3	chī kǔ	bear hardships; suffer
+吃力	吃力	chi1li4	chīlì	strenuous; exhausted
+迟钝	遲鈍	chi2dun4	chídùn	slow (witted); stupid; dull
+迟缓	遲緩	chi2huan3	chíhuǎn	slow; sluggish
+迟疑	遲疑	chi2yi2	chíyí	hesitate
+持久	持久	chi2jiu3	chíjiǔ	duration; enduring; lasting; persistent
+赤道	赤道	chi4dao4	chìdào	the equator
+赤字	赤字	chi4zi4	chìzì	(financial) deficit; red ink
+冲动	沖動	chong1dong4	chōngdòng	impulsive; act on impulse
+冲击	沖擊	chong1ji1	chōngjī	attack; impact; a shock
+冲突	沖突	chong1tu1	chōngtū	conflict; clash
+充当	充當	chong1dang1	chōngdāng	serve as; play the part of
+充沛	充沛	chong1pei4	chōngpèi	abundant; plentiful; vigorous
+充实	充實	chong1shi2	chōngshí	substantial; rich; enrich; substantiate
+充足	充足	chong1zu2	chōngzú	adequate; sufficient; abundant
+重叠	重疊	chong2die2	chóngdié	to overlap
+崇拜	崇拜	chong2bai4	chóngbài	worship; adore
+崇高	崇高	chong2gao1	chónggāo	lofty; sublime
+崇敬	崇敬	chong2jing4	chóngjìng	revere; admire; veneration
+稠密	稠密	chou2mi4	chóumì	dense; thick
+筹备	籌備	chou2bei4	chóubèi	make preparations; get ready for something
+丑恶	醜惡	chou3'e4	chǒu'è	ugly; repulsive; odiousness
+出路	出路	chu1lu4	chūlù	a way out; outlet
+出卖	出賣	chu1mai4	chūmài	sell; betray; sell out
+出身	出身	chu1shen1	chūshēn	family background; class origin
+出神	出神	chu1 shen2	chū shén	be lost in thought; entranced; preoccupation; Trance (music genre)
+出息	出息	chu1xi	chūxi	future prospects; aspiration; promise
+初步	初步	chu1bu4	chūbù	initial; preliminary; tentative
+除	除	chu2	chú	besides; except; remove; to divide (mathematics)
+处分	處分	chu3fen4	chǔfèn	punish; punishment; discipline; disposal
+处境	處境	chu3jing4	chǔjìng	plight; unfavorable situation
+处置	處置	chu3zhi4	chǔzhì	to handle; take care of; punish
+储备	儲備	chu3bei4	chǔbèi	reserves; store up
+储存	儲存	chu3cun2	chǔcún	stockpile; to store
+储蓄	儲蓄	chu3xu4	chǔxù	to save; to deposit
+触犯	觸犯	chu4fan4	chùfàn	offend; violate
+川流不息	川流不息	chuan1 liu2 bu4 xi1	chuān liú bù xī	(saying) flowing of an endless stream
+穿越	穿越	chuan1yue4	chuānyuè	pass through; cut across
+传达	傳達	chuan2da2	chuándá	convey; transmit; communicate
+传单	傳單	chuan2dan1	chuándān	leaflet; flier; pamphlet
+传授	傳授	chuan2shou4	chuánshòu	impart; pass on; teach
+船舶	船舶	chuan2bo2	chuánbó	ships; boats; watercraft
+喘气	喘氣	chuan3qi4	chuǎnqì	to pant; gasp for breath
+串	串	chuan4	chuàn	string together; conspire; gang up; mix up; bunch
+床单	床單	chuang2dan1	chuángdān	bed sheet
+创立	創立	chuang4li4	chuànglì	to found; establish
+创新	創新	chuang4xin1	chuàngxīn	innovate; innovation
+创业	創業	chuang4ye4	chuàngyè	begin an undertaking; start a major task; start a company
+创作	創作	chuang4zuo4	chuàngzuò	create; to produce; creative work
+吹牛	吹牛	chui1 niu2	chuī niú	to brag; (regional) to chat
+吹捧	吹捧	chui1peng3	chuīpěng	flatter sb.; extol sb.'s accomplishments
+炊烟	炊煙	chui1yan1	chuīyān	smoke from kitchen chimneys
+垂直	垂直	chui2zhi2	chuízhí	perpendicular; vertical
+锤	錘	chui2	chuí	hammer; weight
+纯粹	純粹	chun2cui4	chúncuì	purely; pure
+纯洁	純潔	chun2jie2	chúnjié	pure; unadulterated; cleanse
+慈善	慈善	ci2shan4	císhàn	philanthropic; benevolent; charitable
+慈祥	慈祥	ci2xiang2	cíxiáng	a kindly person; benevolent (often of older people)
+磁带	磁帶	ci2dai4	cídài	cassette tape
+雌雄	雌雄	ci2xiong2	cíxióng	male and female; winners and losers
+次品	次品	ci4pin3	cìpǐn	defective or substandard products
+次序	次序	ci4xu4	cìxù	sequence; order
+伺候	伺候	ci4hou	cìhou	serve; wait upon; act as a valet
+刺	刺	ci4	cì	thorn; to sting; to prick; pierce; stab
+从容	從容	cong2rong2	cóngróng	leisurely; calm
+丛	叢	cong2	cóng	crowd together; thicket; collection
+凑合	湊合	cou4he	còuhe	bring together; make do in a bad situation; improvise
+粗鲁	粗魯	cu1lu3	cūlǔ	crude; coarse; rough; language
+窜	竄	cuan4	cuàn	to flee; to escape; run away
+摧残	摧殘	cui1can2	cuīcán	to ruin; devastate; vandalize
+脆弱	脆弱	cui4ruo4	cuìruò	weak; fragile; flimsy; frail
+搓	搓	cuo1	cuō	rub or roll between the hands or fingers; to twist
+磋商	磋商	cuo1shang1	cuōshāng	discuss seriously; consult; negotiate
+挫折	挫折	cuo4zhe2	cuòzhé	setback; defeat; frustration
+搭	搭	da1	dā	to erect; to build; travel by (car, plane, etc.); to hang; to join
+搭档	搭檔	da1dang4	dādàng	team up; cooperate; work together
+搭配	搭配	da1pei4	dāpèi	pair up; arrange in pairs; to add sth. into a group; to suit
+达成	達成	da2 cheng2	dá chéng	to reach (an agreement); achieve
+答辩	答辯	da2bian4	dábiàn	reply (to an accusation)
+答复	答複	da2fu4	dáfù	to answer; to reply
+打包	打包	da3bao1	dǎbāo	get a doggy bag (at a restaurant); pack up
+打官司	打官司	da3 guan1si	dǎ guānsi	go to court
+打击	打擊	da3ji1	dǎjī	to strike; to hit; to attack
+打架	打架	da3 jia4	dǎ jià	to fight; scuffle; to come to blows
+打量	打量	da3liang	dǎliang	take measure of; size up
+打猎	打獵	da3 lie4	dǎ liè	hunt; to go hunting
+打仗	打仗	da3zhang4	dǎzhàng	fight; go to war; fight a battle
+大不了	大不了	da4buliao3	dàbuliǎo	at the worst; if worst comes to worst; serious, alarming
+大臣	大臣	da4chen2	dàchén	chancellor
+大伙儿	大夥兒	da4huo3r	dàhuǒr	everyone
+大肆	大肆	da4si4	dàsì	wantonly; without any constraint
+大体	大體	da4ti3	dàtǐ	in general; more or less; on the whole
+大意	大意	da4yi4	dàyì	main idea; general idea; gist
+大致	大致	da4zhi4	dàzhì	more or less; roughly; approximately
+歹徒	歹徒	dai3tu2	dǎitú	evil person who commits crimes; villain; gangster
+代价	代價	dai4jia4	dàijià	price; cost; expense
+代理	代理	dai4li3	dàilǐ	acting (temporarily filling a position); agent
+带领	帶領	dai4ling3	dàilǐng	to guide; to lead
+怠慢	怠慢	dai4man4	dàimàn	to slight; give somebody a cold shoulder; treat somebody in a cold manner
+逮捕	逮捕	dai4bu3	dàibǔ	to arrest; to capture
+担保	擔保	dan1bao3	dānbǎo	guarantee; vouch for
+胆怯	膽怯	dan3qie4	dǎnqiè	timid; coward
+诞辰	誕辰	dan4chen2	dànchén	birthday
+诞生	誕生	dan4sheng1	dànshēng	be born; come into being
+淡季	淡季	dan4ji4	dànjì	off season; slow business season
+淡水	淡水	dan4shui3	dànshuǐ	fresh water; potable water (water with low salt content)
+蛋白质	蛋白質	dan4bai2zhi4	dànbáizhì	protein
+当场	當場	dang1chang3	dāngchǎng	at the scene; on the spot
+当初	當初	dang1chu1	dāngchū	at that time; at the outset; originally
+当代	當代	dang1dai4	dāngdài	present day; contemporary
+当面	當面	dang1 mian4	dāng miàn	to sb.'s face; in sb.'s presence
+当前	當前	dang1qian2	dāngqián	current; modern; present
+当事人	當事人	dang1shi4ren2	dāngshìrén	persons involved or implicated; party (to an affair)
+当务之急	當務之急	dang1wu4zhi1ji2	dāngwùzhījí	the most pressing matter of the moment; a top priority task; urgent matter
+当选	當選	dang1xuan3	dāngxuǎn	be elected
+党	黨	dang3	dǎng	party; club; association
+档案	檔案	dang4'an4	dàng'àn	file; record; archive
+档次	檔次	dang4ci4	dàngcì	grade; quality; class; level
+导弹	導彈	dao3dan4	dǎodàn	guided missile; cruise missile
+导航	導航	dao3hang2	dǎoháng	navigation
+导向	導向	dao3xiang4	dǎoxiàng	guidance; lead to; direct something towards
+捣乱	搗亂	dao3 luan4	dǎo luàn	cause a disturbance; look for trouble
+倒闭	倒閉	dao3bi4	dǎobì	go bankrupt; close down
+盗窃	盜竊	dao4qie4	dàoqiè	steal; pilfer
+稻谷	稻谷	dao4gu3	dàogǔ	rice crops/paddy
+得不偿失	得不償失	de2 bu4 chang2 shi1	dé bù cháng shī	the gains do not outweigh the losses
+得力	得力	de2li4	délì	able; competent
+得天独厚	得天獨厚	de2tian1du2hou4	détiāndúhòu	enjoy exceptional advantages; richly endowed by nature
+得罪	得罪	de2zui4	dézuì	offend; a faux pas
+灯笼	燈籠	deng1long	dēnglong	lantern
+登陆	登陸	deng1lu4	dēnglù	to land; come ashore; sign/log in
+登录	登錄	deng1lu4	dēnglù	sign-in
+蹬	蹬	deng1	dēng	press down with the foot; step back or into something
+等候	等候	deng3hou4	děnghòu	wait; queue
+等级	等級	deng3ji2	děngjí	degree; rate
+瞪	瞪	deng4	dèng	stare at; to glower
+堤坝	堤壩	di1ba4	dībà	dam; dyke
+敌视	敵視	di2shi4	díshì	be hostile; adopt a negative attitude towards
+抵达	抵達	di3da2	dǐdá	arrive; to reach (a destination); touch down
+抵抗	抵抗	di3kang4	dǐkàng	resist; resistance
+抵制	抵制	di3zhi4	dǐzhì	resistance; refusal (to cooperate); boycott
+地步	地步	di4bu4	dìbù	condition; plight; extent
+地势	地勢	di4shi4	dìshì	terrain; topography of a place
+地质	地質	di4zhi4	dìzhì	geology
+递增	遞增	di4zeng1	dìzēng	increase step by step; steadily increase
+颠簸	顛簸	dian1bo3	diānbǒ	shake; to jolt; bump
+颠倒	顛倒	dian1dao3	diāndǎo	turn upside down; upend
+典礼	典禮	dian3li3	diǎnlǐ	celebration; ceremony
+典型	典型	dian3xing2	diǎnxíng	typical case; model
+点缀	點綴	dian3zhui4	diǎnzhuì	decorate; an ornament; beautify; embellish; be the finishing touch
+电源	電源	dian4yuan2	diànyuán	electric power supply
+垫	墊	dian4	diàn	cushion; to pad; pay for somebody and expect to be repaid
+惦记	惦記	dian4ji4	diànjì	to remember with concern; to be concerned about; to think about; to keep thinking about; to worry about
+奠定	奠定	dian4ding4	diàndìng	establish; to found; to settle
+叼	叼	diao1	diāo	hold sth. in the mouth
+雕刻	雕刻	diao1ke4	diāokè	carve; engrave; sculpt
+雕塑	雕塑	diao1su4	diāosù	sculpture; a statue; a Buddhist image
+吊	吊	diao4	diào	hang; suspend
+调动	調動	diao4dong4	diàodòng	to transfer; to maneuver (troops, etc.)
+跌	跌	die1	diē	to fall down; to drop
+丁	丁	ding1	dīng	male adult; robust; cubes (of food); T-shaped (4th Heavenly Stem)
+叮嘱	叮囑	ding1zhu3	dīngzhǔ	urge again and again; exhort; repeatedly warn
+盯	盯	ding1	dīng	to stare; to gaze
+定期	定期	ding4qi1	dìngqī	regularly; at regular intervals
+定义	定義	ding4yi4	dìngyì	definition
+丢人	丟人	diu1 ren2	diū rén	lose face; be disgraced
+丢三落四	丟三落四	diu1san1 la4si4	diūsān làsì	forgetful; scatterbrained
+东道主	東道主	dong1dao4zhu3	dōngdàozhǔ	host for a party or conference
+东张西望	東張西望	dong1zhang1xi1wang4	dōngzhāngxīwàng	look in all directions; glance around
+董事长	董事長	dong3shi4zhang3	dǒngshìzhǎng	chairman of the board
+动荡	動蕩	dong4dang4	dòngdàng	(social or political) turmoil; unrest; upheaval
+动机	動機	dong4ji1	dòngjī	motive; motivation; intention
+动静	動靜	dong4jing4	dòngjìng	sound of activity; activity
+动力	動力	dong4li4	dònglì	power; motion; impetus; driving force
+动脉	動脈	dong4mai4	dòngmài	artery
+动身	動身	dong4 shen1	dòng shēn	go on a journey; leave
+动手	動手	dong4shou3	dòngshǒu	get to work; to touch; strike a blow
+动态	動態	dong4tai4	dòngtài	development; trend; dynamic state
+动员	動員	dong4yuan2	dòngyuán	mobilize
+冻结	凍結	dong4jie2	dòngjié	(loan, wage, price) freeze
+栋	棟	dong4	dòng	roof beam; (mw for buildings)
+兜	兜	dou1	dōu	pocket; bag; wrap up (in a piece of cloth); move around (in a circle); canvass (solicit); take responsibility
+陡峭	陡峭	dou3qiao4	dǒuqiào	steep; precipitous
+斗争	鬥爭	dou4zheng1	dòuzhēng	to struggle; to fight for; to battle
+督促	督促	du1cu4	dūcù	supervise and urge sb. to complete a task
+毒品	毒品	du2pin3	dúpǐn	drugs; narcotics; poison
+独裁	獨裁	du2cai2	dúcái	dictatorship
+堵塞	堵塞	du3se4	dǔsè	block; stop
+赌博	賭博	du3bo2	dǔbó	to gamble
+杜绝	杜絕	du4jue2	dùjué	put an end to
+端	端	duan1	duān	end; beginning; extremity; carry holding something from the sides
+端午节	端午節	Duan1wu3 Jie2	Duānwǔ Jié	Dragon Boat Festival
+端正	端正	duan1zheng4	duānzhèng	upright; regular; proper; correct
+短促	短促	duan3cu4	duǎncù	short in time duration; fleeting; brief
+断定	斷定	duan4ding4	duàndìng	conclude; determine; figure out
+断绝	斷絕	duan4jue2	duànjué	sever; break off
+堆积	堆積	dui1ji1	duījī	pile up; accumulate
+队伍	隊伍	dui4wu	duìwu	ranks; troops
+对策	對策	dui4ce4	duìcè	countermeasure for dealing with a situation
+对称	對稱	dui4chen4	duìchèn	symmetry
+对付	對付	dui4fu	duìfu	to handle; deal with
+对抗	對抗	dui4kang4	duìkàng	withstand; resist; antagonize
+对立	對立	dui4li4	duìlì	oppose; to counter
+对联	對聯	dui4lian2	duìlián	rhyming couplet; vertical written couplet usually placed along either side of a doorway
+对应	對應	dui4ying4	duìyìng	corresponding; counterpart
+对照	對照	dui4zhao4	duìzhào	contrast; compare
+兑现	兌現	dui4xian4	duìxiàn	cash a check; honor a commitment
+顿时	頓時	dun4shi2	dùnshí	immediately; suddenly
+多元化	多元化	duo1yuan2hua4	duōyuánhuà	diversify; diversification
+哆嗦	哆嗦	duo1suo	duōsuo	tremble; to shiver; to quiver
+堕落	墮落	duo4luo4	duòluò	morally degenerate; become depraved
+额外	額外	e2wai4	éwài	extra; added; additional
+恶心	惡心	e3xin	ěxin	disgusting; nauseous; make somebody embarrassed (èxīn: bad/vicious habit; vice)
+恶化	惡化	e4hua4	èhuà	worsen; deteriorate
+遏制	遏制	e4zhi4	èzhì	keep within limits; contain; restrain; hold back
+恩怨	恩怨	en1yuan4	ēnyuàn	grievance; old rivalry; mixture of gratitude and resentment
+而已	而已	er2yi3	éryǐ	that's all; nothing more
+二氧化碳	二氧化碳	er4yang3hua4tan4	èryǎnghuàtàn	carbon dioxide; CO2
+发布	發布	fa1bu4	fābù	issue; announce; release
+发财	發財	fa1 cai2	fā cái	get rich
+发呆	發呆	fa1dai1	fādāi	stare blankly; daze off
+发动	發動	fa1dong4	fādòng	to start; to launch; mobilize
+发觉	發覺	fa1jue2	fājué	discover; detect
+发射	發射	fa1she4	fāshè	to launch; to shoot (a projectile); to fire (a rocket)
+发誓	發誓	fa1shi4	fāshì	to vow; to pledge; swear
+发行	發行	fa1xing2	fāxíng	publish; to issue; distribute
+发炎	發炎	fa1yan2	fāyán	become inflamed from infection or injury
+发扬	發揚	fa1yang2	fāyáng	develop; make full use of; to carry on
+发育	發育	fa1yu4	fāyù	develop; growth
+法人	法人	fa3ren2	fǎrén	legal entity (i.e., a corporation)
+番	番	fan1	fān	(mw for acts or deeds); foreign
+凡是	凡是	fan2shi4	fánshì	every; any; all; without exception
+繁华	繁華	fan2hua2	fánhuá	flourishing; bustling; prosperous
+繁忙	繁忙	fan2mang2	fánmáng	busy; bustling
+繁体字	繁體字	fan2ti3zi4	fántǐzì	traditional Chinese character
+繁殖	繁殖	fan2zhi2	fánzhí	propagate; to breed; reproduce
+反驳	反駁	fan3bo2	fǎnbó	retort; refute
+反常	反常	fan3chang2	fǎncháng	abnormal; unusual
+反感	反感	fang3an3	fǎngǎn	(strongly) dislike
+反抗	反抗	fan3kang4	fǎnkàng	resist; to revolt
+反馈	反饋	fan3kui4	fǎnkuì	feedback; send information back
+反面	反面	fan3mian4	fǎnmiàn	the reverse side of sth.; opposite side of a topic
+反射	反射	fan3she4	fǎnshè	reflex; reflection (from a mirror, etc.)
+反思	反思	fan3si1	fǎnsī	think back over something that happened; to reflect; introspection
+反问	反問	fan3wen4	fǎnwèn	ask a rhetorical question; answer a question with a question
+反之	反之	fan3zhi1	fǎnzhī	whereas...; on the other hand ...; conversely ...
+泛滥	泛濫	fan4lan4	fànlàn	to be in flood; to overflow (the banks); to inundate; to spread unchecked
+范畴	範疇	fan4chou2	fànchóu	category
+贩卖	販賣	fan4mai4	fànmài	sell; peddle; (often derogatory) to traffic in
+方位	方位	fang1wei4	fāngwèi	position; direction; points of the compass; bearing
+方言	方言	fang1yan2	fāngyán	dialect
+方圆	方圓	fang1yuan2	fāngyuán	circumference; neighborhood; vicinity
+方针	方針	fang1zhen1	fāngzhēn	policy; guidelines
+防守	防守	fang2shou3	fángshǒu	to defend; protect; to guard
+防御	防禦	fang2yu4	fángyù	defense; resist; to guard
+防止	防止	fang2zhi3	fángzhǐ	prevent; protect; guard against; avoid
+防治	防治	fang2zhi4	fángzhì	prevent and cure
+访问	訪問	fang3wen4	fǎngwèn	to visit; call on; to interview
+纺织	紡織	fang3zhi1	fǎngzhī	spinning and weaving; textile
+放大	放大	fang4da4	fàngdà	enlarge; amplify
+放射	放射	fang4she4	fàngshè	radiate; radioactive
+飞禽走兽	飛禽走獸	fei1qin2zou3shou4	fēiqínzǒushòu	birds and animals; the beasts of the field and the birds of the air
+飞翔	飛翔	fei1xiang2	fēixiáng	fly; hover
+飞跃	飛躍	fei1yue4	fēiyuè	to leap
+非法	非法	fei1fa3	fēifǎ	illegal
+肥沃	肥沃	fei2wo4	féiwò	fertile
+诽谤	誹謗	fei3bang4	fěibàng	slander; libel
+肺	肺	fei4	fèi	lung
+废除	廢除	fei4chu2	fèichú	abolish; annul; abrogate
+废寝忘食	廢寢忘食	fei4qin3wang4shi2	fèiqǐnwàngshí	to forget even sleeping and eating
+废墟	廢墟	fei4xu1	fèixū	ruins
+沸腾	沸騰	fei4teng2	fèiténg	to boil; boiling
+分辨	分辨	fen1bian4	fēnbiàn	distinguish; differentiate; resolve
+分寸	分寸	fen1cun	fēncun	propriety; the limits of proper speech or action
+分红	分紅	fen1 hong2	fēn hóng	a bonus; to award a bonus; to draw or recieve dividends; to share profits
+分解	分解	fen1jie3	fēnjiě	to decompose; to resolve; to break down
+分裂	分裂	fen1lie4	fēnliè	split up; to divide; separate
+分泌	分泌	fen1mi4	fēnmì	secrete
+分明	分明	fen1ming2	fēnmíng	clear; distinct; evidently; clearly
+分歧	分歧	fen1qi2	fēnqí	difference (of opinion/position）
+分散	分散	fen1san4	fēnsàn	to scatter; disperse; distribute
+吩咐	吩咐	fen1fu4	fēnfù	instruct; instructions; to tell; to order (to do something)
+坟墓	墳墓	fen2mu4	fénmù	tomb; sepulcher
+粉末	粉末	fen3mo4	fěnmò	fine powder; dust
+粉色	粉色	fen3se4	fěnsè	pink
+粉碎	粉碎	fen3sui4	fěnsuì	to crash; break up
+分量	分量	fen4liang4	fènliàng	weight; heft; amount
+愤怒	憤怒	fen4nu4	fènnù	angry; indignant; furious; anger; indignation; wrath; ire
+丰满	豐滿	feng1man3	fēngmǎn	plump; well developed; plentiful; Fengman district of Jilin City, Jilin Province
+丰盛	豐盛	feng1sheng4	fēngshèng	sumptuous; lavish
+丰收	豐收	feng1shou1	fēngshōu	bumper crop; have a good harvest
+风暴	風暴	feng1bao4	fēngbào	storm; violent commotion
+风度	風度	feng1du4	fēngdù	elegant demeanor; grace; poise; style
+风光	風光	feng1guang1	fēngguāng	a natural scenic view; sight
+风气	風氣	feng1qi4	fēngqì	general mood; atmosphere; common practice
+风趣	風趣	feng1qu4	fēngqù	humor; wit; humorous
+风土人情	風土人情	feng1tu3ren2qing2	fēngtǔrénqíng	local conditions (human and environmental)
+风味	風味	feng1wei4	fēngwèi	local flavor; local style
+封闭	封閉	feng1bi4	fēngbì	to seal; to close; confine
+封建	封建	feng1jian4	fēngjiàn	feudal; feudalism
+封锁	封鎖	feng1suo3	fēngsuǒ	to blockade; to seal off
+锋利	鋒利	feng1li4	fēnglì	sharp (i.e. a knife blade); incisive; to the point
+逢	逢	feng2	féng	to meet; come upon
+奉献	奉獻	feng4xian4	fèngxiàn	consecrate; dedicate; devote
+否决	否決	fou3jue2	fǒujué	veto; reject; overrule
+夫妇	夫婦	fu1fu4	fūfù	married couple; husband and wife
+夫人	夫人	fu1ren2	fūrén	lady; madam; Mrs.; wife
+敷衍	敷衍	fu1yan3	fūyǎn	to elaborate (on a theme); to expound (the classics); to do sth. half-heartedly or just for show; barely enough to get by; perfunctory; apathetic; to skimp; to botch
+服从	服從	fu2cong2	fúcóng	to obey; to comply
+服气	服氣	fu2qi4	fúqì	be convinced
+俘虏	俘虜	fu2lu3	fúlǔ	captive; prisoner
+符号	符號	fu2hao4	fúhào	symbol; mark; sign
+幅度	幅度	fu2du4	fúdù	width; margin; extent
+辐射	輻射	fu2she4	fúshè	radiation
+福利	福利	fu2li4	fúlì	material benefits; welfare; well-being
+福气	福氣	fu2qi4	fúqì	good fortune
+抚摸	撫摸	fu3mo1	fǔmō	gently caress and stroke; to pet; to fondle
+抚养	撫養	fu3yang3	fǔyǎng	foster; bring up; raise
+俯视	俯視	fu3shi4	fǔshì	look down at; overlook
+辅助	輔助	fu3zhu4	fǔzhù	assist; aide
+腐败	腐敗	fu3bai4	fǔbài	corruption; corrupt; rotten
+腐烂	腐爛	fu3lan4	fǔlàn	rot; become gangrenous
+腐蚀	腐蝕	fu3shi2	fǔshí	erode; corrode; corrupt; rusty
+腐朽	腐朽	fu3xiu3	fǔxiǔ	rotten; decayed; decadent; degenerate
+负担	負擔	fu4dan1	fùdān	to (bear a) burden; carry; a load
+附和	附和	fu4he4	fùhè	repeat an agreement; copy sb.'s action or words
+附件	附件	fu4jian4	fùjiàn	attachment; enclosure
+附属	附屬	fu4shu3	fùshǔ	subsidiary; auxiliary; affiliate; attached
+复活	複活	fu4huo2	fùhuó	resurrection
+复兴	複興	fu4xing1	fùxīng	revive; restore
+副	副	fu4	fù	vice-; secondary; auxiliary; deputy; assistant; classifier for pairs (i.e. glasses)
+赋予	賦予	fu4yu3	fùyǔ	confer upon; bestow; endow; entrust (a task)
+富裕	富裕	fu4yu4	fùyù	rich; to prosper; wealthy
+腹泻	腹瀉	fu4xie4	fùxiè	diarrhea
+覆盖	覆蓋	fu4gai4	fùgài	to cover
+改良	改良	gai3liang2	gǎiliáng	improve; to reform
+钙	鈣	gai4	gài	calcium
+盖章	蓋章	gai4zhang1	gàizhāng	affix one's seal; seal; stamp
+干旱	幹旱	gan1han4	gānhàn	drought; dry
+干扰	幹擾	gan1rao3	gānrǎo	interfere; obstruction
+干涉	幹涉	gan1she4	gānshè	interfere; intervene; meddle
+干预	幹預	gan1yu4	gānyù	meddle; intervene; intervention
+尴尬	尴尬	gang1a4	gāngà	awkward; embarrassed
+感慨	感慨	gan3kai3	gǎnkǎi	lament; with a tinge of emotion or regret
+感染	感染	gan3ran3	gǎnrǎn	infection; infect; influence
+干劲	幹勁	gan4jin4	gànjìn	enthusiasm; energy; drive
+纲领	綱領	gang1ling3	gānglǐng	program; guiding principle
+岗位	崗位	gang3wei4	gǎngwèi	a post; a job
+港口	港口	gang3kou3	gǎngkǒu	port; harbor
+港湾	港灣	gang3wan1	gǎngwān	harbor; estuary
+杠杆	杠杆	gang4gan3	gànggǎn	lever; pry bar; crowbar; financial leverage
+高超	高超	gao1chao1	gāochāo	excellent; superb
+高潮	高潮	gao1chao2	gāocháo	high tide; upsurge; climax; chorus (of a song)
+高峰	高峰	gao1feng1	gāofēng	peak; summit; apex
+高明	高明	gao1ming2	gāomíng	brilliant; wise
+高尚	高尚	gao1shang4	gāoshàng	nobly; lofty
+高涨	高漲	gao1zhang3	gāozhǎng	upsurge; (tensions, etc.) run high
+稿件	稿件	gao3jian4	gǎojiàn	rough draft of a document
+告辞	告辭	gao4ci2	gàocí	take leave; bid farewell
+告诫	告誡	gao4jie4	gàojiè	warn; admonish
+疙瘩	疙瘩	ge1da	gēda	swelling or lump on skin
+鸽子	鴿子	ge1zi	gēzi	dove; pigeon
+搁	擱	ge1	gē	to place; put aside
+割	割	ge1	gē	to cut (apart/off)
+歌颂	歌頌	ge1song4	gēsòng	sing the praise of; extol; eulogize
+革命	革命	ge2ming4	gémìng	revolution; revolutionary (politics); cause great social change; rise in revolt; take part in revolution
+格局	格局	ge2ju2	géjú	structure; pattern
+格式	格式	ge2shi4	géshì	form; specification; format
+隔阂	隔閡	ge2he2	géhé	estrangement; misunderstanding
+隔离	隔離	ge2li2	gélí	insulate; separate; isolate
+个体	個體	ge4ti3	gètǐ	individual
+各抒己见	各抒己見	ge4shu1ji3jian4	gèshūjǐjiàn	everyone gives their own view
+根深蒂固	根深蒂固	gen1 shen1 di4 gu4	gēn shēn dì gù	deep-rooted; ingrained; inveterate (problem, etc.)
+根源	根源	gen1yuan2	gēnyuán	origin; root; source
+跟前	跟前	gen1qian2	gēnqián	in front of
+跟随	跟隨	gen1sui2	gēnsuí	follow; followed
+跟踪	跟蹤	gen1zong1	gēnzōng	follow somebody's tracks; tail; shadow
+更新	更新	geng1xin1	gēngxīn	to replace the old with new; to renew; to renovate; to upgrade; to update; to regenerate; to rejuvenate
+更正	更正	geng1zheng4	gēngzhèng	correct; correction
+耕地	耕地	geng1di4	gēngdì	arable land; to plow land
+工艺品	工藝品	gong1yi4pin3	gōngyìpǐn	handicraft; handiwork
+公安局	公安局	gong1an1ju2	gōngānjú	public security bureau
+公道	公道	gong1dao	gōngdao	fair; equitable
+公告	公告	gong1gao4	gōnggào	post; announcement
+公关	公關	gong1guan1	gōngguān	public relations
+公民	公民	gong1min2	gōngmín	citizen
+公然	公然	gong1ran2	gōngrán	(do something) openly; undisguised
+公认	公認	gong1ren4	gōngrèn	publicly know (to be); recognize; generally acknowledged
+公式	公式	gong1shi4	gōngshì	formula
+公务	公務	gong1wu4	gōngwù	public affairs; official business
+公正	公正	gong1zheng4	gōngzhèng	just; fair
+公证	公證	gong1zheng4	gōngzhèng	notarization
+功劳	功勞	gong1lao2	gōngláo	contribution; meritorious; credit
+功效	功效	gong1xiao4	gōngxiào	efficiency; effectiveness
+攻击	攻擊	gong1ji1	gōngjī	to attack; accuse; to charge
+攻克	攻克	gong1ke4	gōngkè	to capture; to take
+供不应求	供不應求	gong1 bu2 ying4 qiu2	gōng bú yìng qiú	(saying) demand outstrips supply
+供给	供給	gong1ji3	gōngjǐ	to furnish; provide; to supply
+宫殿	宮殿	gong1dian4	gōngdiàn	palace
+恭敬	恭敬	gong1jing4	gōngjìng	dutiful; deferential
+巩固	鞏固	gong3gu4	gǒnggù	consolidate; solidify
+共和国	共和國	gong4he2guo2	gònghéguó	republic
+共计	共計	gong4ji4	gòngjì	sum up; total
+共鸣	共鳴	gong4ming2	gòngmíng	physical resonance; sympathetic response to something
+勾结	勾結	gou1jie2	gōujié	collude with; collaborate; gang up
+钩子	鈎子	gou1zi	gōuzi	hook
+构思	構思	gou4si1	gòusī	outline a story; make preliminary sketch
+孤独	孤獨	gu1du2	gūdú	lonely; solitary
+孤立	孤立	gu1li4	gūlì	isolate; isolated
+姑且	姑且	gu1qie3	gūqiě	temporarily; the time being
+辜负	辜負	gu1fu4	gūfù	let down; disappoint; fail to live up to
+古董	古董	gu3dong3	gǔdǒng	antique
+古怪	古怪	gu3guai4	gǔguài	eccentric; grotesque; oddly
+股东	股東	gu3dong1	gǔdōng	stockholder; shareholder
+股份	股份	gu3fen4	gǔfèn	a share (in a company) stock
+骨干	骨幹	gu3gan4	gǔgàn	backbone; mainstay
+鼓动	鼓動	gu3dong4	gǔdòng	agitate; instigate
+固然	固然	gu4ran2	gùrán	admittedly; it is true that; indeed
+固体	固體	gu4ti3	gùtǐ	solid
+固有	固有	gu4you3	gùyǒu	intrinsic/inherent to something; native
+固执	固執	gu4zhi2	gùzhí	persistent; stubborn
+故乡	故鄉	gu4xiang1	gùxiāng	hometown; homeland; birthplace
+故障	故障	gu4zhang4	gùzhàng	malfunction; breakdown
+顾虑	顧慮	gu4lü4	gùlǜ	misgivings; apprehensions
+顾问	顧問	gu4wen4	gùwèn	adviser; consultant
+雇佣	雇傭	gu4yong1	gùyōng	employ; hire
+拐杖	拐杖	guai3zhang4	guǎizhàng	crutch; walking stick
+关怀	關懷	guan1huai2	guānhuái	care; solicitude; show care for; concerned about; attentive to
+关照	關照	guan1zhao4	guānzhào	concern; look after; keep an eye on
+观光	觀光	guang1uang1	guānguāng	sight see; tour
+官方	官方	guan1fang1	guānfāng	official; (by the) government
+管辖	管轄	guan3xia2	guǎnxiá	administer; have jurisdiction (over)
+贯彻	貫徹	guan4che4	guànchè	to implement; put into practice; carry out
+惯例	慣例	guan4li4	guànlì	conventional
+灌溉	灌溉	guang4ai4	guàngài	irrigate
+罐	罐	guan4	guàn	can; jar; pot; pitcher; jug
+光彩	光彩	guang1cai3	guāngcǎi	splendor; radiance; brilliance; honor
+光辉	光輝	guang1hui1	guānghuī	radiance; brilliant; glory
+光芒	光芒	guang1mang2	guāngmáng	rays of light; brilliant rays; radiance
+光荣	光榮	guang1rong2	guāngróng	glory; honor
+广阔	廣闊	guang3kuo4	guǎngkuò	wide; vast
+归根到底	歸根到底	gui1 gen1 dao4 di3	guī gēn dào dǐ	(saying) to sum it up ...
+归还	歸還	gui1huan2	guīhuán	return something; revert
+规范	規範	gui1fan4	guīfàn	standard (design or model); norm; without variation; to specify
+规格	規格	gui1ge2	guīgé	standard; norm; specification
+规划	規劃	gui1hua4	guīhuà	plan; program; project
+规章	規章	gui1zhang1	guīzhāng	regulations; rule
+轨道	軌道	gui3dao4	guǐdào	orbit; railway; trajectory
+贵族	貴族	gui4zu2	guìzú	lord; nobility; nobleman; noblewoman
+跪	跪	gui4	guì	kneel
+棍棒	棍棒	gun4bang4	gùnbàng	club
+国防	國防	guo2fang2	guófáng	national defense
+国务院	國務院	guo2wu4yuan4	guówùyuàn	State Council (PRC); State Department (USA)
+果断	果斷	guo3duan4	guǒduàn	firm; decisive
+过度	過度	guo4du4	guòdù	excessive; exceeding; lavishly
+过渡	過渡	guo4du4	guòdù	to cross a river by ferry; transition; interim
+过奖	過獎	guo4jiang3	guòjiǎng	praise excessively; flatter
+过滤	過濾	guo4lü4	guòlǜ	to filter; filter
+过失	過失	guo4shi1	guòshī	defect; fault
+过问	過問	guo4wen4	guòwèn	take an interest in; get involved with
+过瘾	過瘾	guo4yin3	guòyǐn	satisfy a craving; get a kick out of sth; do to one's heart's content
+过于	過于	guo4yu2	guòyú	too much; excessively
+嗨	嗨	hai1	hāi	hey/hi (loanword); oh; alas;
+海拔	海拔	hai3ba2	hǎibá	height above sea level; elevation
+海滨	海濱	hai3bin1	hǎibīn	shore; seaside
+含糊	含糊	han2hu	hánhu	unclear; vague; unsure
+含义	含義	han2yi4	hányì	implied meaning; connotation
+寒暄	寒暄	han2xuan1	hánxuān	exchanging conventional greetings; winter and summer
+罕见	罕見	han3jian4	hǎnjiàn	rare; rarely seen; peculiar
+捍卫	捍衛	han4wei4	hànwèi	defend; uphold; safeguard
+行列	行列	hang2lie4	hángliè	procession; ranks; queue
+航空	航空	hang2kong1	hángkōng	aviation
+航天	航天	hang2tian1	hángtiān	space flight
+航行	航行	hang2xing2	hángxíng	to sail; to fly
+毫米	毫米	hao2mi3	háomǐ	millimeter
+毫无	毫無	hao2 wu2	háo wú	not at all; completely without; not in the least
+豪迈	豪邁	hao2mai4	háomài	bold and generous; heroic
+号召	號召	hao4zhao4	hàozhào	call upon; summon; to appeal
+耗费	耗費	hao4fei4	hàofèi	waste; spend; consume
+呵	呵	he1	hē	breathe out; scold
+合并	合並	he2bing4	hébìng	merge; annex
+合成	合成	he2cheng2	héchéng	compound; synthesis; mixture
+合伙	合夥	he2huo3	héhuǒ	to make a partnership
+合算	合算	he2suan4	hésuàn	worthwhile; reckon up
+和蔼	和藹	he2'ai3	hé'ǎi	kindly; good-tempered; amiable
+和解	和解	he2jie3	héjiě	settlement; to become reconciled
+和睦	和睦	he2mu4	hémù	peaceful relations; harmonious
+和气	和氣	he2qi	héqi	friendly; polite; amiable
+和谐	和諧	he2xie2	héxié	harmonious; concordant
+嘿	嘿	hei1	hēi	hey; interjection for calling attention
+痕迹	痕迹	hen2ji4	hénjì	vestige; trace
+狠心	狠心	hen3 xin1	hěn xīn	callous; cruel; cold-blooded
+恨不得	恨不得	hen4 bu de	hèn bu de	cannot bear not; be dying to
+横	橫	heng2	héng	horizontal; across; (horizontal character stroke)
+哼	哼	heng1	hēng	groan; snort; to hum; croon
+轰动	轟動	hong1dong4	hōngdòng	a sensation; a stir
+烘	烘	hong1	hōng	to dry or warm by the fire; to bake; to heat by fire; to set off by contrast
+宏观	宏觀	hong2guan1	hóngguān	macro-; macroscopic
+宏伟	宏偉	hong2wei3	hóngwěi	grand; imposing; magnificent; grand
+洪水	洪水	hong2shui3	hóngshuǐ	flood
+哄	哄	hong3	hǒng	fool; coax; to amuse (a child)
+喉咙	喉嚨	hou2long2	hóulóng	throat; larynx
+吼	吼	hou3	hǒu	roar; howl
+后代	後代	hou4dai4	hòudài	posterity; later generations; descendants
+后顾之忧	後顧之憂	hou4gu4zhi1you1	hòugùzhīyōu	fears of trouble in the rear (idiom); family worries (obstructing freedom to act); trouble back at home; worries about the future consequences; often in negative expressions, meaning no worries about anything
+后勤	後勤	hou4qin2	hòuqín	logistics
+候选	候選	hou4xuan3	hòuxuǎn	candidate
+呼唤	呼喚	hu1huan4	hūhuàn	call out (a name etc.); shout
+呼啸	呼嘯	hu1xiao4	hūxiào	whistle; scream; howl
+呼吁	呼籲	hu1yu4	hūyù	call on (someone to do something); appeal
+忽略	忽略	hu1lüe4	hūlüè	ignore; forget about; neglect
+胡乱	胡亂	hu2luan4	húluàn	carelessly; recklessly
+胡须	胡須	hu2xu1	húxū	beard; moustache; whiskers
+湖泊	湖泊	hu2po1	húpō	lake
+花瓣	花瓣	hua1ban4	huābàn	petal
+花蕾	花蕾	hua1lei3	huālěi	(flower) bud
+华丽	華麗	hua2li4	huálì	gorgeous; magnificent
+华侨	華僑	hua2qiao2	huáqiáo	overseas Chinese
+化肥	化肥	hua4fei2	huàféi	chemical fertilizer
+化石	化石	hua4shi2	huàshí	fossil
+化验	化驗	hua4yan4	huàyàn	laboratory test; chemically examine
+化妆	化妝	hua4 zhuang1	huà zhuāng	put on make-up
+划分	劃分	hua4fen1	huàfēn	divide up; differentiate
+画蛇添足	畫蛇添足	hua4she2tian1zu2	huàshétiānzú	draw legs on a snake (idiom); to ruin something by adding something superfluous
+话筒	話筒	hua4tong3	huàtǒng	microphone; transmitter; megaphone
+欢乐	歡樂	huan1le4	huānlè	gaiety; glee; delighted
+还原	還原	huan2yuan2	huányuán	restore to the original state; (Chemistry) reduce
+环节	環節	huan2jie2	huánjié	link; sector; segment (of annelid worms)
+缓和	緩和	huan3he2	huǎnhé	alleviate; to moderate; to ease (tension)
+患者	患者	huan4zhe3	huànzhě	sufferer; patient; the sick
+荒凉	荒涼	huang1liang2	huāngliáng	desolate
+荒谬	荒謬	huang1miu4	huāngmiù	ridiculous; nonsensical
+荒唐	荒唐	huang1tang	huāngtang	beyond belief; preposterous; absurd; intemperate
+皇帝	皇帝	huang2di4	huángdì	emperor
+皇后	皇後	huang2hou4	huánghòu	an empress
+黄昏	黃昏	huang2hun1	huánghūn	dusk; evening; nightfall
+恍然大悟	恍然大悟	huang3ran2da4wu4	huǎngrándàwù	suddenly see the light; suddenly realize what has happened; twig
+晃	晃	huang4	huàng	to sway; to shake
+挥霍	揮霍	hui1huo4	huīhuò	squander money without restraint; squander
+辉煌	輝煌	hui1huang2	huīhuáng	splendid; glorious
+回报	回報	hui2bao4	huíbào	repayment; payback
+回避	回避	hui2bi4	huíbì	avoid; shun; evade
+回顾	回顧	hui2gu4	huígù	look back; to review
+回收	回收	hui2shou1	huíshōu	recycle; recover and put back to use
+悔恨	悔恨	hui3hen4	huǐhèn	remorse; repentance
+毁灭	毀滅	hui3mie4	huǐmiè	perish; ruin; destroy
+汇报	彙報	hui4bao4	huìbào	report; give an account of; to collect information and report back
+会晤	會晤	hui4wu4	huìwù	meet; meeting; conference
+贿赂	賄賂	hui4lu4	huìlù	to bribe
+昏迷	昏迷	hun1mi2	hūnmí	lose consciousness; be in a coma
+荤	葷	hun1	hūn	meat or fish dish; pungent vegetables forbidden to Buddhist vegetarians
+浑身	渾身	hun2shen1	húnshēn	entire body; from head to foot
+混合	混合	hun4he2	hùnhé	to mix; to blend
+混乱	混亂	hun4luan4	hùnluàn	confusion; chaotic
+混淆	混淆	hun4xiao2	hùnxiáo	obscure; confuse; mix up; blur; mislead; confusing
+混浊	混濁	hun4zhuo2	hùnzhuó	muddy; dirty; turbid
+活该	活該	huo2gai1	huógāi	serve sb. right; deservedly; ought
+活力	活力	huo2li4	huólì	energy; vitality; vigor
+火箭	火箭	huo3jian4	huǒjiàn	rocket
+火焰	火焰	huo3yan4	huǒyàn	blaze; flame
+火药	火藥	huo3yao4	huǒyào	gunpowder
+货币	貨幣	huo4bi4	huòbì	currency; money
+讥笑	譏笑	ji1xiao4	jīxiào	sneer at; deride
+饥饿	饑餓	ji1'e4	jī'è	hunger; hungry; starve
+机动	機動	ji1dong4	jīdòng	motorized; mobile; flexible
+机构	機構	ji1gou4	jīgòu	structure; organization; institution
+机灵	機靈	ji1ling	jīling	clever; quick-witted; smartness
+机密	機密	ji1mi4	jīmì	secret; classified (information)
+机械	機械	ji1xie4	jīxiè	machine; mechanical
+机遇	機遇	ji1yu4	jīyù	opportunity; stroke of good luck; favorable circumstance
+机智	機智	ji1zhi4	jīzhì	tact; quick-witted; resourceful
+基地	基地	ji1di4	jīdì	base (of operations)
+基金	基金	ji1jin1	jījīn	fund; endowment
+基因	基因	ji1yin1	jīyīn	gene
+激发	激發	ji1fa1	jīfā	to arouse; excite
+激励	激勵	ji1li4	jīlì	urge; encourage; motivation
+激情	激情	ji1qing2	jīqíng	passion; strong emotion; fervor; enthusiasm
+及早	及早	ji2zao3	jízǎo	as soon as possible; at the earliest possible time
+吉祥	吉祥	ji2xiang2	jíxiáng	lucky
+级别	級別	ji2bie2	jíbié	rank; level; grade
+极端	極端	ji2duan1	jíduān	extreme
+极限	極限	ji2xian4	jíxiàn	limit; extreme boundary
+即便	即便	ji2bian4	jíbiàn	even if; even though
+即将	即將	ji2jiang1	jíjiāng	will shortly; soon; be on the verge of
+急功近利	急功近利	ji2gong1jin4li4	jígōngjìnlì	eager for success and profit
+急剧	急劇	ji2ju4	jíjù	rapid; sudden
+急切	急切	ji2qie4	jíqiè	eager; impatient; imperative
+急于求成	急于求成	ji2yu2qiu2cheng2	jíyúqiúchéng	impatient for success
+急躁	急躁	ji2zao4	jízào	irritable; impetuous; impatient
+疾病	疾病	ji2bing4	jíbìng	disease; illness; sickness; ailment
+集团	集團	ji2tuan2	jítuán	group; bloc; circle; clique
+嫉妒	嫉妒	ji2du4	jídù	to be jealous; to envy, covet; to hate; to begrudge
+籍贯	籍貫	ji2guan4	jíguàn	place of one's ancestry
+给予	給予	ji3yu3	jǐyǔ	to give
+计较	計較	ji4jiao4	jìjiào	focus excessively on; haggle; bicker; argue
+记性	記性	ji4xing	jìxing	memory
+记载	記載	ji4zai3	jìzǎi	write down; to record
+纪要	紀要	ji4yao4	jìyào	written summary of a meeting; minutes
+技巧	技巧	ji4qiao3	jìqiǎo	skill; technique
+忌讳	忌諱	ji4hui4	jìhuì	avoid as a taboo; abstain from; taboo
+季度	季度	ji4du4	jìdù	(financial) quarter; period of three months
+季军	季軍	ji4jun1	jìjūn	third in a race; bronze medalist
+迹象	迹象	ji4xiang4	jìxiàng	mark; indication; sign
+继承	繼承	ji4cheng2	jìchéng	inherit; carry on; succeed
+寄托	寄托	ji4tuo1	jìtuō	entrust somebody someone's care; consign; commit
+寂静	寂靜	ji4jing4	jìjìng	quiet
+加工	加工	jia1 gong1	jiā gōng	to process; processing; machining
+加剧	加劇	jia1ju4	jiājù	aggravate; intensify; sharpen; accelerate
+夹杂	夾雜	jia1za2	jiāzá	mix together; have two dissimilar substances mixed together
+佳肴	佳肴	jia1yao2	jiāyáo	delicacy
+家常	家常	jia1chang2	jiācháng	the daily life of a family; home-style (food)
+家伙	家夥	jia1huo	jiāhuo	guy; chap; tool; weapon
+家属	家屬	jia1shu3	jiāshǔ	family member; a dependent
+家喻户晓	家喻戶曉	jia1 yu4 hu4 xiao3	jiā yù hù xiǎo	become a household name; well-known
+尖端	尖端	jian1duan1	jiānduān	highest peak; the tip; sharp pointed end; most advanced and sophisticated
+尖锐	尖銳	jian1rui4	jiānruì	sharp; intense; penetrating
+坚定	堅定	jian1ding4	jiāndìng	firm; staunch; resolute
+坚固	堅固	jiang1u4	jiāngù	firm; strong; sturdy
+坚韧	堅韌	jian1ren4	jiānrèn	tough and durable; hard-bitten; firm and tenacious
+坚实	堅實	jian1shi2	jiānshí	firm and substantial; solid
+坚硬	堅硬	jian1ying4	jiānyìng	hard; solid
+艰难	艱難	jian1nan2	jiānnán	difficult; arduous
+监督	監督	jian1du1	jiāndū	control; monitor; supervise; inspect
+监视	監視	jian1shi4	jiānshì	oversee; to monitor
+监狱	監獄	jian1yu4	jiānyù	prison; jail
+煎	煎	jian1	jiān	pan-fry; fry in shallow oil
+拣	揀	jian3	jiǎn	choose; select; sort out
+检讨	檢討	jian3tao3	jiǎntǎo	self-criticism; analyze
+检验	檢驗	jian3yan4	jiǎnyàn	inspect; examine; to test
+剪彩	剪彩	jian3 cai3	jiǎn cǎi	cut the ribbon at an opening ceremony
+简化	簡化	jian3hua4	jiǎnhuà	simplify; simplification
+简陋	簡陋	jian3lou4	jiǎnlòu	simple and crude (i.e. room or building)
+简体字	簡體字	jian3ti3zi4	jiǎntǐzì	simplified Chinese characters
+简要	簡要	jian3yao4	jiǎnyào	concise; brief
+见多识广	見多識廣	jian4duo1shi2guang3	jiànduōshíguǎng	experienced and knowledgeable
+见解	見解	jian4jie3	jiànjiě	view; opinion; understanding
+见闻	見聞	jian4wen2	jiànwén	information
+见义勇为	見義勇爲	jian4yi4yong3wei2	jiànyìyǒngwéi	to see what is right and act courageously (idiom, from Analects); to stand up bravely for the truth; acting heroically in a just cause
+间谍	間諜	jian4die2	jiàndié	a spy; intelligence agent
+间隔	間隔	jiang4e2	jiàngé	interval; intermission; gap; be separated
+间接	間接	jian4jie1	jiànjiē	indirect
+剑	劍	jian4	jiàn	sword
+健全	健全	jian4quan2	jiànquán	Perfect; sound; to perfect/strengthen/amplify
+舰艇	艦艇	jian4ting3	jiàntǐng	warship; naval vessel
+践踏	踐踏	jian4ta4	jiàntà	trample
+溅	濺	jian4	jiàn	to splash
+鉴别	鑒別	jian4bie2	jiànbié	differentiate; distinguish
+鉴定	鑒定	jian4ding4	jiàndìng	appraise; identify; evaluate
+鉴于	鑒于	jian4yu2	jiànyú	in light of; in view of; seeing that
+将近	將近	jiang1jin4	jiāngjìn	almost; nearly; close to
+将就	將就	jiang1jiu	jiāngjiu	put up with; accept somewhat reluctantly
+将军	將軍	jiang1jun1	jiāngjūn	a general (military officer)
+僵硬	僵硬	jiang1ying4	jiāngyìng	stiff
+奖励	獎勵	jiang3li4	jiǎnglì	to reward (as encouragement)
+奖赏	獎賞	jiang3shang3	jiǎngshǎng	to reward
+桨	槳	jiang3	jiǎng	oar; paddle
+降临	降臨	jiang4lin2	jiànglín	befall; descend
+交叉	交叉	jiao1cha1	jiāochā	cross; intersect
+交代	交代	jiao1dai4	jiāodài	explain; account for; hand over
+交涉	交涉	jiao1she4	jiāoshè	negotiate; discuss a matter with the opposing side
+交易	交易	jiao1yi4	jiāoyì	business transaction; deal; trade
+娇气	嬌氣	jiao1qi4	jiāoqì	delicate; effeminate; squeamish
+焦点	焦點	jiao1dian3	jiāodiǎn	focus; focal point
+焦急	焦急	jiao1ji2	jiāojí	anxiety; worried
+角落	角落	jiao3luo4	jiǎoluò	corner; nook
+侥幸	僥幸	jiao3xing4	jiǎoxìng	by luck; by a fluke
+搅拌	攪拌	jiao3ban4	jiǎobàn	stir; mix up
+缴纳	繳納	jiao3na4	jiǎonà	to pay (taxes)
+较量	較量	jiao4liang4	jiàoliàng	competition; to have a contest with sb.
+教养	教養	jiao4yang3	jiàoyǎng	upbringing; education; bring up; nurture and train
+阶层	階層	jie1ceng2	jiēcéng	hierarchy
+皆	皆	jie1	jiē	all; each and every; in all cases
+接连	接連	jie1lian2	jiēlián	one after another; in a row; in succession
+揭露	揭露	jie1lu4	jiēlù	expose; unmask
+节制	節制	jie2zhi4	jiézhì	to be restrained or moderate
+节奏	節奏	jie2zou4	jiézòu	rhythm; cadence; tempo
+杰出	傑出	jie2chu1	jiéchū	outstanding; preeminent
+结晶	結晶	jie2jing1	jiéjīng	a crystal; to crystallize
+结局	結局	jie2ju2	jiéjú	conclusion; ending
+结算	結算	jie2suan4	jiésuàn	settle up the bill; close an account
+截止	截止	jie2zhi3	jiézhǐ	end; close; stop; expiration
+截至	截至	jie2zhi4	jiézhì	up until; by (a specified time
+竭尽全力	竭盡全力	jie2jin4 quan2li4	jiéjìn quánlì	to spare no efforts; do one's utmost
+解除	解除	jie3chu2	jiěchú	remove; relieve (someone of their duties); sack; get rid of
+解放	解放	jie3fang4	jiěfàng	liberate
+解雇	解雇	jie3gu4	jiěgù	fire; lay off; dismiss from
+解剖	解剖	jie3pou1	jiěpōu	dissect; analyze; anatomy
+解散	解散	jie3san4	jiěsàn	dismiss; dissolve; disband
+解体	解體	jie3ti3	jiětǐ	disintegrate
+戒备	戒備	jie4bei4	jièbèi	take precautions; be on the alert
+界限	界限	jie4xian4	jièxiàn	boundary; marginal; limit
+借鉴	借鑒	jie4jian4	jièjiàn	take example by; use other people's experience
+借助	借助	jie4zhu4	jièzhù	get help from
+金融	金融	jin1rong2	jīnróng	banking finance; financial
+津津有味	津津有味	jin1jin1 you3 wei4	jīnjīn yǒu wèi	(saying) with gusto; eagerly; with great interest
+紧迫	緊迫	jin3po4	jǐnpò	urgent; urgency
+锦上添花	錦上添花	jin3shang4tian1hua1	jǐnshàngtiānhuā	lit. on brocade, add flowers (idiom); to decorate sth already perfect / gilding the lily
+进而	進而	jin4'er2	jìn'ér	and then (what follows next)
+进攻	進攻	jing4ong1	jìngōng	attack (military); assault
+进化	進化	jin4hua4	jìnhuà	evolution
+进展	進展	jin4zhan3	jìnzhǎn	make progress; development; make headway
+近来	近來	jin4lai2	jìnlái	recently; lately
+晋升	晉升	jin4sheng1	jìnshēng	promote to a higher position
+浸泡	浸泡	jin4pao4	jìnpào	to soak
+茎	莖	jing1	jīng	stalk; stem
+经费	經費	jing1fei4	jīngfèi	funds; expenses
+经纬	經緯	jing1wei3	jīngwěi	warp and woof; longitude and latitude; main points
+惊动	驚動	jing1dong4	jīngdòng	alarm; alert; startle; disturb
+惊奇	驚奇	jing1qi2	jīngqí	amaze; astonished
+惊讶	驚訝	jing1ya4	jīngyà	surprised; astonished; astound
+兢兢业业	兢兢業業	jing1jing1 ye4ye4	jīngjīng yèyè	cautious and conscientious
+精打细算	精打細算	jing1 da3 xi4 suan4	jīng dǎ xì suàn	(saying) meticulous planning and careful accounting
+精华	精華	jing1hua2	jīnghuá	elite; best feature; most important part of an object; essence; quintessence
+精简	精簡	jing1jian3	jīngjiǎn	simplify; reduce
+精密	精密	jing1mi4	jīngmì	accuracy; exact; precise; refined
+精确	精確	jing1que4	jīngquè	accurate; precise
+精通	精通	jing1tong1	jīngtōng	proficient; have a good command of
+精心	精心	jing1xin1	jīngxīn	with utmost care; meticulous; detailed
+精益求精	精益求精	jing1 yi4 qiu2 jing1	jīng yì qiú jīng	(saying) improving and wanting to improve even more
+精致	精致	jing1zhi4	jīngzhì	exquisite; delicate; refined
+井	井	jing3	jǐng	a well
+颈椎	頸椎	jing3zhui1	jǐngzhuī	cervical vertebra; the seven cervical vertebrae in the neck of humans and most mammals
+警告	警告	jing3gao4	jǐnggào	to warn; admonish
+警惕	警惕	jing3ti4	jǐngtì	vigilant; alert; be on guard
+竞赛	競賽	jing4sai4	jìngsài	race; contest; competition
+竞选	競選	jing4xuan3	jìngxuǎn	run for (electoral) office; take part in an election
+敬礼	敬禮	jing4li3	jìnglǐ	to salute; best regards
+敬业	敬業	jing4ye4	jìngyè	work ethic
+境界	境界	jing4jie4	jìngjiè	boundary; state; realm; level
+镜头	鏡頭	jing4tou2	jìngtóu	camera shot (in a movie, etc.); scene; camera lens
+纠纷	糾紛	jiu1fen1	jiūfēn	dispute; quarrel
+纠正	糾正	jiu1zheng4	jiūzhèng	to correct; to make right
+酒精	酒精	jiu3jing1	jiǔjīng	alcohol; ethanol
+救济	救濟	jiu4ji4	jiùjì	emergency relief; aid; help out in a disaster
+就近	就近	jiu4jin4	jiùjìn	nearby; in a close neighborhood
+就业	就業	jiu4ye4	jiùyè	employment; getting a job
+就职	就職	jiu4 zhi2	jiù zhí	take office; assume a post
+拘留	拘留	ju1liu2	jūliú	detain (a prison); keep (someone) in custody
+拘束	拘束	ju1shu4	jūshù	restrict; constrained; ill at ease; reticent
+居民	居民	ju1min2	jūmín	resident; inhabitant
+居住	居住	ju1zhu4	jūzhù	reside; dwell; to live (in a place)
+鞠躬	鞠躬	ju1gong1	jūgōng	to bow
+局部	局部	ju2bu4	júbù	part; local
+局面	局面	ju2mian4	júmiàn	aspect; situation
+局势	局勢	ju2shi4	júshì	situation; state (of affairs)
+局限	局限	ju2xian4	júxiàn	to limit; confine; restrict or confine sth.
+咀嚼	咀嚼	ju3jue2	jǔjué	to chew
+沮丧	沮喪	ju3sang4	jǔsàng	dejected; depressed; dispirited
+举动	舉動	ju3dong4	jǔdòng	action; act; (make) a move; movement
+举世瞩目	舉世矚目	ju3shi4 zhu3mu4	jǔshì zhǔmù	attract worldwide attention
+举足轻重	舉足輕重	ju3zu2qing1zhong4	jǔzúqīngzhòng	a foot's move sways the balance; hold the balance of power; play a key role
+剧本	劇本	ju4ben3	jùběn	script for a play; opera; movie; etc
+剧烈	劇烈	ju4lie4	jùliè	acute; violent; severe
+据悉	據悉	ju4xi1	jùxī	according to reports; it is reported (that)
+聚精会神	聚精會神	ju4 jing1 hui4 shen2	jù jīng huì shén	concentrate one's attention
+卷	卷	juan3	juǎn	to roll (up); to coil; (mw for tapes)
+决策	決策	jue2ce4	juécè	Make policy; make strategic decision
+觉悟	覺悟	jue2wu4	juéwù	consciousness; awareness; (Buddhist) enlightenment
+觉醒	覺醒	jue2xing3	juéxǐng	awaken; arousal; realize
+绝望	絕望	jue2 wang4	jué wàng	desperation; forlorn; hopeless
+倔强	倔強	jue2jiang4	juéjiàng	stubborn; unbending
+军队	軍隊	jun1dui4	jūnduì	army troops
+君子	君子	jun1zi3	jūnzǐ	gentleman; man of noble character
+卡通	卡通	ka3tong1	kǎtōng	cartoon
+开采	開采	kai1cai3	kāicǎi	extract ore or some other natural resource from a mine
+开除	開除	kai1chu2	kāichú	expel; to discharge; to kick out
+开阔	開闊	kai1kuo4	kāikuò	wide; open (spaces)
+开朗	開朗	kai1lang3	kāilǎng	outgoing and cheerful; optimistic; carefree; spacious and well-lit
+开明	開明	kai1ming2	kāimíng	enlightened; open-minded
+开辟	開辟	kai1pi4	kāipì	open up; to start; to build
+开拓	開拓	kai1tuo4	kāituò	break new ground (for agriculture); development
+开展	開展	kai1zhan3	kāizhǎn	begin to develop; to launch
+开支	開支	kai1zhi1	kāizhī	expenditures; pay; expenses
+刊登	刊登	kan1deng1	kāndēng	publish in a newspaper; carry a story
+刊物	刊物	kan1wu4	kānwù	publication; periodical; journal
+勘探	勘探	kan1tan4	kāntàn	exploration
+侃侃而谈	侃侃而談	kan3kan3'er2tan2	kǎnkǎn'értán	speak frankly and in measured tones; argue about leisurely and boldly
+砍伐	砍伐	kan3fa2	kǎnfá	cut down; lop; hew (as a tree)
+看待	看待	kan4dai4	kàndài	look upon; regard
+慷慨	慷慨	kang1kai3	kāngkǎi	vehement; fervent; generous
+扛	扛	kang2	káng	to carry on one's shoulder
+抗议	抗議	kang4yi4	kàngyì	to protest; protest
+考察	考察	kao3cha2	kǎochá	inspect; investigate; analyze
+考古	考古	kao3gu3	kǎogǔ	archaeology
+考核	考核	kao3he2	kǎohé	examine; check up on
+考验	考驗	kao3yan4	kǎoyàn	put to the test; trial
+靠拢	靠攏	kao4long3	kàolǒng	draw close; close up; move up
+科目	科目	ke1mu4	kēmù	(school) subject
+磕	磕	ke1	kē	knock; tap
+可观	可觀	ke3guan1	kěguān	considerable; impressive
+可口	可口	ke3kou3	kěkǒu	tasty; taste good
+可恶	可惡	ke3wu4	kěwù	hateful; abominable; repulsive
+可行	可行	ke3xing2	kěxíng	feasible
+渴望	渴望	ke3wang4	kěwàng	wishful; to yearn for; desire
+克制	克制	ke4zhi4	kèzhì	restrain; take a firm hold on
+刻不容缓	刻不容緩	ke4bu4rong2huan3	kèbùrónghuǎn	demand immediate action; brook no delay
+客户	客戶	ke4hu4	kèhù	customer; account; client
+课题	課題	ke4ti2	kètí	task; problem; issue; question for discussion
+恳切	懇切	ken3qie4	kěnqiè	earnest; genuine; fair-spoken
+啃	啃	ken3	kěn	gnaw; nibble; bite
+坑	坑	keng1	kēng	pit; hole; defraud
+空洞	空洞	kong1dong4	kōngdòng	empty; hollow; vacuous; devoid of content
+空前绝后	空前絕後	kong1qian2jue2hou4	kōngqiánjuéhòu	unprecedented and unrepeatable; never to be reduplicated; the first and the last; unmatched; unique
+空想	空想	kong1xiang3	kōngxiǎng	daydream; fantasy
+空虚	空虛	kong1xu1	kōngxū	hollow; emptiness; meaningless
+孔	孔	kong3	kǒng	hole
+恐怖	恐怖	kong3bu4	kǒngbù	afraid; terror
+恐吓	恐嚇	kong3he4	kǒnghè	to threaten
+恐惧	恐懼	kong3ju4	kǒngjù	fear; dread; phobia
+空白	空白	kong4bai2	kòngbái	blank space; blank
+空隙	空隙	kong4xi4	kòngxì	crack; gap between two objects
+口气	口氣	kou3qi4	kǒuqì	tone of voice; manner of speaking
+口腔	口腔	kou3qiang1	kǒuqiāng	space inside mouth (oral cavity)
+口头	口頭	kou3tou2	kǒutóu	oral; verbal
+口音	口音	kou3yin1	kǒuyīn	accent
+扣	扣	kou4	kòu	to fasten; to button; button; buckle; knot; to arrest; to confiscate; to deduct (money); discount; to knock; put upside down; to smash or spike (a ball); to cover (with a bowl etc); fig. to tag a label on sb
+枯萎	枯萎	ku1wei3	kūwěi	wither; withered
+枯燥	枯燥	ku1zao4	kūzào	dry and dull; uninteresting
+哭泣	哭泣	ku1qi4	kūqì	weep; cry; sob
+苦尽甘来	苦盡甘來	ku3jing4an1lai2	kǔjìngānlái	sweetness comes after bitterness; the hard times are over and the good times are just beginning
+苦涩	苦澀	ku3se4	kǔsè	bitter and astringent; pained; agonized; anguished
+挎	挎	kua4	kuà	carry over one's shoulder or slung on one's side
+跨	跨	kua4	kuà	step across; stride; straddle; to cross
+快活	快活	kuai4huo	kuàihuo	happy; cheerful
+宽敞	寬敞	kuan1chang	kuānchang	spacious; commodious
+宽容	寬容	kuan1rong2	kuānróng	tolerant; lenient
+款待	款待	kuan3dai4	kuǎndài	to entertain (guests)
+款式	款式	kuan3shi4	kuǎnshì	pattern; design; style
+筐	筐	kuang1	kuāng	basket
+旷课	曠課	kuang4 ke4	kuàng kè	cut school; be truant from school
+况且	況且	kuang4qie3	kuàngqiě	moreover; besides; in addition
+矿产	礦産	kuang4chan3	kuàngchǎn	minerals
+框架	框架	kuang4jia4	kuàngjià	frame; framework; skeleton
+亏待	虧待	kui1dai4	kuīdài	treat sb. unfairly
+亏损	虧損	kui1sun3	kuīsǔn	deficit; (financial) loss
+捆绑	捆綁	kun3bang3	kǔnbǎng	tie up; bundled
+扩充	擴充	kuo4chong1	kuòchōng	expand; extend
+扩散	擴散	kuo4san4	kuòsàn	spread; proliferation
+扩张	擴張	kuo4zhang1	kuòzhāng	expansion; extension
+喇叭	喇叭	la3ba	lǎba	horn; trumpet; loudspeaker
+蜡烛	蠟燭	la4zhu2	làzhú	candle
+啦	啦	la	la	sentence-final particle: a contraction of 了 (le) and 啊 (a)
+来历	來曆	lai2li4	láilì	history; antecedents; origin
+来源	來源	lai2yuan2	láiyuán	source; originate
+栏目	欄目	lan2mu4	lánmù	column (in a newspaper,TV,etc)
+懒惰	懶惰	lan3duo4	lǎnduò	lazy; idle
+狼狈	狼狽	lang2bei4	lángbèi	in a difficult position or situation; in a tight corner; scoundrel! (derogatory)
+狼吞虎咽	狼吞虎咽	lang2tun1hu3yan4	lángtūnhǔyàn	wolf down one's food (idiom); gorge oneself
+捞	撈	lao1	lāo	dredge up; fish up
+牢固	牢固	lao2gu4	láogù	firm; secure; solid
+牢骚	牢騷	lao2sao1	láosāo	grumble; complaint
+唠叨	唠叨	lao2dao	láodao	be talkative (especially about trivial matters); be garrulous; prattle
+乐趣	樂趣	le4qu4	lèqù	delight; pleasure; joy; fun
+乐意	樂意	le4yi4	lèyì	be happy/willing do something; content; satisfied
+雷达	雷達	lei2da2	léidá	radar
+类似	類似	lei4si4	lèisì	similar; analogous
+冷酷	冷酷	leng3ku4	lěngkù	grim; unfeeling; callous
+冷落	冷落	leng3luo4	lěngluò	to treat somebody coldy; to snub; desolate; to give the cold shoulder
+冷却	冷卻	leng3que4	lěngquè	cooling; cool off
+愣	愣	leng4	lèng	dumbfounded; stupefied; distracted; (spoken) blunt; rash
+黎明	黎明	li2ming2	límíng	dawn; daybreak
+礼节	禮節	li3jie2	lǐjié	etiquette; proprieties; festival
+礼尚往来	禮尚往來	li3shang4wang3lai2	lǐshàngwǎnglái	courtesy requires reciprocity
+里程碑	裏程碑	li3cheng2bei1	lǐchéngbēi	milestone
+理睬	理睬	li3cai3	lǐcǎi	heed; pay attention to (usually used in the negative)
+理所当然	理所當然	li3 suo3 dang1 ran2	lǐ suǒ dāng rán	(idiom) it goes without saying; certainly; of course; be natural and right
+理直气壮	理直氣壯	li3zhi2qi4zhuang4	lǐzhíqìzhuàng	with justice on one's side, one is bold and assured; to have the courage of ones convictions; just and forceful
+理智	理智	li3zhi4	lǐzhì	reason; intellect; rational
+力求	力求	li4qiu2	lìqiú	make every effort; do one's best
+力所能及	力所能及	li4suo3neng2ji2	lìsuǒnéngjí	within one's power; to the best of one's ability
+力争	力爭	li4zheng1	lìzhēng	work hard; do all one can to; strive for/argue strongly
+历代	曆代	li4dai4	lìdài	successive dynasties; past dynasties
+历来	曆來	li4lai2	lìlái	always; throughout (a period of time)
+立场	立場	li4chang3	lìchǎng	position; standpoint
+立方	立方	li4fang1	lìfāng	cube; (mw cubic units of measure)
+立交桥	立交橋	li4jiao1qiao2	lìjiāoqiáo	overpass; one road goes on top of another; cloverleaf intersection
+立体	立體	li4ti3	lìtǐ	solid; three dimensional
+立足	立足	li4zu2	lìzú	base oneself on; be established; have a footing
+利害	利害	li4hai	lìhai	serious; formidable; devastating; (-hài: advantages and disadvantages)
+例外	例外	li4wai4	lìwài	(make an) exception
+粒	粒	li4	lì	a grain; granule; (mw for grain-like things)
+连年	連年	lian2nian2	liánnián	successive years; over many years; once again this year
+连锁	連鎖	lian2suo3	liánsuǒ	chain (store etc); to interlock
+连同	連同	lian2tong2	liántóng	together with; along with
+联欢	聯歡	lian2huan1	liánhuān	have a get-together
+联络	聯絡	lian2luo4	liánluò	communication; to contact
+联盟	聯盟	lian2meng2	liánméng	alliance; union; coalition
+联想	聯想	lian2xiang3	liánxiǎng	to associate (cognitively); to make an associative connection; mental association; word prediction and auto-complete functions of input method editing programs; abbr. for 联想集团 Lenovo Group (PRC computer firm)
+廉洁	廉潔	lian2jie2	liánjié	honest; incorruptible
+良心	良心	liang2xin1	liángxīn	conscience
+谅解	諒解	liang4jie3	liàngjiě	understanding; make an allowance for; forgive
+晾	晾	liang4	liàng	dry in the air/sun; (colloquial) snub or ignore
+辽阔	遼闊	liao2kuo4	liáokuò	vast; extensive
+列举	列舉	lie4ju3	lièjǔ	make a list; enumerate
+临床	臨床	lin2chuang2	línchuáng	clinical
+淋	淋	lin2	lín	to drain; to drip; drench
+吝啬	吝啬	lin4se4	lìnsè	stingy; mean; miserly
+伶俐	伶俐	ling2li4	línglì	clever; witty; intelligent
+灵感	靈感	ling2gan3	línggǎn	inspiration; insight; a burst of creativity in scientific or artistic endeavor
+灵魂	靈魂	ling2hun2	línghún	soul; spirit; conscience
+灵敏	靈敏	ling2min3	língmǐn	sensitive
+凌晨	淩晨	ling2chen2	língchén	early in the morning
+零星	零星	ling2xing1	língxīng	partial; scattered; fragmentary
+领会	領會	ling3hui4	lǐnghuì	understand; comprehend; grasp
+领事馆	領事館	ling3shi4guan3	lǐngshìguǎn	consulate
+领土	領土	ling3tu3	lǐngtǔ	territory
+领悟	領悟	ling3wu4	lǐngwù	comprehend; grasp; fathom
+领先	領先	ling3xian1	lǐngxiān	leadership; to lead; be in front
+领袖	領袖	ling3xiu4	lǐngxiù	leader
+溜	溜	liu1	liū	slip away; to skate; to glide
+留恋	留戀	liu2lian4	liúliàn	be reluctant to leave
+留念	留念	liun2ian4	liúniàn	to keep as a souvenir
+留神	留神	liu2 shen2	liú shén	(idiom) take care to ...; be careful of ...
+流浪	流浪	liu2lang4	liúlàng	drift about; wander
+流露	流露	liu2lu4	liúlù	express; reveal (one's thoughts or feelings)
+流氓	流氓	liu2mang2	liúmáng	rogue; hooligan; gangster
+流通	流通	liu2tong1	liútōng	circulate; currency
+聋哑	聾啞	long2ya3	lóngyǎ	deaf and dumb; deaf-mute
+隆重	隆重	long2zhong4	lóngzhòng	grand; prosperous; ceremonious
+垄断	壟斷	long3duan4	lǒngduàn	monopoly
+笼罩	籠罩	long3zhao4	lǒngzhào	envelop; to shroud; be masked by
+搂	摟	lou3	lǒu	to hug; to embrace
+炉灶	爐竈	lu2zao4	lúzào	kitchen range; cooking range; stovetop range
+屡次	屢次	lü3ci4	lǚcì	repeatedly; time and again; frequently
+履行	履行	lü3xing2	lǚxíng	fulfill (one's obligations); carry out
+掠夺	掠奪	lüe4duo2	lüèduó	to plunder; rob; pillage
+轮船	輪船	lun2chuan2	lúnchuán	steamship
+轮廓	輪廓	lun2kuo4	lúnkuò	outline; silhouette
+轮胎	輪胎	lun2tai1	lúntāi	tire (of a wheel)
+论坛	論壇	lun4tan2	lùntán	forum
+论证	論證	lun4zheng4	lùnzhèng	prove a point; expound on; argumentation
+啰唆	啰唆	luo1suo	luōsuo	long-winded; wordy; troublesome; pesky
+络绎不绝	絡繹不絕	luo4yi4bu4jue2	luòyìbùjué	endless stream
+落成	落成	luo4cheng2	luòchéng	complete a construction project
+落实	落實	luo4shi2	luòshí	workable; implement
+麻痹	麻痹	ma2bi4	mábì	paralysis; palsy; numbness
+麻木	麻木	ma2mu4	mámù	numb
+麻醉	麻醉	ma2zui4	mázuì	anesthesia
+码头	碼頭	ma3tou	mǎtou	dock; wharf
+蚂蚁	螞蟻	ma3yi3	mǎyǐ	ant
+嘛	嘛	ma, ma2	ma, má	(used to persuade somebody to do something); (particle indicating obviousness) | (colloqial) what?
+埋伏	埋伏	mai2fu	máifu	ambush; lie in ambush
+埋没	埋沒	mai2mo4	máimò	oblivion; bury; neglect
+埋葬	埋葬	mai2zang4	máizàng	bury
+迈	邁	mai4	mài	to step; stride
+脉搏	脈搏	mai4bo2	màibó	pulse; throbbing
+埋怨	埋怨	man2yuan4	mányuàn	complain; blame; connotes sb or sth is to blame
+蔓延	蔓延	man4yan2	mànyán	extend; spread; to creep
+漫长	漫長	man4chang2	màncháng	very long; endless
+漫画	漫畫	man4hua4	mànhuà	comics; manga
+慢性	慢性	man4xing4	mànxìng	slow and patient; chronic (disease)
+忙碌	忙碌	mang2lu4	mánglù	be busy; bustling
+盲目	盲目	mang2mu4	mángmù	blindness; aimless
+茫茫	茫茫	mang2mang2	mángmáng	boundless; vast and obscure
+茫然	茫然	mang2ran2	mángrán	unseeing; ignorant; have no knowledge of sth.
+茂盛	茂盛	mao4sheng4	màoshèng	exuberance; luxuriant
+冒充	冒充	mao4chong1	màochōng	pretend to be (somebody or something else); pass (somebody or something) off as; impersonate
+冒犯	冒犯	mao4fan4	màofàn	to offend
+枚	枚	mei2	méi	(mw for coins, rings, medals)
+媒介	媒介	mei2jie4	méijiè	media; medium
+美观	美觀	mei3guan1	měiguān	pleasing to the eye; beautiful; artistic
+美满	美滿	mei3man3	měimǎn	happy; blissful
+美妙	美妙	mei3miao4	měimiào	beautiful (when describing a work of art); wonderful; splendid
+萌芽	萌芽	meng2ya2	méngyá	sprout; bud; germ of a plant
+猛烈	猛烈	meng3lie4	měngliè	fierce; violent
+眯	眯	mi1	mī	to squint; to take a nap
+弥补	彌補	mi2bu3	míbǔ	make up for a deficiency; remedy; offset
+弥漫	彌漫	mi2man4	mímàn	fill the air; permeate; to suffuse
+迷惑	迷惑	mi2huo4	míhuò	to puzzle; confuse; mystify
+迷人	迷人	mi2ren2	mírén	charming; enchanting; cute
+迷信	迷信	mi2xin4	míxìn	superstition; be superstitious
+谜语	謎語	mi2yu3	míyǔ	riddle; conundrum
+密度	密度	mi4du4	mìdù	density; thickness; consistency
+密封	密封	mi4feng1	mìfēng	seal up; pressurize
+棉花	棉花	mian2hua	miánhua	cotton
+免得	免得	mian3de	miǎnde	so as not to; so as to avoid
+免疫	免疫	mian3yi4	miǎnyì	immune
+勉励	勉勵	mian3li4	miǎnlì	encourage
+勉强	勉強	mian3qiang3	miǎnqiǎng	reluctantly; grudgingly; force sb. to do sth.
+面貌	面貌	mian4mao4	miànmào	appearance; looks; features
+面子	面子	mian4zi	miànzi	honor; reputation; prestige; face
+描绘	描繪	miao2hui4	miáohuì	describe; portray
+瞄准	瞄准	miao2zhun3	miáozhǔn	take aim (a weapon at a target)
+渺小	渺小	miao3xiao3	miǎoxiǎo	tiny; minute; negligible
+藐视	藐視	miao3shi4	miǎoshì	treat with contempt
+灭亡	滅亡	mie4wang2	mièwáng	be destroyed; perish; exterminate; become extinct
+蔑视	蔑視	mie4shi4	mièshì	despise; loathe; disparage; scorn
+民间	民間	min2jian1	mínjiān	among the people; popular; folk
+民主	民主	min2zhu3	mínzhǔ	democracy
+敏捷	敏捷	min3jie2	mǐnjié	nimble; agile; shrewd
+敏锐	敏銳	min3rui4	mǐnruì	keen; sharp; acute; brisk
+名次	名次	ming2ci4	míngcì	position in a ranking of names
+名额	名額	ming2'e2	míng'é	particular number of people; quota
+名副其实	名副其實	ming2 fu4 qi2 shi2	míng fù qí shí	not just in name only; but also in reality
+名誉	名譽	ming2yu4	míngyù	fame; reputation; honor; honorary
+明明	明明	ming2ming2	míngmíng	obviously; plainly; undoubtedly
+明智	明智	ming2zhi4	míngzhì	wise
+命名	命名	ming4ming2	mìngmíng	give a name; to dub; christen; naming
+摸索	摸索	mo1suo3	mōsuǒ	feel about; grope around; fumble
+模范	模範	mo2fan4	mófàn	model; exemplar
+模式	模式	mo2shi4	móshì	model; pattern; method
+模型	模型	mo2xing2	móxíng	model; mould; matrix; pattern
+膜	膜	mo2	mó	membrane; film
+摩擦	摩擦	mo2ca1	mócā	friction; clash (between two parties); conflict
+磨合	磨合	mo2he2	móhé	adapt gradually to each other; to consult; break in; wear in
+魔鬼	魔鬼	mo2gui3	móguǐ	devil; demon; monster
+魔术	魔術	mo2shu4	móshù	magic
+抹杀	抹殺	mo3sha1	mǒshā	write off; erase; remove from evidence
+莫名其妙	莫名其妙	mo4ming2qi2miao4	mòmíngqímiào	odd; baffling; unaccountable
+墨水儿	墨水兒	mo4shui3er	mòshuǐer	ink
+默默	默默	mo4mo4	mòmò	in silence; not speaking
+谋求	謀求	mou2qiu2	móuqiú	seek; strive for; try to get
+模样	模樣	mu2yang4	múyàng	appearance; form; approximation
+母语	母語	mu3yu3	mǔyǔ	native/mother tongue
+目睹	目睹	mu4du3	mùdǔ	witness; see first hand
+目光	目光	mu4guang1	mùguāng	sight; vision; view
+沐浴	沐浴	mu4yu4	mùyù	take a bath; revel; immerse
+拿手	拿手	na2shou3	náshǒu	good at; adept
+纳闷儿	納悶兒	na4 men4r	nà mènr	feel puzzled; bewildered
+耐用	耐用	nai4yong4	nàiyòng	durable
+南辕北辙	南轅北轍	nan2yuan2bei3zhe2	nányuánběizhé	at odds with; act in a way that defeats one's purpose
+难得	難得	nan2de2	nándé	hard to come by; difficult to get; rare
+难堪	難堪	nan2kan1	nánkān	hard to take; endure; embarrassed
+难能可贵	難能可貴	nan2neng2ke3gui4	nánnéngkěguì	estimable; extremely good
+恼火	惱火	nao3huo3	nǎohuǒ	get angry; irritated; annoy
+内涵	內涵	nei4han2	nèihán	connotation
+内幕	內幕	nei4mu4	nèimù	inside story; non-public information; behind the scenes
+内在	內在	nei4zai4	nèizài	intrinsic; innate
+能量	能量	neng2liang4	néngliàng	energy; capabilities
+拟定	擬定	ni3ding4	nǐdìng	make an initial draft; draw up
+逆行	逆行	ni4xing2	nìxíng	go/drive against the traffic; go in the wrong direction; regress; retrograde
+年度	年度	nian2du4	niándù	year (e.g. school year, fiscal year, etc.); annual
+捏	捏	nie1	niē	to pinch (with one's fingers); knead
+凝固	凝固	ning2gu4	nínggù	curdle; freeze; solidify; congeal
+凝聚	凝聚	ning2ju4	níngjù	agglomeration; agglomerate; cohesion; coherence
+凝视	凝視	ning2shi4	níngshì	gaze; stare
+拧	擰	ning2	níng	wring; to pinch
+宁肯	甯肯	ning4ken3	nìngkěn	would rather ...; it would be better
+宁愿	甯願	ning4yuan4	nìngyuàn	would rather; better
+扭转	扭轉	niu3zhuan3	niǔzhuǎn	to reverse; turn around (an undesirable situation)
+纽扣儿	紐扣兒	niu3kou4r	niǔkòur	button
+农历	農曆	nong2li4	nónglì	agricultural calendar; lunar calendar
+浓厚	濃厚	nong2hou4	nónghòu	dense; thick (fog, clouds, etc.)
+奴隶	奴隸	nu2li4	núlì	slave
+虐待	虐待	nüe4dai4	nüèdài	to abuse; maltreat; tyrannize
+挪	挪	nuo2	nuó	shift; move
+哦	哦	o4	ò	oh (indicates understanding)
+殴打	毆打	ou1da3	ōudǎ	beat up; hit
+呕吐	嘔吐	ou3tu4	ǒutù	to vomit; retch; nausea
+偶像	偶像	ou3xiang4	ǒuxiàng	Idol
+趴	趴	pa1	pā	lie on one's stomach
+排斥	排斥	pai2chi4	páichì	to reject; repulse; exclude
+排除	排除	pai2chu2	páichú	eliminate; get rid of; remove
+排放	排放	pai2fang4	páifàng	to discharge; emit
+排练	排練	pai2lian4	páiliàn	to rehearse
+徘徊	徘徊	pai2huai2	páihuái	pace back and forth; hesitate; waver
+派别	派別	pai4bie2	pàibié	denomination; group; school; faction; school of thought; sect
+派遣	派遣	pai4qian3	pàiqiǎn	send (on a mission); dispatch
+攀登	攀登	pan1deng1	pāndēng	to climb; clamber; to pull oneself up
+盘旋	盤旋	pan2xuan2	pánxuán	spiral; coil; circle; go around
+判决	判決	pan4jue2	pànjué	judgment (by a court of law); adjudicate
+畔	畔	pan4	pàn	riverbank; side; boundary
+庞大	龐大	pang2da4	pángdà	enormous; huge; tremendous
+抛弃	抛棄	pao1qi4	pāoqì	discard; abandon; dump (sb)
+泡沫	泡沫	pao4mo4	pàomò	foam; (soap bubble); (economic) bubble
+培育	培育	pei2yu4	péiyù	to train; nurture; to breed
+配备	配備	pei4bei4	pèibèi	provide; outfit with
+配偶	配偶	pei4'ou3	pèi'ǒu	mate; consort; spouse
+配套	配套	pei4 tao4	pèi tào	form a complete set
+盆地	盆地	pen2di4	péndì	basin
+烹饪	烹饪	peng1ren4	pēngrèn	cooking; culinary arts
+捧	捧	peng3	pěng	hold or carry with both hands facing up
+批发	批發	pi1fa1	pīfā	wholesale
+批判	批判	pi1pan4	pīpàn	criticize; critique
+劈	劈	pi1	pī	split in two; to divide
+皮革	皮革	pi2ge2	pígé	leather
+疲惫	疲憊	pi2bei4	píbèi	beaten; exhausted; tired
+疲倦	疲倦	pi2juan4	píjuàn	tired; weary
+屁股	屁股	pi4gu	pìgu	butt; rear; rump
+譬如	譬如	pi4ru2	pìrú	for example; for instance; such as
+偏差	偏差	pian1cha1	piānchā	bias; deviation
+偏见	偏見	pian1jian4	piānjiàn	prejudice
+偏僻	偏僻	pian1pi4	piānpì	remote and isolated; far from the city
+偏偏	偏偏	pian1pian1	piānpiān	unexpectedly; contrary to expectations
+片断	片斷	pian4duan4	piànduàn	part; passage; extract; fragment; snatch
+片刻	片刻	pian4ke4	piànkè	a short period of time
+漂浮	漂浮	piao1fu2	piāofú	superficial; float; hover; drift
+飘扬	飄揚	piao1yang2	piāoyáng	wave in the wind; flutter; fly
+撇	撇	pie3	piě	left-curving stroke (丿); throw; fling
+拼搏	拼搏	pin1bo2	pīnbó	struggle; wrestle
+拼命	拼命	pin1 ming4	pīn mìng	risk one's life; desperately; with all one's might
+贫乏	貧乏	pin2fa2	pínfá	lacking; incomplete
+贫困	貧困	pin2kun4	pínkùn	poor; impoverished
+频繁	頻繁	pin2fan2	pínfán	frequently; often
+频率	頻率	pin2lü4	pínlǜ	frequency
+品尝	品嘗	pin3chang2	pǐncháng	try; taste a small amount; to sample
+品德	品德	pin3de2	pǐndé	moral character; morality; morals
+品质	品質	pin3zhi4	pǐnzhì	quality; character
+品种	品種	pin3zhong3	pǐnzhǒng	breed; variety
+平凡	平凡	ping2fan2	píngfán	commonplace; ordinary
+平面	平面	ping2mian4	píngmiàn	a plane (i.e. flat surface); type; category
+平坦	平坦	ping2tan3	píngtǎn	flat
+平行	平行	ping2xing2	píngxíng	parallel; concurrent
+平庸	平庸	ping2yong1	píngyōng	mediocre
+平原	平原	ping2yuan2	píngyuán	field; plain; flatlands
+评估	評估	ping2gu1	pínggū	evaluate
+评论	評論	ping2lun4	pínglùn	comment on; discuss; remark
+屏幕	屏幕	ping2mu4	píngmù	screen (TV, etc.)
+屏障	屏障	ping2zhang4	píngzhàng	wall; barrier; protective screen
+坡	坡	po1	pō	slope
+泼	潑	po1	pō	to splash; to spill; rude and unreasonable; brutish
+颇	頗	po1	pō	rather; quite; inclined to one side
+迫不及待	迫不及待	po4bu4ji2dai4	pòbùjídài	be too impatient to wait
+迫害	迫害	po4hai4	pòhài	persecute; persecution
+破例	破例	po4li4	pòlì	make an exception
+魄力	魄力	po4li4	pòlì	daring resolution; boldness; courage
+扑	撲	pu1	pū	to assault; rush at; throw oneself on
+铺	鋪	pu4, pu1	pù, pū	bed; store | to spread; to lay
+朴实	樸實	pu3shi2	pǔshí	plain; sober; down-to-earth
+朴素	樸素	pu3su4	pǔsù	plain; simple; austerity
+普及	普及	pu3ji2	pǔjí	widespread; popular; popularize
+瀑布	瀑布	pu4bu4	pùbù	waterfall
+凄凉	淒涼	qi1liang2	qīliáng	desolate; feel like no one likes you
+期望	期望	qi1wang4	qīwàng	hope; expectation
+期限	期限	qi1xian4	qīxiàn	time limit; deadline; allotted time
+欺负	欺負	qi1fu	qīfu	to bully; intimidate
+欺骗	欺騙	qi1pian4	qīpiàn	deceive; to cheat; to dupe
+齐全	齊全	qi2quan2	qíquán	complete
+齐心协力	齊心協力	qi2xin1xie2li4	qíxīnxiélì	make concerted efforts
+奇妙	奇妙	qi2miao4	qímiào	wonderful; fantastic
+歧视	歧視	qi2shi4	qíshì	discriminate (against someone)
+旗袍	旗袍	qi2pao2	qípáo	cheongsam; Chinese-style dress
+旗帜	旗幟	qi2zhi4	qízhì	flag; banner
+乞丐	乞丐	qi3gai4	qǐgài	beggar
+岂有此理	豈有此理	qi3 you3 ci3 li3	qǐ yǒu cǐ lǐ	outrageous; ridiculous; absurd
+企图	企圖	qi3tu2	qǐtú	(to ) attempt; try; attempt
+启程	啓程	qi3cheng2	qǐchéng	set out on a journey
+启蒙	啓蒙	qi3meng2	qǐméng	enlighten; enlightenment； instruct the young; to initiate
+启示	啓示	qi3shi4	qǐshì	enlightenment; revelation
+启事	啓事	qi3shi4	qǐshì	announcement; public information (usually posted on a billboard)
+起草	起草	qi3 cao3	qǐ cǎo	draft (a bill); draw up (plans)
+起初	起初	qi3chu1	qǐchū	at first; originally; in the beginning
+起伏	起伏	qi3fu2	qǐfú	ups and downs; with a wavy motion
+起哄	起哄	qi3 hong4	qǐ hòng	gather together; cause a commotion
+起码	起碼	qi3ma3	qǐmǎ	at the minimum; at the very least
+起源	起源	qi3yuan2	qǐyuán	origin; originate; come from
+气概	氣概	qi4gai4	qìgài	mettle; spirit; gumption
+气功	氣功	qi4gong1	qìgōng	Qi Gong, a system of deep breathing exercises
+气魄	氣魄	qi4po4	qìpò	spirit; daring; nerve; boldness; enterprising outlook
+气色	氣色	qi4se4	qìsè	complexion
+气势	氣勢	qi4shi4	qìshì	imposing manner; look of great force or imposing manner
+气味	氣味	qi4wei4	qìwèi	odor; scent
+气象	氣象	qi4xiang4	qìxiàng	meteorology; atmosphere; phenomenon
+气压	氣壓	qi4ya1	qìyā	atmospheric pressure; barometric pressure
+气质	氣質	qi4zhi4	qìzhì	temperament; disposition
+迄今为止	迄今爲止	qi4jin1wei2zhi3	qìjīnwéizhǐ	until now; so far; to date
+器材	器材	qi4cai2	qìcái	equipment; material
+器官	器官	qi4guan1	qìguān	organ; apparatus
+掐	掐	qia1	qiā	pick (flowers); pinch; clutch
+洽谈	洽談	qia4tan2	qiàtán	discuss; talk over
+恰当	恰當	qia4dang4	qiàdàng	appropriate; suitable; proper
+恰到好处	恰到好處	qia4 dao4 hao3 chu4	qià dào hǎo chù	just right; it's just perfect
+恰巧	恰巧	qia4qiao3	qiàqiǎo	happen by chance; coincidence
+千方百计	千方百計	qian1 fang1 bai3 ji4	qiān fāng bǎi jì	by every possible means
+迁就	遷就	qian1jiu4	qiānjiù	humor; yield; adapt to; accommodate (something)
+迁徙	遷徙	qian1xi3	qiānxǐ	migrate; move; change one's residence
+牵	牽	qian1	qiān	to lead along; to pull (an animal on a tether)
+牵扯	牽扯	qian1che3	qiānchě	implicate; involve
+牵制	牽制	qian1zhi4	qiānzhì	control; curb; restrict; impede
+谦逊	謙遜	qian1xun4	qiānxùn	humble; modest; humility
+签署	簽署	qian1shu3	qiānshǔ	sign (an agreement)
+前景	前景	qian2jing3	qiánjǐng	outlook; future (prospects); foreground
+前提	前提	qian2ti2	qiántí	premise; precondition
+潜力	潛力	qian2li4	qiánlì	potential; capacity
+潜水	潛水	qian2shui3	qiánshuǐ	go diving
+潜移默化	潛移默化	qian2yi2mo4hua4	qiányímòhuà	exert a subtle influence on sb.'s character, thinking, etc.; impercebtibly influence; to influence secretly
+谴责	譴責	qian3ze2	qiǎnzé	denounce; condemn; criticize
+强制	強制	qiang2zhi4	qiángzhì	enforce; control; coerce
+抢劫	搶劫	qiang3jie2	qiǎngjié	rob; looting
+抢救	搶救	qiang3jiu4	qiǎngjiù	rescue; to save
+强迫	強迫	qiang3po4	qiǎngpò	compel; to force
+桥梁	橋梁	qiao2liang2	qiáoliáng	bridge
+窍门	竅門	qiao4men2	qiàomén	special tricks
+翘	翹	qiao4	qiào	stick up; bend upwards
+切实	切實	qie4shi2	qièshí	realistic; feasible; conscientiously
+锲而不舍	锲而不舍	qie4'er2bu4she3	qiè'érbùshě	keep on chipping away; work with perseverance
+钦佩	欽佩	qin1pei4	qīnpèi	admire; have great respect for
+侵犯	侵犯	qin1fan4	qīnfàn	encroach on; infringe on; violation
+侵略	侵略	qin1lüe4	qīnlüè	invasion; encroachment; invade
+亲密	親密	qin1mi4	qīnmì	intimate; close; familiarity
+亲热	親熱	qin1re4	qīnrè	intimate; affectionate; warm
+勤俭	勤儉	qin2jian3	qínjiǎn	hardworking and thrifty
+勤劳	勤勞	qin2lao2	qínláo	hardworking; diligent; industrious
+倾听	傾聽	qing1ting1	qīngtīng	listen attentively; heed (other people's opinions)
+倾向	傾向	qing1xiang4	qīngxiàng	trend; tendency; inclination
+倾斜	傾斜	qing1xie2	qīngxié	incline; lean; to slant; to slope; to tilt
+清澈	清澈	qing1che4	qīngchè	clear; limpid
+清晨	清晨	qing1chen2	qīngchén	early morning
+清除	清除	qing1chu2	qīngchú	eliminate; get rid of
+清洁	清潔	qing1jie2	qīngjié	clean; unpolluted; purity
+清理	清理	qing1li3	qīnglǐ	cleanup; put in order; check up
+清晰	清晰	qing1xi1	qīngxī	clear; distinct; clarity
+清醒	清醒	qing1xing3	qīngxǐng	clear-headed; sober; regain consciousness
+清真	清真	qing1zhen1	qīngzhēn	Muslim
+情报	情報	qing2bao4	qíngbào	intelligence; information-gathering
+情节	情節	qing2jie2	qíngjié	plot; circumstances
+情理	情理	qing2li3	qínglǐ	reason; sense
+情形	情形	qing2xing	qíngxing	circumstances; situation
+晴朗	晴朗	qing2lang3	qínglǎng	sunny and cloudless
+请柬	請柬	qing3jian3	qǐngjiǎn	invitation card; written invitation
+请教	請教	qing3jiao4	qǐngjiào	consult; seek advice
+请示	請示	qing3shi4	qǐngshì	ask for instructions
+请帖	請帖	qing3tie3	qǐngtiě	invitation card; written invitation
+丘陵	丘陵	qiu1ling2	qiūlíng	hills
+区分	區分	qu1fen1	qūfēn	differentiate; find differing aspects; find the difference between
+区域	區域	qu1yu4	qūyù	area; region; district
+曲折	曲折	qu1zhe2	qūzhé	winding; zigzag; complicated
+驱逐	驅逐	qu1zhu2	qūzhú	banishment; expel; deport
+屈服	屈服	qu1fu2	qūfú	yield; give in; submit
+渠道	渠道	qu2dao4	qúdào	irrigation ditch; medium or channel of communication
+曲子	曲子	qu3zi	qǔzi	folk tune; music; melody
+取缔	取締	qu3di4	qǔdì	to ban; suppress
+趣味	趣味	qu4wei4	qùwèi	fun; interest; delight; taste
+圈套	圈套	quan1tao4	quāntào	trap
+权衡	權衡	quan2heng2	quánhéng	trade-off; weigh pros and cons
+权威	權威	quan2wei1	quánwēi	authority; authoritative
+全局	全局	quan2ju2	quánjú	overall situation
+全力以赴	全力以赴	quan2 li4 yi3 fu4	quán lì yǐ fù	do at all costs; make an all-out effort
+拳头	拳頭	quan2tou	quántou	fist
+犬	犬	quan3	quǎn	dog (Kangxi radical 94)
+缺口	缺口	que1kou3	quēkǒu	gap; breach; shortfall
+缺席	缺席	que1 xi2	quē xí	absence; absent; default
+缺陷	缺陷	que1xian4	quēxiàn	a defect; a flaw; disfigurement
+瘸	瘸	que2	qué	lame
+确保	確保	que4bao3	quèbǎo	ensure; guarantee
+确立	確立	que4li4	quèlì	to establish; to institute
+确切	確切	que4qie4	quèqiè	definite; exact; precise
+确信	確信	que4xin4	quèxìn	confident; be certain of; to firmly believe
+群众	群衆	qun2zhong4	qúnzhòng	the masses; multitude
+染	染	ran3	rǎn	dye; to catch (a disease)
+嚷	嚷	rang3	rǎng	blurt out; shout
+让步	讓步	rang4 bu4	ràng bù	give in; concede; yield
+饶恕	饒恕	rao2shu4	ráoshù	forgive; pardon; spare
+扰乱	擾亂	rao3luan4	rǎoluàn	disturb; perturb; harass
+惹祸	惹禍	re3huo4	rěhuò	stir up troubles
+热泪盈眶	熱淚盈眶	re4 lei4 ying2 kuang4	rè lèi yíng kuàng	(saying) eyes brimming with tears; extremely moved
+热门	熱門	re4men2	rèmén	in demand; popular; in vogue
+人道	人道	ren2dao4	réndào	humanitarianism; humane
+人格	人格	reng2e2	réngé	personality; moral integrity; character
+人工	人工	reng2ong1	réngōng	man-made; manpower; manual work
+人家	人家	ren2jia1	rénjiā	other people; others; they; I; family; household
+人间	人間	ren2jian1	rénjiān	man's world; the world
+人士	人士	ren2shi4	rénshì	person; public figure
+人为	人爲	ren2wei2	rénwéi	artificial; man-made
+人性	人性	ren2xing4	rénxìng	human nature; humanity
+人质	人質	ren2zhi4	rénzhì	hostage
+仁慈	仁慈	ren2ci2	réncí	benevolent; kindhearted; charitable
+忍耐	忍耐	ren3nai4	rěnnài	show restraint; endure; exercise patience
+忍受	忍受	ren3shou4	rěnshòu	to bear; endure; tolerate
+认定	認定	ren4ding4	rèndìng	maintain (that sth. is true); firmly believe
+认可	認可	ren4ke3	rènkě	approve; accept; ratify
+任命	任命	ren4ming4	rènmìng	appoint and nominate
+任性	任性	ren4xing4	rènxìng	willful; headstrong
+任意	任意	ren4yi4	rènyì	arbitrarily; at will; at random
+任重道远	任重道遠	ren4zhong4dao4yuan3	rènzhòngdàoyuǎn	lit. a heavy load and a long road; fig. to bear heavy responsibilities through a long struggle; shoulder heavy responsibilities
+仍旧	仍舊	reng2jiu4	réngjiù	still (remaining); remain (the same); yet
+日新月异	日新月異	ri4xin1yue4yi4	rìxīnyuèyì	change with each passing day
+日益	日益	ri4yi4	rìyì	day by day; more and more; increasingly
+荣幸	榮幸	rong2xing4	róngxìng	honored
+荣誉	榮譽	rong2yu4	róngyù	honor; glory
+容貌	容貌	rong2mao4	róngmào	facial features; looks; appearance
+容纳	容納	rong2na4	róngnà	contain; accommodate; tolerate (different options)
+容器	容器	rong2qi4	róngqì	container; receptacle; vessel
+容忍	容忍	rong2ren3	róngrěn	put up with; tolerate; condone
+溶解	溶解	rong2jie3	róngjiě	dissolve; solution
+融化	融化	rong2hua4	rónghuà	melt; thaw; dissolve; blend into
+融洽	融洽	rong2qia4	róngqià	harmonious; friendly relations
+柔和	柔和	rou2he2	róuhé	gentle; soft; mild
+揉	揉	rou2	róu	knead; to massage; to rub
+儒家	儒家	ru2jia1	rújiā	Confucianism
+若干	若幹	ruo4gan1	ruògān	a certain number or amount; how many; how much
+弱点	弱點	ruo4dian3	ruòdiǎn	weak point; failing
+撒谎	撒謊	sa1 huang3	sā huǎng	to tell lies
+散文	散文	san3wen2	sǎnwén	prose; essay
+散布	散布	san4bu4	sànbù	to scatter; disseminate; to spread
+散发	散發	san4fa1	sànfā	distribute; emit
+丧失	喪失	sang4shi1	sàngshī	to lose; to forfeit
+骚扰	騷擾	sao1rao3	sāorǎo	harass; disturb; molest; cause a commotion
+嫂子	嫂子	sao3zi	sǎozi	(informal) elder brother's wife; sister-in-law
+刹车	刹車	sha1 che1	shā chē	brake (when driving); stop; switch off
+啥	啥	sha2	shá	(spoken) what
+筛选	篩選	shai1xuan3	shāixuǎn	to filter; to sift
+山脉	山脈	shan1mai4	shānmài	mountain range
+闪烁	閃爍	shan3shuo4	shǎnshuò	to twinkle; to flicker; glimmer
+擅长	擅長	shan4chang2	shàncháng	be good at; be expert in
+擅自	擅自	shan4zi4	shànzì	unauthorized
+伤脑筋	傷腦筋	shang1 nao3jin1	shāng nǎojīn	troublesome; bothersome
+商标	商標	shang1biao1	shāngbiāo	trademark; logo
+上级	上級	shang4ji2	shàngjí	higher authorities; superiors
+上进	上進	shang4jin4	shàngjìn	make forward progress; do better
+上任	上任	shang4 ren4	shàng rèn	take office
+上瘾	上瘾	shang4yin3	shàngyǐn	become addicted; get into a habit
+上游	上遊	shang4you2	shàngyóu	upper reaches (of a river); advanced position
+尚且	尚且	shang4qie3	shàngqiě	yet; still; even; also
+捎	捎	shao1	shāo	bring or take (along); deliver (a message)
+梢	梢	shao1	shāo	tip of a branch
+哨	哨	shao4	shào	a whistle; sentry post
+奢侈	奢侈	she1chi3	shēchǐ	luxury; sumptuous; extravagant
+舌头	舌頭	she2tou	shétou	tongue
+设立	設立	she4li4	shèlì	set up; establish
+设想	設想	she4xiang3	shèxiǎng	imagine; consider; tentative plan
+设置	設置	she4zhi4	shèzhì	set up; install; to fit
+社区	社區	she4qu1	shèqū	community
+涉及	涉及	she4ji2	shèjí	involve; relate to; to touch upon (a topic)
+摄氏度	攝氏度	she4shi4du4	shèshìdù	degrees Celsius
+申报	申報	shen1bao4	shēnbào	declare; report (to customs or other authority)
+呻吟	呻吟	shen1yin2	shēnyín	to moan; to groan
+绅士	紳士	shen1shi4	shēnshì	gentleman
+深奥	深奧	shen1'ao4	shēn'ào	profound; deep
+深沉	深沈	shen1chen2	shēnchén	deep; extreme; low pitched (sound); grave; of major importance
+深情厚谊	深情厚誼	shen1qing2hou4yi4	shēnqínghòuyì	profound friendship
+神经	神經	shen2jing1	shénjīng	nerve
+神奇	神奇	shen2qi2	shénqí	miraculous; magical; mystical
+神气	神氣	shen2qi4	shénqì	expression; manner; spirited
+神圣	神聖	shen2sheng4	shénshèng	divine; holy; sacred
+神态	神態	shen2tai4	shéntài	appearance; looks; manner; expression
+神仙	神仙	shen2xian1	shénxiān	fig. lighthearted person; Daoist immortal; supernatural entity; (in modern fiction) fairy, elf, leprechaun, etc.; supernatural being, celestial being, immortal; a person who has the power of clairvoyance or who is free from worldly cares
+审查	審查	shen3cha2	shěnchá	examine; investigate; censorship
+审理	審理	shen3li3	shěnlǐ	hear (a case)
+审美	審美	shen3mei3	shěnměi	aesthetic sense; appreciation of the arts
+审判	審判	shen3pan4	shěnpàn	put (someone) to trial; to try somebody
+渗透	滲透	shen4tou4	shèntòu	infiltrate; permeate
+慎重	慎重	shen4zhong4	shènzhòng	cautious; careful; prudent
+生存	生存	sheng1cun2	shēngcún	exist; survive
+生机	生機	sheng1ji1	shēngjī	reprieve from death; life force; vitality
+生理	生理	sheng1li3	shēnglǐ	physiology
+生疏	生疏	sheng1shu1	shēngshū	unfamiliar; strange; out of practice
+生态	生態	sheng1tai4	shēngtài	way of life; ecology
+生物	生物	sheng1wu4	shēngwù	organism; living creature; life form
+生肖	生肖	sheng1xiao4	shēngxiào	Chinese zodiac
+生效	生效	sheng1 xiao4	shēng xiào	take effect; become effective
+生锈	生鏽	sheng1xiu4	shēngxiù	to rust
+生育	生育	sheng1yu4	shēngyù	give birth; to rear; bring up (children)
+声明	聲明	sheng1ming2	shēngmíng	statement; declare; proclaim
+声势	聲勢	sheng1shi4	shēngshì	momentum; fame and power; prestige
+声誉	聲譽	sheng1yu4	shēngyù	reputation; fame
+牲畜	牲畜	sheng1chu4	shēngchù	livestock; domesticated animals
+省会	省會	sheng3hui4	shěnghuì	provincial capital
+胜负	勝負	sheng4fu4	shèngfù	victory or defeat; the outcome of a battle
+盛产	盛産	sheng4chan3	shèngchǎn	abound in; teem with; superabundant
+盛开	盛開	sheng4kai1	shèngkāi	to bloom; be in full flower
+盛情	盛情	sheng4qing2	shèngqíng	great kindness; boundless hospitality
+盛行	盛行	sheng4xing2	shèngxíng	in fashion; prevalent; prevail
+尸体	屍體	shi1ti3	shītǐ	dead body; corpse; carcass
+失事	失事	shi1 shi4	shī shì	be involved in a crash; (have an) accident
+失误	失誤	shi1wu4	shīwù	mistake; lapse; miss
+失踪	失蹤	shi1 zong1	shī zōng	be missing; be unaccounted for
+师范	師範	shi1fan4	shīfàn	teacher-training; pedagogical; normal (school)
+施加	施加	shi1jia1	shījiā	exert (effort or pressure)
+施展	施展	shi1zhan3	shīzhǎn	use fully; put to good use
+十足	十足	shi2zu2	shízú	full of; complete; 100 percent
+石油	石油	shi2you2	shíyóu	oil; petroleum
+时常	時常	shi2chang2	shícháng	time and again; often; frequently
+时而	時而	shi2'er2	shí'ér	occasionally; often, but not at any fixed time
+时光	時光	shi2guang1	shíguāng	time; era; period of time
+时机	時機	shi2ji1	shíjī	opportune time; opportunity
+时事	時事	shi2shi4	shíshì	current events; the present situation
+识别	識別	shi2bie2	shíbié	identify; distinguish; discern
+实惠	實惠	shi2hui4	shíhuì	substantial material benefit; advantageous (deal)
+实力	實力	shi2li4	shílì	strength
+实施	實施	shi2shi1	shíshī	to implement; put into effect; carry out
+实事求是	實事求是	shi2 shi4 qiu2 shi4	shí shì qiú shì	be practical and realistic; seek truth from facts
+实行	實行	shi2xing2	shíxíng	to implement; put into practice; carry out
+实质	實質	shi2zhi4	shízhì	substance; essence; gist
+拾	拾	shi2	shí	pick up; ten (banker's anti-fraud numeral)
+使命	使命	shi3ming4	shǐmìng	a (diplomatic or other) mission
+示范	示範	shi4fan4	shìfàn	demonstrate; lead the way; show how something is done
+示威	示威	shi4wei1	shìwēi	hold a protest demonstration
+示意	示意	shi4yi4	shìyì	to signal; to hint; to gesture; to motion; to indicate (an idea to sb)
+世代	世代	shi4dai4	shìdài	for generations; generation to generation
+势必	勢必	shi4bi4	shìbì	is bound to (happen)
+势力	勢力	shi4li	shìli	power; influence
+事故	事故	shi4gu4	shìgù	accident
+事迹	事迹	shi4ji4	shìjì	achievement; deed
+事件	事件	shi4jian4	shìjiàn	event; happening; incident
+事态	事態	shi4tai4	shìtài	situation; existing state of affairs
+事务	事務	shi4wu4	shìwù	affairs; work
+事项	事項	shi4xiang4	shìxiàng	matter; item
+事业	事業	shi4ye4	shìyè	undertaking; project; cause; enterprise
+试图	試圖	shi4tu2	shìtú	to try; to attempt
+试验	試驗	shi4yan4	shìyàn	experiment; test
+视力	視力	shi4li4	shìlì	vision; eyesight
+视频	視頻	shi4pin2	shìpín	video
+视线	視線	shi4xian4	shìxiàn	line of sight; view line
+视野	視野	shi4ye3	shìyě	field of vision
+是非	是非	shi4fei1	shìfēi	right and wrong; truth and fiction; quarrel
+适宜	適宜	shi4yi2	shìyí	suitable for; appropriate for
+逝世	逝世	shi4shi4	shìshì	pass away; to die
+释放	釋放	shi4fang4	shìfàng	release; set free; liberate (a prisoner)
+收藏	收藏	shou1cang2	shōucáng	collect; keep
+收缩	收縮	shou1suo1	shōusuō	pull back; shrink
+收益	收益	shou1yi4	shōuyì	earnings; profit
+收音机	收音機	shou1yin1ji1	shōuyīnjī	radio
+手法	手法	shou3fa3	shǒufǎ	technique; trick; skill; tact
+手势	手勢	shou3shi4	shǒushì	gesture; sign; signal
+手艺	手藝	shou3yi4	shǒuyì	craft; workmanship; one's cooking
+守护	守護	shou3hu4	shǒuhù	guard; defend; protect
+首饰	首飾	shou3shi4	shǒushì	jewelry
+首要	首要	shou3yao4	shǒuyào	the most important; chief; principal
+受罪	受罪	shou4zui4	shòuzuì	endure hardships; have a hard time
+授予	授予	shou4yu3	shòuyǔ	to award; confer
+书法	書法	shu1fa3	shūfǎ	calligraphy; penmanship
+书籍	書籍	shu1ji2	shūjí	books; works
+书记	書記	shu1ji	shūji	secretary; clerk
+书面	書面	shu1mian4	shūmiàn	in writing; written (guarantee, etc.)
+舒畅	舒暢	shu1chang4	shūchàng	happy; entirely free from worry
+疏忽	疏忽	shu1hu	shūhu	neglect; overlook; negligence
+疏远	疏遠	shu1yuan3	shūyuǎn	drift apart; keep at a distance; not in close touch; estranged
+束	束	shu4	shù	to tie; to bind; restrain; (mw for bunches, bundles, bouquets, etc.)
+束缚	束縛	shu4fu4	shùfù	to bind; restrict; to tie
+树立	樹立	shu4li4	shùlì	set up; establish
+竖	豎	shu4	shù	vertical; to erect; vertical stroke
+数额	數額	shu4'e2	shù'é	amount; sum of money; fixed number
+耍	耍	shua3	shuǎ	play/mess around with; juggle
+衰老	衰老	shuai1lao3	shuāilǎo	grow old; age; deteriorate
+衰退	衰退	shuai1tui4	shuāituì	decline; fall; drop; falter
+率领	率領	shuai4ling3	shuàilǐng	lead; command; head
+涮火锅	涮火鍋	shuan4huo3guo1	shuànhuǒguō	to instant-boil (mutton, beef, vegetables, etc.)
+双胞胎	雙胞胎	shuang1bao1tai1	shuāngbāotāi	twins
+爽快	爽快	shuang3kuai4	shuǎngkuài	refreshed; rejuvenated; frank
+水利	水利	shui3li4	shuǐlì	water conservancy; irrigation works
+水龙头	水龍頭	shui3long2tou2	shuǐlóngtóu	faucet; tap
+水泥	水泥	shuin3i2	shuǐní	cement
+瞬间	瞬間	shun4jian1	shùnjiān	in the twinkling of an eye; in an instant; momentary
+司法	司法	si1fa3	sīfǎ	judicial; (administration of) justice
+司令	司令	si1ling4	sīlìng	commanding officer
+私自	私自	si1zi4	sīzì	private; secretly; without permission
+思念	思念	sin1ian4	sīniàn	think of; long for; to miss
+思索	思索	si1suo3	sīsuǒ	think deeply; ponder
+思维	思維	si1wei2	sīwéi	(line) of thought; thinking
+斯文	斯文	si1wen	sīwen	refined; educated; cultured; intellectual; men of letters; scholars; literati; polite; gentle
+死亡	死亡	si3wang2	sǐwáng	to die; death; be dead
+四肢	四肢	si4zhi1	sìzhī	arms and legs; the four limbs of the body
+寺庙	寺廟	si4miao4	sìmiào	temple; monastery
+饲养	飼養	si4yang3	sìyǎng	to raise; to rear (domestic animal)
+肆无忌惮	肆無忌憚	si4wu2ji4dan4	sìwújìdàn	absolutely unrestrained; unbridled; without the slightest scruple
+耸	聳	song3	sǒng	shrug; towering; shock (alarm)
+艘	艘	sou1	sōu	(mw for boats and ships)
+苏醒	蘇醒	su1xing3	sūxǐng	wake up; regain consciousness
+俗话	俗話	su2hua4	súhuà	common saying; proverb
+诉讼	訴訟	su4song4	sùsòng	lawsuit
+素食	素食	su4shi2	sùshí	vegetables; vegetarian food
+素质	素質	su4zhi4	sùzhì	inner quality; basic essence; character quality
+塑造	塑造	su4zao4	sùzào	to shape; mould; figure
+算数	算數	suan4shu4	suànshù	(do) arithmetic; count
+随即	隨即	sui2ji2	suíjí	immediately (after); soon after; immediately
+随意	隨意	sui2yi4	suíyì	as one wishes; according to one's wishes
+岁月	歲月	sui4yue4	suìyuè	the years of a person's life
+隧道	隧道	sui4dao4	suìdào	tunnel
+损坏	損壞	sun3huai4	sǔnhuài	to damage; injure
+索取	索取	suo3qu3	suǒqǔ	demand; ask for; to exact
+索性	索性	suo3xing4	suǒxìng	you might as well (do it); simply; just; frankly; bluntly; directly
+塌	塌	ta1	tā	collapse; fall down; crumple
+踏实	踏實	ta1shi	tāshi	practical; down-to-earth; realistic; feel at ease; steadfast
+塔	塔	ta3	tǎ	pagoda; tower
+台风	台風	tai2feng1	táifēng	typhoon
+太空	太空	tai4kong1	tàikōng	outer space
+泰斗	泰鬥	tai4dou3	tàidǒu	leading scholar of his time; magnate
+贪婪	貪婪	tan1lan2	tānlán	greedy; avaricious
+贪污	貪汙	tan1wu1	tānwū	(political, moral) corruption; embezzle
+摊	攤	tan1	tān	to spread out; vendor's stand; booth; fry; (mw for puddles)
+瘫痪	癱瘓	tan1huan4	tānhuàn	paralysis
+弹性	彈性	tan2xing4	tánxìng	flexibility; elasticity
+坦白	坦白	tan3bai2	tǎnbái	honest; forthcoming; to confess
+叹气	歎氣	tan4 qi4	tàn qì	to sigh
+探测	探測	tan4ce4	tàncè	probe; take readings; detect; explore
+探索	探索	tan4suo3	tànsuǒ	explore; quest
+探讨	探討	tan4tao3	tàntǎo	inquire into; explore
+探望	探望	tan4wang4	tànwàng	pay a visit; look around
+倘若	倘若	tang3ruo4	tǎngruò	provided that; supposing that; if; in case
+掏	掏	tao1	tāo	fish out (from pocket)
+滔滔不绝	滔滔不絕	tao1tao1 bu4 jue2	tāotāo bù jué	(saying) talking non-stop; gushing; torrential
+陶瓷	陶瓷	tao2ci2	táocí	ceramics; pottery and porcelain
+陶醉	陶醉	tao2zui4	táozuì	be intoxicated (with power, success, etc.)
+淘汰	淘汰	tao2tai4	táotài	eliminate (in a competition); natural selection; die/phase out
+讨好	討好	tao3hao3	tǎohǎo	to flatter
+特长	特長	te4chang2	tècháng	strong point; specialty
+特定	特定	te4ding4	tèdìng	special; specific; designated
+特意	特意	te4yi4	tèyì	specially for; with the special intention of
+提拔	提拔	ti2ba2	tíbá	promote to a higher job; elevate
+提炼	提煉	ti2lian4	tíliàn	extract (ore, minerals, etc.); refine; purify
+提示	提示	ti2shi4	tíshì	to prompt; to present; to point out; to draw attention to sth; hint; brief; cue
+提议	提議	ti2yi4	tíyì	propose; suggest
+题材	題材	ti2cai2	tícái	subject matter
+体裁	體裁	ti3cai2	tǐcái	types or forms of literature
+体积	體積	ti3ji1	tǐjī	volume; bulk
+体谅	體諒	ti3liang4	tǐliàng	empathize; express sympathy; allow (for something)
+体面	體面	ti3mian4	tǐmiàn	dignity; honorable; face
+体系	體系	ti3xi4	tǐxì	system; setup
+天才	天才	tian1cai2	tiāncái	talent; gift; a genius; talented
+天赋	天賦	tian1fu4	tiānfù	natural talent
+天伦之乐	天倫之樂	tian1lun2zhi1le4	tiānlúnzhīlè	family happiness
+天然气	天然氣	tian1ran2qi4	tiānránqì	natural gas
+天生	天生	tian1sheng1	tiānshēng	innate; inherent; natural
+天堂	天堂	tian1tang2	tiāntáng	paradise; heaven
+天文	天文	tian1wen2	tiānwén	astronomy
+田径	田徑	tian2jing4	tiánjìng	track and field
+田野	田野	tian2ye3	tiányě	field; open country
+舔	舔	tian3	tiǎn	to lick
+挑剔	挑剔	tiao1ti	tiāoti	picky; fastidious
+条款	條款	tiao2kuan3	tiáokuǎn	clause (of contract or law)
+条理	條理	tiao2li3	tiáolǐ	consecutive; arrangement; orderliness
+条约	條約	tiao2yue1	tiáoyuē	treaty; pact
+调和	調和	tiao2he2	tiáohé	harmonious; harmony
+调剂	調劑	tiao2ji4	tiáojì	make an adjustment
+调节	調節	tiao2jie2	tiáojié	adjust; regulate; reconcile
+调解	調解	tiao2jie3	tiáojiě	mediation; bring together to an agreement
+调料	調料	tiao2liao4	tiáoliào	seasoning; flavoring
+挑拨	挑撥	tiao3bo1	tiǎobō	incite disharmony; provoke; stir up tension in others
+挑衅	挑釁	tiao3xin4	tiǎoxìn	provoke; defiance
+跳跃	跳躍	tiao4yue4	tiàoyuè	jump; leap; bound; skip
+亭子	亭子	ting2zi	tíngzi	pavilion; kiosk
+停泊	停泊	ting2bo2	tíngbó	anchor; mooring (of a ship)
+停顿	停頓	ting2dun4	tíngdùn	pause; halt
+停滞	停滯	ting2zhi4	tíngzhì	stagnation; be at a standstill; bogged down
+挺拔	挺拔	ting3ba2	tǐngbá	tall and straight
+通货膨胀	通貨膨脹	tong1huo4 peng2zhang4	tōnghuò péngzhàng	inflation
+通缉	通緝	tong1ji1	tōngjī	order the arrest of a criminal
+通俗	通俗	tong1su2	tōngsú	popular; common; everyday; average; vulgar
+通讯	通訊	tong1xun4	tōngxùn	communication; correspondence; news dispatch
+通用	通用	tong1yong4	tōngyòng	in common use; interchangeable; General Motors
+同胞	同胞	tong2bao1	tóngbāo	compatriot; fellow countryman
+同志	同志	tong2zhi4	tóngzhì	comrade; gay (slang)
+铜	銅	tong2	tóng	copper
+童话	童話	tong2hua4	tónghuà	fairy tale
+统筹兼顾	統籌兼顧	tong3chou2jiang1u4	tǒngchóujiāngù	take every aspects into consideration through plan and preparation
+统计	統計	tong3ji4	tǒngjì	statistics; to tally; to add up
+统统	統統	tong3tong3	tǒngtǒng	totally; completely
+统治	統治	tong3zhi4	tǒngzhì	to rule (a country); govern; governance
+投机	投機	tou2ji1	tóujī	speculate (on financial markets); congenial; opportunistic
+投票	投票	tou2piao4	tóupiào	vote; poll
+投诉	投訴	tou2su4	tóusù	make a complaint; appeal to a court
+投降	投降	tou2xiang2	tóuxiáng	to surrender
+投掷	投擲	tou2zhi4	tóuzhì	throw something a long distance; hurl
+透露	透露	tou4lu4	tòulù	divulge; to reveal; leak out
+秃	禿	tu1	tū	bald; blunt
+突破	突破	tu1po4	tūpò	break through; breakthrough
+图案	圖案	tu2'an4	tú'àn	design; pattern
+徒弟	徒弟	tu2di4	túdì	disciple
+途径	途徑	tu2jing4	tújìng	way; channel
+涂抹	塗抹	tu2mo3	túmǒ	scribble; smear; doodle
+土壤	土壤	tu3rang3	tǔrǎng	soil; earth
+团结	團結	tuan2jie2	tuánjié	unite; hold a rally; join forces
+团体	團體	tuan2ti3	tuántǐ	group; organization; team
+团圆	團圓	tuan2yuan2	tuányuán	have a reunion; reunite as a family
+推测	推測	tui1ce4	tuīcè	speculate; conjecture; surmise
+推翻	推翻	tui1fan1	tuīfān	overthrow; topple
+推理	推理	tui1li3	tuīlǐ	reasoning; speculative; inference
+推论	推論	tui1lun4	tuīlùn	infer; a deduction; a corollary
+推销	推銷	tui1xiao1	tuīxiāo	to market; sell
+吞吞吐吐	吞吞吐吐	tun1tun1tu3tu3	tūntūntǔtǔ	hum and haw (idiom); mumble as if hiding something; speak and break off, then start again; to hold something back
+托运	托運	tuo1yun4	tuōyùn	check in (baggage); consign for shipment
+拖延	拖延	tuo1yan2	tuōyán	prolong; protraction; delay; stall; procrastinate
+脱离	脫離	tuo1li2	tuōlí	to separate oneself from; to break away from; be divorced from; diastasis (medicine); abscission; abjunction (botany)
+妥当	妥當	tuo3dang	tuǒdang	appropriate; proper; pertinence
+妥善	妥善	tuo3shan4	tuǒshàn	appropriate; proper; well-arranged
+妥协	妥協	tuo3xie2	tuǒxié	to compromise; reach terms
+椭圆	橢圓	tuo3yuan2	tuǒyuán	ellipse; oval
+唾弃	唾棄	tuo4qi4	tuòqì	cast aside; spurn
+挖掘	挖掘	wa1jue2	wājué	excavate; dig; unearth
+哇	哇	wa	wa	wow; (sound of crying or surprise)
+娃娃	娃娃	wa2wa	wáwa	baby; child; doll
+瓦解	瓦解	wa3jie3	wǎjiě	collapse; disintegrate; crumble
+歪曲	歪曲	wai1qu1	wāiqū	to distort; to misrepresent; to twist; crooked; askew; aslant
+外表	外表	wai4biao3	wàibiǎo	outward appearance; external; outside
+外行	外行	wai4hang2	wàiháng	layman; amateur; nonprofessional
+外界	外界	wai4jie4	wàijiè	the outside world; external
+外向	外向	wai4xiang4	wàixiàng	extroverted; export-oriented (economy)
+丸	丸	wan2	wán	pill; pellet
+完备	完備	wan2bei4	wánbèi	complete; perfect
+完毕	完畢	wan2bi4	wánbì	finish; end; complete
+玩弄	玩弄	wan2nong4	wánnòng	resort to; play with; engage in
+玩意儿	玩意兒	wan2yi4r	wányìr	thing; toy; gadget
+顽固	頑固	wang2u4	wángù	stubborn; obstinate
+顽强	頑強	wan2qiang2	wánqiáng	tenacious; hard to defeat
+挽回	挽回	wan3hui2	wǎnhuí	reverse or salvage (a situation); redeem; retrieve
+挽救	挽救	wan3jiu4	wǎnjiù	to rescue; retrieve; to remedy
+惋惜	惋惜	wan3xi1	wǎnxī	feel sorry for a person; sympathize; to regret
+万分	萬分	wan4fen1	wànfēn	very much; extremely
+往常	往常	wang3chang2	wǎngcháng	habitually in the past; as one used to do; as it used to be
+往事	往事	wang3shi4	wǎngshì	the past events; former happenings
+妄想	妄想	wang4xiang3	wàngxiǎng	vainly hope; wishful thinking; delusion
+危机	危機	wei1ji1	wēijī	crisis
+威风	威風	wei1feng1	wēifēng	awe-inspiring authority; power and prestige; impressive force
+威力	威力	wei1li4	wēilì	might; power that invokes fear
+威望	威望	wei1wang4	wēiwàng	prestige
+威信	威信	wei1xin4	wēixìn	prestige; reputation; veneration; authority; trust
+微不足道	微不足道	wei1 bu4 zu2 dao4	wēi bù zú dào	negligible; insignificant; not worth mentioning
+微观	微觀	wei1guan1	wēiguān	microscopic; sub atomic
+为难	爲難	wei2nan2	wéinán	make things difficult for someone; embarrassed
+为期	爲期	wei2qi1	wéiqī	be scheduled for; last for (a certain duration)
+违背	違背	wei2bei4	wéibèi	violate; go against
+唯独	唯獨	wei2du2	wéidú	only; just (i.e. it is only that ...); alone
+维持	維持	wei2chi2	wéichí	maintain; preserve
+维护	維護	wei2hu4	wéihù	defend; to safeguard; defense; maintain
+维生素	維生素	wei2sheng1su4	wéishēngsù	vitamin
+伪造	僞造	wei3zao4	wěizào	forge; to fake; to counterfeit
+委托	委托	wei3tuo1	wěituō	to entrust; to trust; to ensign; to commission
+委员	委員	wei3yuan2	wěiyuán	committee member; committee; council
+卫星	衛星	wei4xing1	wèixīng	satellite
+未免	未免	wei4mian3	wèimiǎn	(of something that one finds has gone too far); rather a bit too
+畏惧	畏懼	wei4ju4	wèijù	to fear; foreboding
+喂	喂	wei4, wei2	wèi, wéi	hey; to feed | hello (on the phone)
+蔚蓝	蔚藍	wei4lan2	wèilán	azure; sky blue
+慰问	慰問	wei4wen4	wèiwèn	to express sympathy; consolation; extend regards to; salute
+温带	溫帶	wen1dai4	wēndài	temperate zone
+温和	溫和	wen1he2	wēnhé	moderate; warm; (-huo: lukewarm)
+文凭	文憑	wen2ping2	wénpíng	diploma
+文物	文物	wen2wu4	wénwù	cultural relic; historical relic
+文献	文獻	wen2xian4	wénxiàn	document; literature
+文雅	文雅	wen2ya3	wényǎ	elegant; refined
+文艺	文藝	wen2yi4	wényì	literature and art
+问世	問世	wen4shi4	wènshì	be published; to come out
+窝	窩	wo1	wō	nest; den
+乌黑	烏黑	wu1hei1	wūhēi	jet-black; pitch-black
+污蔑	汙蔑	wu1mie4	wūmiè	to slander
+诬陷	誣陷	wu1xian4	wūxiàn	entrap; to frame; plant false evidence against sb.
+无比	無比	wu2bi3	wúbǐ	matchless; incomparable
+无偿	無償	wu2chang2	wúcháng	free; no charge; at no cost
+无耻	無恥	wu2chi3	wúchǐ	without any sense of shame; shameless; audaciousness
+无动于衷	無動于衷	wu2dong4yu2zhong1	wúdòngyúzhōng	aloof; indifferent; unconcerned; untouched
+无非	無非	wu2fei1	wúfēi	nothing but; only
+无辜	無辜	wu2gu1	wúgū	innocent
+无精打采	無精打采	wu2jing1da3cai3	wújīngdǎcǎi	listless; be dispirited; in low spirits
+无赖	無賴	wu2lai4	wúlài	hoodlum; rascal; rogue; rascally; scoundrelly
+无理取闹	無理取鬧	wu2li3qun3ao4	wúlǐqǔnào	to make trouble without reason (idiom); wilfully make trouble; to be deliberately provocative; deliberately awkward; pointless provocation
+无能为力	無能爲力	wu2 neng2 wei2 li4	wú néng wéi lì	incapable of action; powerless; impotent
+无穷无尽	無窮無盡	wu2qiong2wu2jin4	wúqióngwújìn	vast and limitless; endless span of time; no vestige of a beginning, no prospect of an end
+无微不至	無微不至	wu2 wei1 bu2 zhi4	wú wēi bú zhì	in every possible way; meticulously
+无忧无虑	無憂無慮	wu2you1wu2lü4	wúyōuwúlǜ	carefree and without worries
+无知	無知	wu2zhi1	wúzhī	ignorance
+武器	武器	wu3qi4	wǔqì	weapon; arms
+武侠	武俠	wu3xia2	wǔxiá	knight-errant; a genre of swordplay martial arts movies and books
+武装	武裝	wu3zhuang1	wǔzhuāng	arms; equipment; to arm
+侮辱	侮辱	wu3ru3	wǔrǔ	to insult; humiliate
+舞蹈	舞蹈	wu3dao3	wǔdǎo	a dance
+务必	務必	wu4bi4	wùbì	must; need to; be sure to
+物美价廉	物美價廉	wu4mei3jia4lian2	wùměijiàlián	attractive goods at inexpensive prices
+物业	物業	wu4ye4	wùyè	property management
+物资	物資	wu4zi1	wùzī	goods and materials; commodity
+误差	誤差	wu4cha1	wùchā	difference; error; inaccuracy
+误解	誤解	wu4jie3	wùjiě	misunderstand; misread
+夕阳	夕陽	xi1yang2	xīyáng	setting sun
+昔日	昔日	xi1ri4	xīrì	formerly; in olden days
+牺牲	犧牲	xi1sheng1	xīshēng	sacrifice (one's life, etc.)
+溪	溪	xi1	xī	creek
+熄灭	熄滅	xi1mie4	xīmiè	extinguish; go out (of fire); die out; extinction
+膝盖	膝蓋	xi1gai4	xīgài	knee
+习俗	習俗	xi2su2	xísú	custom; tradition; (local) convention
+袭击	襲擊	xi2ji1	xíjī	surprise attack; to raid
+媳妇	媳婦	xi2fu4	xífù	daughter-in-law; son's wife
+喜闻乐见	喜聞樂見	xi3wen2le4jian4	xǐwénlèjiàn	a delight to see (idiom); an attractive spectacle
+喜悦	喜悅	xi3yue4	xǐyuè	happy; joyous
+系列	系列	xi4lie4	xìliè	series
+细胞	細胞	xi4bao1	xìbāo	cell (biology)
+细菌	細菌	xi4jun1	xìjūn	bacteria; virus; germ
+细致	細致	xi4zhi4	xìzhì	delicate; meticulous
+峡谷	峽谷	xia2gu3	xiágǔ	canyon; ravine; gorge
+狭隘	狹隘	xia2'ai4	xiá'ài	narrow; tight; narrow (minded); lacking in experience
+狭窄	狹窄	xia2zhai3	xiázhǎi	narrow
+霞	霞	xia2	xiá	red clouds
+下属	下屬	xia4shu3	xiàshǔ	subordinate; underling
+先进	先進	xian1jin4	xiānjìn	advanced (technology); to advance
+先前	先前	xian1qian2	xiānqián	before; previously
+纤维	纖維	xian1wei2	xiānwéi	fiber
+掀起	掀起	xian1qi3	xiānqǐ	lift; raise in height
+鲜明	鮮明	xian1ming2	xiānmíng	bright; clear-cut; distinct
+闲话	閑話	xian2hua4	xiánhuà	gossip; digression
+贤惠	賢惠	xian2hui4	xiánhuì	virtuous and dutiful (of women)
+弦	弦	xian2	xián	bow string; string of musical instruments
+衔接	銜接	xian2jie1	xiánjiē	to join together; to combine
+嫌	嫌	xian2	xián	to dislike; suspicion; grudge
+嫌疑	嫌疑	xian2yi2	xiányí	suspicion; (be) suspected (of)
+显著	顯著	xian3zhu4	xiǎnzhù	notable; marked; outstanding; remarkable
+现场	現場	xian4chang3	xiànchǎng	scene (of event or incident); on the spot
+现成	現成	xian4cheng2	xiànchéng	ready-made; off-the-shelf
+现状	現狀	xian4zhuang4	xiànzhuàng	current situation; status quo
+线索	線索	xian4suo3	xiànsuǒ	trail; clues; hints; thread (of a story)
+宪法	憲法	xian4fa3	xiànfǎ	constitution; charter
+陷害	陷害	xian4hai4	xiànhài	cast blame on; to frame
+陷阱	陷阱	xian4jing3	xiànjǐng	trap; snare
+陷入	陷入	xian4ru4	xiànrù	sink into; get caught up in; land in (a predicament)
+馅儿	餡兒	xian4r	xiànr	stuffing; filling
+乡镇	鄉鎮	xiang1zhen4	xiāngzhèn	village and town
+相差	相差	xiang1cha4	xiāngchà	differ; difference
+相等	相等	xiang1deng3	xiāngděng	be equal to; equally; equivalent
+相辅相成	相輔相成	xiang1fu3xiang1cheng2	xiāngfǔxiāngchéng	supplement and complement each other
+相应	相應	xiang1ying4	xiāngyìng	correspond; relevant
+镶嵌	鑲嵌	xiang1qian4	xiāngqiàn	inlay
+响亮	響亮	xiang3liang4	xiǎngliàng	loud and clear; resounding
+响应	響應	xiang3ying4	xiǎngyìng	respond to; answer
+想方设法	想方設法	xiang3 fang1 she4 fa3	xiǎng fāng shè fǎ	(saying) think of or try every possible method; by all means possible
+向导	向導	xiang4dao3	xiàngdǎo	guide
+向来	向來	xiang4lai2	xiànglái	always; all along
+向往	向往	xiang4wang3	xiàngwǎng	yearn for; look forward to
+巷	巷	xiang4	xiàng	lane; alley
+相声	相聲	xiang4sheng	xiàngsheng	comic dialogue; crosstalk
+削	削	xue1	xuē	to pare/peel with a knife; to cut; to chop
+消除	消除	xiao1chu2	xiāochú	eliminate; remove; clear up (abstract things）
+消毒	消毒	xiao1 du2	xiāo dú	disinfect; sterilize
+消防	消防	xiao1fang2	xiāofáng	fire-fighting; fire prevention and control
+消耗	消耗	xiao1hao4	xiāohào	use up; consume
+消灭	消滅	xiao1mie4	xiāomiè	eliminate; perish; wipe out
+销毁	銷毀	xiao1hui3	xiāohuǐ	destroy (by melting or burning)
+潇洒	潇灑	xiao1sa3	xiāosǎ	free and easy
+小心翼翼	小心翼翼	xiao3xin1 yi4yi4	xiǎoxīn yìyì	carefully; cautiously; with great care
+肖像	肖像	xiao4xiang4	xiàoxiàng	portrait
+效益	效益	xiao4yi4	xiàoyì	benefit；results
+协会	協會	xie2hui4	xiéhuì	an association; a society
+协商	協商	xie2shang1	xiéshāng	consult with; talk things over
+协调	協調	xie2tiao2	xiétiáo	coordinate; harmonize
+协议	協議	xie2yi4	xiéyì	agreement; pact; protocol
+协助	協助	xie2zhu4	xiézhù	assist; to help
+携带	攜帶	xie2dai4	xiédài	take with; portable
+泄露	泄露	xie4lou4	xièlòu	leak (information); divulge
+泄气	泄氣	xie4qi4	xièqì	despair; feel like giving up/disappointing; pathetic
+屑	屑	xie4	xiè	crumbs; filings; worth while
+谢绝	謝絕	xie4jue2	xièjué	politely refuse
+心得	心得	xin1de2	xīndé	knowledge gained
+心甘情愿	心甘情願	xing1an1qing2yuan4	xīngānqíngyuàn	totally willing; perfectly happy to
+心灵	心靈	xin1ling2	xīnlíng	heart; soul; smart; quick-witted
+心态	心態	xin1tai4	xīntài	pyschology; mentality; spirit
+心疼	心疼	xin1teng2	xīnténg	love dearly; the pain of love
+心血	心血	xin1xue4	xīnxuè	heart and blood; painstaking effort; meticulous care
+心眼儿	心眼兒	xin1yan3r	xīnyǎnr	one's thoughts; mind; intention; willingness to accept new ideas
+辛勤	辛勤	xin1qin2	xīnqín	hardworking; diligent; industrious
+欣慰	欣慰	xin1wei4	xīnwèi	be gratified; satisfied
+欣欣向荣	欣欣向榮	xin1xin1 xiang4 rong2	xīnxīn xiàng róng	flourishing; thriving; prosperous
+新陈代谢	新陳代謝	xin1 chen2 dai4xie4	xīn chén dàixiè	metabolism (bio); (saying) the new replaces the old
+新郎	新郎	xin1lang2	xīnláng	bridegroom; groom
+新娘	新娘	xin1niang2	xīnniáng	bride
+新颖	新穎	xin1ying3	xīnyǐng	new and original; novel
+薪水	薪水	xin1shui3	xīnshuǐ	salary; wage; pay; stipend
+信赖	信賴	xin4lai4	xìnlài	trust; have confidence in; confide
+信念	信念	xin4nian4	xìnniàn	faith; belief; conviction
+信仰	信仰	xin4yang3	xìnyǎng	firm belief; faith; believe in (a religion)
+信誉	信譽	xin4yu4	xìnyù	reputation; prestige; trust
+兴隆	興隆	xing1long2	xīnglóng	prosperous; flourishing
+兴旺	興旺	xing1wang4	xīngwàng	prosperous; thriving; to prosper
+腥	腥	xing1	xīng	fishy (smell)
+刑事	刑事	xing2shi4	xíngshì	criminal; penal
+行政	行政	xing2zheng4	xíngzhèng	administration; administrative
+形态	形態	xing2tai4	xíngtài	shape; form; pattern
+兴高采烈	興高采烈	xing4 gao1 cai3 lie4	xìng gāo cǎi liè	in high spirits
+兴致勃勃	興致勃勃	xing4zhi4bo2bo2	xìngzhìbóbó	in high spirits
+性感	性感	xing4gan3	xìnggǎn	sex appeal; sexy; sexuality
+性命	性命	xing4ming4	xìngmìng	life
+性能	性能	xing4neng2	xìngnéng	function; performance
+凶恶	凶惡	xiong1'e4	xiōng'è	fierce; ferocious; menacing
+凶手	凶手	xiong1shou3	xiōngshǒu	murderer; assassin; assailant
+汹涌	洶湧	xiong1yong3	xiōngyǒng	(used in reference to an ocean, river, lake etc.) violently surge up; turbulent
+胸怀	胸懷	xiong1huai2	xiōnghuái	think about; heart; one's bosom (the seat of emotions); breast; broad-minded and open
+胸膛	胸膛	xiong1tang2	xiōngtáng	chest
+雄厚	雄厚	xiong2hou4	xiónghòu	abundant; strong and solid; rich
+雄伟	雄偉	xiong2wei3	xióngwěi	grand; majestic
+修复	修複	xiu1fu4	xiūfù	restoration; repair
+修建	修建	xiu1jian4	xiūjiàn	to build; to construct; renovate
+修养	修養	xiu1yang3	xiūyǎng	accomplishment; self-cultivation
+羞耻	羞恥	xiu1chi3	xiūchǐ	(a feeling of) shame
+绣	繡	xiu4	xiù	embroider; embroidery
+嗅觉	嗅覺	xiu4jue2	xiùjué	sense of smell; scent
+须知	須知	xu1zhi1	xūzhī	prerequisites; knowledge requirement
+虚假	虛假	xu1jia3	xūjiǎ	false; phony; pretense; deceit
+虚荣	虛榮	xu1rong2	xūróng	vanity
+虚伪	虛僞	xu1wei3	xūwěi	false; hypocritical; artificial; sham
+需求	需求	xu1qiu2	xūqiú	requirement; demand (economics)
+许可	許可	xu3ke3	xǔkě	allow; permit; permission
+序言	序言	xu4yan2	xùyán	preface of a book, used to explain the book's objective
+畜牧	畜牧	xu4mu4	xùmù	raise animals
+酗酒	酗酒	xu4jiu3	xùjiǔ	heavy drinking; drink to excess; binge drink
+宣誓	宣誓	xuan1 shi4	xuān shì	swear an oath (of office); make a vow
+宣扬	宣揚	xuan1yang2	xuānyáng	publicize; make public or well known
+喧哗	喧嘩	xuan1hua2	xuānhuá	cause a scene
+悬挂	懸挂	xuang2ua4	xuánguà	suspend; hang; suspension (cable car)
+悬念	懸念	xuan2nian4	xuánniàn	reader's involvement; suspense in a movie, place etc
+悬殊	懸殊	xuan2shu1	xuánshū	a wide gap; big contrast; large disparity; a mismatch
+悬崖峭壁	懸崖峭壁	xuan2ya2qiao4bi4	xuányáqiàobì	cliffside
+旋律	旋律	xuan2lü4	xuánlǜ	melody; tune; rhythm
+旋转	旋轉	xuan2zhuan3	xuánzhuǎn	to whirl; to spin; rotate
+选拔	選拔	xuan3ba2	xuǎnbá	select the best; choose
+选举	選舉	xuan3ju3	xuǎnjǔ	elect; election
+选手	選手	xuan3shou3	xuǎnshǒu	athlete; contestant; player
+炫耀	炫耀	xuan4yao4	xuànyào	to show off; flaunt
+削弱	削弱	xue1ruo4	xuēruò	weaken; to cripple
+学说	學說	xue2shuo1	xuéshuō	theory; doctrine
+学位	學位	xue2wei4	xuéwèi	academic degree; educational level
+雪上加霜	雪上加霜	xue3shang4jia1shuang1	xuěshàngjiāshuāng	(literally) add frost to snow; one disaster after another; insult added to injury
+血压	血壓	xue4ya1	xuèyā	blood pressure
+熏陶	熏陶	xun1tao2	xūntáo	to influence (positively)
+寻觅	尋覓	xun2mi4	xúnmì	to seek; to look for
+巡逻	巡邏	xun2luo2	xúnluó	to patrol (police, army or navy)
+循环	循環	xun2huan2	xúnhuán	circular cycle; loop; circulate
+循序渐进	循序漸進	xun2 xu4 jian4 jin4	xún xù jiàn jìn	make steady progress incrementally; step by step program
+压迫	壓迫	ya1po4	yāpò	oppress
+压岁钱	壓歲錢	ya1sui4qian2	yāsuìqián	gifts of money given to children during the Spring Festival
+压缩	壓縮	ya1suo1	yāsuō	to compress
+压抑	壓抑	ya1yi4	yāyì	constrain or repress one's emotions; inhibition; repressive
+压榨	壓榨	ya1zha4	yāzhà	to press; to squeeze; to extract juice, oil, etc. by squeezing
+压制	壓制	ya1zhi4	yāzhì	suppress; inhibit; stifle
+鸦雀无声	鴉雀無聲	ya1que4wu2sheng1	yāquèwúshēng	not even a crow or sparrow can be heard (idiom); silence reigns
+亚军	亞軍	ya4jun1	yàjūn	second place; runner-up
+烟花爆竹	煙花爆竹	yan1hua1bao4zhu2	yānhuābàozhú	fireworks and crackers
+淹没	淹沒	yan1mo4	yānmò	submerge; drown; to flood
+延期	延期	yan2 qi1	yán qī	delay; extend; postpone
+延伸	延伸	yan2shen1	yánshēn	extend; spread; stretch
+延续	延續	yan2xu4	yánxù	continue; last longer
+严寒	嚴寒	yan2han2	yánhán	bitter cold; severe winter
+严禁	嚴禁	yan2jin4	yánjìn	strictly prohibit; forbid
+严峻	嚴峻	yan2jun4	yánjùn	grim; severe; rigorous; harsh
+严厉	嚴厲	yan2li4	yánlì	strict; severe
+严密	嚴密	yan2mi4	yánmì	strict; closely-knit; tight
+言论	言論	yan2lun4	yánlùn	expression of (political) opinion; speech
+岩石	岩石	yan2shi2	yánshí	rock; stone
+炎热	炎熱	yan2re4	yánrè	blistering hot; sizzling hot (weather)
+沿海	沿海	yan2hai3	yánhǎi	coastal
+掩盖	掩蓋	yang3ai4	yǎngài	conceal; cover up; hide behind
+掩护	掩護	yan3hu4	yǎnhù	cover; shield; screen
+掩饰	掩飾	yan3shi4	yǎnshì	conceal a fault; gloss over
+眼光	眼光	yang3uang1	yǎnguāng	vision
+眼色	眼色	yan3se4	yǎnsè	a wink; signal with one's eyes
+眼神	眼神	yan3shen2	yǎnshén	expression or emotion showing in one's eyes
+演变	演變	yan3bian4	yǎnbiàn	develop; evolve
+演习	演習	yan3xi2	yǎnxí	rehearse; practice; put on a play
+演绎	演繹	yan3yi4	yǎnyì	deduction; to deduce; to infer
+演奏	演奏	yan3zou4	yǎnzòu	give an instrumental performance
+厌恶	厭惡	yan4wu4	yànwù	loathe; to hate; detest
+验收	驗收	yan4shou1	yànshōu	inspect and then accept (i.e. received goods
+验证	驗證	yan4zheng4	yànzhèng	inspect and verify
+氧气	氧氣	yang3qi4	yǎngqì	oxygen
+样品	樣品	yang4pin3	yàngpǐn	sample; specimen
+谣言	謠言	yao2yan2	yáoyán	rumor
+摇摆	搖擺	yao2bai3	yáobǎi	to waver; to wag; to sway
+摇滚	搖滾	yao2gun3	yáogǔn	rock and roll
+遥控	遙控	yao2kong4	yáokòng	remote control
+遥远	遙遠	yao2yuan3	yáoyuǎn	distant; remote
+要点	要點	yao4dian3	yàodiǎn	main point; essential
+要命	要命	yao4ming4	yàomìng	cause somebody's death; very; extremely; frighteningly; annoyance
+要素	要素	yao4su4	yàosù	essential factor; key constituent
+耀眼	耀眼	yao4yan3	yàoyǎn	dazzle; to shine
+野蛮	野蠻	ye3man2	yěmán	barbarous; uncivilized; cruel; wild
+野心	野心	ye3xin1	yěxīn	ambition; wild schemes or ambitions; careerism
+液体	液體	ye4ti3	yètǐ	liquid
+一度	一度	yi2du4	yídù	for a time; at one time; one time; once
+一帆风顺	一帆風順	yi4fan1feng1shun4	yìfānfēngshùn	(saying) smooth sailing
+一贯	一貫	yi2guan4	yíguàn	consistent; constant; from start to finish; then as now
+一举两得	一舉兩得	yi4ju3liang3de2	yìjǔliǎngdé	kill two birds with one stone; (literally) attain two objectives with a single move
+一流	一流	yi1liu2	yīliú	top-grade
+一目了然	一目了然	yi2mu4liao3ran2	yímùliǎorán	obvious at a glance
+一如既往	一如既往	yi4ru2ji4wang3	yìrújìwǎng	just as in the past (idiom); as before; continuing as always
+一丝不苟	一絲不苟	yi4si1bu4gou3	yìsībùgǒu	(literally) not one thread loose; strictly according to the rules; meticulous
+一向	一向	yi2xiang4	yíxiàng	all along; the whole time; constantly; always
+衣裳	衣裳	yi1shang	yīshang	clothes
+依旧	依舊	yi1jiu4	yījiù	as before; still
+依据	依據	yi1ju4	yījù	according to; basis; foundation
+依靠	依靠	yi1kao4	yīkào	rely on; depend on
+依赖	依賴	yi1lai4	yīlài	depend on; be dependent on
+依托	依托	yi1tuo1	yītuō	rely on; depend on
+仪器	儀器	yi2qi4	yíqì	apparatus; (scientific) instrument
+仪式	儀式	yi2shi4	yíshì	ceremony
+遗产	遺産	yi2chan3	yíchǎn	heritage; legacy
+遗传	遺傳	yi2chuan2	yíchuán	inherit; hereditary
+遗留	遺留	yi2liu2	yíliú	legacy; left over; hand down
+遗失	遺失	yi2shi1	yíshī	lose; lose due to carelessness
+疑惑	疑惑	yi2huo4	yíhuò	(a sense of) uncertainty; to feel unsure about something; uncertainty
+以便	以便	yi3bian4	yǐbiàn	so that; in order to
+以免	以免	yi3mian3	yǐmiǎn	so as not to; in order to avoid; lest
+以往	以往	yi3wang3	yǐwǎng	in the past; formerly
+以至	以至	yi3zhi4	yǐzhì	down to; up to; to such an extent as to...
+以致	以致	yi3zhi4	yǐzhì	so that; as a result
+亦	亦	yi4	yì	also
+异常	異常	yi4chang2	yìcháng	exceptional; abnormal
+意料	意料	yi4liao4	yìliào	expectation; to anticipate; to think ahead
+意识	意識	yi4shi	yìshi	realize; consciousness; awareness; sense
+意图	意圖	yi4tu2	yìtú	intent; intention; intend
+意味着	意味著	yi4wei4zhe	yìwèizhe	signify; to mean; imply
+意向	意向	yi4xiang4	yìxiàng	will; intent; disposition
+意志	意志	yi4zhi4	yìzhì	will; willpower; determination
+毅力	毅力	yi4li4	yìlì	willpower; perseverance; will; stamina; tenacity
+毅然	毅然	yi4ran2	yìrán	without hesitation; resolutely; firmly
+翼	翼	yi4	yì	wings; fins on fish; shelter
+阴谋	陰謀	yin1mou2	yīnmóu	a plot; a conspiracy
+音响	音響	yin1xiang3	yīnxiǎng	(Electronic) speakers; acoustics; sound field (i.e., in a room or theater)
+引导	引導	yin3dao3	yǐndǎo	to guide; to conduct; introduction
+引擎	引擎	yin3qing2	yǐnqíng	engine
+引用	引用	yin3yong4	yǐnyòng	quote; cite
+饮食	飲食	yin3shi2	yǐnshí	food and drink; diet
+隐蔽	隱蔽	yin3bi4	yǐnbì	conceal; hide; covert; under cover; Take cover!
+隐患	隱患	yin3huan4	yǐnhuàn	hidden danger
+隐瞒	隱瞞	yin3man2	yǐnmán	conceal; hide; (a taboo subject); cover up the truth
+隐私	隱私	yin3si1	yǐnsī	privacy; personal secret
+隐约	隱約	yin3yue1	yǐnyuē	vague; faint; indistinct
+英明	英明	ying1ming2	yīngmíng	wise; brilliant
+英勇	英勇	ying1yong3	yīngyǒng	bravery; heroic; valiant; gallant
+婴儿	嬰兒	ying1'er2	yīng'ér	baby infant
+迎面	迎面	ying2 mian4	yíng miàn	face to face; headlong; in one's face
+盈利	盈利	ying2li4	yínglì	profit; gain
+应酬	應酬	ying4chou	yìngchou	socialize with; a social engagement
+应邀	應邀	ying4yao1	yìngyāo	at sb.'s invitation
+拥护	擁護	yong1hu4	yōnghù	to support; endorse
+拥有	擁有	yong1you3	yōngyǒu	have; possess
+庸俗	庸俗	yong1su2	yōngsú	filthy; vulgar; debased
+永恒	永恒	yong3heng2	yǒnghéng	eternal; everlasting
+勇于	勇于	yong3yu2	yǒngyú	have the courage to; be brave enough
+涌现	湧現	yong3xian4	yǒngxiàn	spring up; emerge prominently
+踊跃	踴躍	yong3yue4	yǒngyuè	eager; enthusiastically
+用户	用戶	yong4hu4	yònghù	user; consumer; subscriber; customer
+优胜劣汰	優勝劣汰	you1sheng4lie4tai4	yōushèngliètài	survival of the fittest
+优先	優先	you1xian1	yōuxiān	priority; preferential
+优异	優異	you1yi4	yōuyì	exceptional; excellent; outstandingly good
+优越	優越	you1yue4	yōuyuè	superior; superiority
+忧郁	憂郁	you1yu4	yōuyù	melancholy; dejected
+犹如	猶如	you2ru2	yóurú	just as; similar to; appearing to be
+油腻	油膩	you2ni4	yóunì	greasy or oily (food)
+油漆	油漆	you2qi1	yóuqī	oil paint; varnish
+有条不紊	有條不紊	you3tiao2bu4wen3	yǒutiáobùwěn	in an orderly way; methodically; systematically; methodical
+幼稚	幼稚	you4zhi4	yòuzhì	childish; naïve; immature
+诱惑	誘惑	you4huo4	yòuhuò	tempt; temptation; entice; lure; attract
+渔民	漁民	yu2min2	yúmín	fisherman; fisher folk
+愚蠢	愚蠢	yu2chun3	yúchǔn	silly; stupid
+愚昧	愚昧	yu2mei4	yúmèi	ignorant; benighted
+舆论	輿論	yu2lun4	yúlùn	public opinion
+与日俱增	與日俱增	yu3ri4ju4zeng1	yǔrìjùzēng	grow with each passing day
+宇宙	宇宙	yu3zhou4	yǔzhòu	universe; cosmos
+羽绒服	羽絨服	yu3rong2fu2	yǔróngfú	down jacket
+玉	玉	yu4	yù	jade (Kangxi radical 96)
+预料	預料	yu4liao4	yùliào	anticipate; to forecast; expectation
+预期	預期	yu4qi1	yùqī	expect; expected; anticipate
+预算	預算	yu4suan4	yùsuàn	budget
+预先	預先	yu4xian1	yùxiān	beforehand; prior
+预言	預言	yu4yan2	yùyán	predict; prophecy
+预兆	預兆	yu4zhao4	yùzhào	omen, sign
+欲望	欲望	yu4wang4	yùwàng	desire; lust
+寓言	寓言	yu4yan2	yùyán	fable
+愈	愈	yu4	yù	recover; heal; the more ... the more
+冤枉	冤枉	yuan1wang	yuānwang	to wrong; injustice; not worthwhile
+元首	元首	yuan2shou3	yuánshǒu	head of state
+元素	元素	yuan2su4	yuánsù	element; element of a set; chemical element
+元宵节	元宵節	Yuan2xiao1 Jie2	Yuánxiāo Jié	the Lantern Festival
+园林	園林	yuan2lin2	yuánlín	gardens; park; landscape
+原告	原告	yuang2ao4	yuángào	plaintiff; complainant; accuser
+原理	原理	yuan2li3	yuánlǐ	principle; theory
+原始	原始	yuan2shi3	yuánshǐ	first; original; primitive
+原先	原先	yuan2xian1	yuánxiān	former; original
+圆满	圓滿	yuan2man3	yuánmǎn	satisfactory
+缘故	緣故	yuang2u4	yuángù	reason; cause
+源泉	源泉	yuan2quan2	yuánquán	headspring; fountainhead; water source
+约束	約束	yue1shu4	yuēshù	restrict; limit to; constrain; restriction
+乐谱	樂譜	yue4pu3	yuèpǔ	sheet music
+岳母	嶽母	yue4mu3	yuèmǔ	wife's mother; mother-in-law
+孕育	孕育	yun4yu4	yùnyù	be pregnant; to produce offspring; nurture (a development, school of thought, artwork, etc.)
+运算	運算	yun4suan4	yùnsuàn	(mathematical) operation
+运行	運行	yun4xing2	yùnxíng	movement; be in motion; run
+酝酿	醞釀	yun4niang4	yùnniàng	mull over (an issue); hold a preliminary round of exploratory discussions
+蕴藏	蘊藏	yun4cang2	yùncáng	hold in store; contain untapped quantities
+熨	熨	yun4	yùn	iron; press
+杂技	雜技	za2ji4	zájì	acrobatics
+杂交	雜交	za2jiao1	zájiāo	create a hybrid; cross-fertilize
+砸	砸	za2	zá	to smash; to pound; to break; fail
+咋	咋	za3	zǎ	how/why (contraction of 怎么)
+灾难	災難	zai1nan4	zāinàn	disaster; catastrophe
+栽培	栽培	zai1pei2	zāipéi	grow; educate; cultivate
+宰	宰	zai3	zǎi	slaughter; butcher; govern; rule; imperial official in dynastic China
+再接再厉	再接再厲	zai4jie1zai4li4	zàijiēzàilì	continue the struggle; persist; unremitting efforts
+在意	在意	zai4 yi4	zài yì	care about; mind; care
+攒	攢	zan3	zǎn	save; hoard
+暂且	暫且	zan4qie3	zànqiě	for the moment; for the time being; temporarily
+赞叹	贊歎	zan4tan4	zàntàn	sigh or grasp in admiration; highly praise
+赞助	贊助	zan4zhu4	zànzhù	support; sponsor
+遭受	遭受	zao1shou4	zāoshòu	suffer; suffering; be subjected to (something unfortunate)
+遭殃	遭殃	zao1 yang1	zāo yāng	to suffer a calamity; go through a disaster
+遭遇	遭遇	zao1yu4	zāoyù	befall; suffer; encounter
+糟蹋	糟蹋	zao1ta4	zāotà	waste; ruin; wreck; spoil; slander
+造型	造型	zao4xing2	zàoxíng	make a model; to mold
+噪音	噪音	zao4yin1	zàoyīn	uproar; rumble; noise; static
+责怪	責怪	ze2guai4	zéguài	blame; rebuke
+贼	賊	zei2	zéi	thief
+增添	增添	zeng1tian1	zēngtiān	add to; increase
+赠送	贈送	zeng4song4	zèngsòng	give as a present
+扎	紮	zha1	zhā	to prick; push a needle into; penetrating
+扎实	紮實	zha1shi	zhāshi	strong; sturdy; practical
+渣	渣	zha1	zhā	dregs; slag
+眨	眨	zha3	zhǎ	wink; blink
+诈骗	詐騙	zha4pian4	zhàpiàn	defraud; swindle; blackmail
+摘要	摘要	zhai1yao4	zhāiyào	summary; abstract
+债券	債券	zhai4quan4	zhàiquàn	bond
+沾光	沾光	zhan1 guang1	zhān guāng	bask in the light; benefit from association with sth.; reflected glory
+瞻仰	瞻仰	zhan1yang3	zhānyǎng	look at with reverence; admire
+斩钉截铁	斬釘截鐵	zhan3 ding1 jie2 tie3	zhǎn dīng jié tiě	to chop the nail and slice the iron (idiom); resolute and decisive; definitely
+展示	展示	zhan3shi4	zhǎnshì	open up; reveal; to display
+展望	展望	zhan3wang4	zhǎnwàng	outlook; prospect; to look ahead; look forward to
+展现	展現	zhan3xian4	zhǎnxiàn	come out; emerge; express; show
+崭新	嶄新	zhan3xin1	zhǎnxīn	brand new
+占据	占據	zhan4ju4	zhànjù	occupy; hold; inhabit
+占领	占領	zhan4ling3	zhànlǐng	occupy (a territory); capture; seize
+战斗	戰鬥	zhan4dou4	zhàndòu	to fight; to battle; to struggle
+战略	戰略	zhan4lüe4	zhànlüè	strategy
+战术	戰術	zhan4shu4	zhànshù	(military) tactics
+战役	戰役	zhan4yi4	zhànyì	military campaign; battle
+章程	章程	zhang1cheng2	zhāngchéng	written rules; statute; regulations; charter of a corporation
+帐篷	帳篷	zhang4peng	zhàngpeng	tent
+障碍	障礙	zhang4'ai4	zhàng'ài	barrier; obstacle
+招标	招標	zhao1biao1	zhāobiāo	to beckon; to invite bids
+招收	招收	zhao1shou1	zhāoshōu	recruit; take in; to hire
+朝气蓬勃	朝氣蓬勃	zhao1 qi4 peng2 bo2	zhāo qì péng bó	full of youthful energy (idiom); full of vigour and vitality; energetic; spirited; a bright spark
+着迷	著迷	zhao2mi2	zháomí	to be fascinated
+沼泽	沼澤	zhao3ze2	zhǎozé	marsh; swamp; glade; wetlands
+照样	照樣	zhao4yang4	zhàoyàng	as before; (same) as usual
+照耀	照耀	zhao4yao4	zhàoyào	to shine; illuminate
+折腾	折騰	zhe1teng	zhēteng	toss from side to side (e.g. sleeplessly); do something over and over again; cause suffering; play crazy; screw around
+遮挡	遮擋	zhe1dang3	zhēdǎng	shelter from; keep out
+折	折	zhe2	zhé	to break; to fracture; convert into; to fold
+折磨	折磨	zhe2mo	zhémo	persecute; to torture
+侦探	偵探	zhen1tan4	zhēntàn	detective
+珍贵	珍貴	zheng1ui4	zhēnguì	precious
+珍稀	珍稀	zhen1xi1	zhēnxī	rare; precious and uncommon
+珍珠	珍珠	zhen1zhu1	zhēnzhū	pearl
+真理	真理	zhen1li3	zhēnlǐ	truth
+真相	真相	zhen1xiang4	zhēnxiàng	the actual facts; reality
+真挚	真摯	zhen1zhi4	zhēnzhì	sincere; sincerity; genuine
+斟酌	斟酌	zhen1zhuo2	zhēnzhuó	Consider; deliberate
+枕头	枕頭	zhen3tou	zhěntou	pillow
+阵地	陣地	zhen4di4	zhèndì	position; battlefront
+阵容	陣容	zhen4rong2	zhènróng	line-up; troop arrangement
+振奋	振奮	zhen4fen4	zhènfèn	stir oneself up; raise one's spirits; inspire
+振兴	振興	zhen4xing1	zhènxīng	develop vigorously; promote; revive; revitalize; invigorate; re-energize
+震撼	震撼	zhen4han4	zhènhàn	to shake
+震惊	震驚	zhen4jing1	zhènjīng	shock; astonish; amaze
+镇定	鎮定	zhen4ding4	zhèndìng	cool; calm; unperturbed
+镇静	鎮靜	zhen4jing4	zhènjìng	calm; cool; tranquil
+正月	正月	zheng1yue4	zhēngyuè	the first month of the lunar calendar
+争端	爭端	zheng1duan1	zhēngduān	dispute; controversy; conflict
+争夺	爭奪	zheng1duo2	zhēngduó	fight over
+争气	爭氣	zheng1 qi4	zhēng qì	work hard for sth.; determined not to fall short
+争先恐后	爭先恐後	zheng1 xian1 kong3 hou4	zhēng xiān kǒng hòu	striving to be first; compete with each other
+争议	爭議	zheng1yi4	zhēngyì	controversy; dispute; contention
+征服	征服	zheng1fu2	zhēngfú	conquer; subdue
+征收	征收	zheng1shou1	zhēngshōu	levy (fine); impose (tariff)
+挣扎	掙紮	zheng1zha2	zhēngzhá	to struggle
+蒸发	蒸發	zheng1fa1	zhēngfā	evaporate; evaporation
+整顿	整頓	zheng3dun4	zhěngdùn	organize; consolidate
+正当	正當	zheng4 dang1	zhèng dāng	timely; just when, (dàng) proper
+正负	正負	zheng4fu4	zhèngfù	positive and negative; plus-minus
+正规	正規	zheng4gui1	zhèngguī	formal; regular; according to standards
+正经	正經	zheng4jing	zhèngjing	decent; serious; standard; really
+正气	正氣	zheng4qi4	zhèngqì	healthy environment; healthy atmosphere
+正义	正義	zheng4yi4	zhèngyì	justice; righteous
+正宗	正宗	zheng4zong1	zhèngzōng	authentic, orthodox; old school
+证实	證實	zheng4shi2	zhèngshí	confirm; verify
+证书	證書	zheng4shu1	zhèngshū	certificate; credentials
+郑重	鄭重	zheng4zhong4	zhèngzhòng	serious; solemn
+政策	政策	zheng4ce4	zhèngcè	policy
+政权	政權	zheng4quan2	zhèngquán	regime; political power; authority
+症状	症狀	zheng4zhuang4	zhèngzhuàng	symptom (of an illness)
+之际	之際	zhi1ji4	zhījì	during; at the time of; the time when something happens
+支撑	支撐	zhi1cheng1	zhīchēng	support; prop up; crutch; brace
+支出	支出	zhi1chu1	zhīchū	spend; pay out; expense
+支流	支流	zhi1liu2	zhīliú	tributary; minor aspect; offshoot
+支配	支配	zhi1pei4	zhīpèi	to control
+支援	支援	zhi1yuan2	zhīyuán	to support; assist; aid
+支柱	支柱	zhi1zhu4	zhīzhù	pillar; prop; mainstay; backbone
+枝	枝	zhi1	zhī	branch; twig; (mw for sticks, rods, pencils)
+知觉	知覺	zhi1jue2	zhījué	perception; consciousness; feeling
+知足常乐	知足常樂	zhi1zu2chang2le4	zhīzúchánglè	content with what one has
+脂肪	脂肪	zhi1fang2	zhīfáng	body fat
+执行	執行	zhi2xing2	zhíxíng	implementation; carry out; execute
+执着	執著	zhi2zhuo2	zhízhuó	to refuse to change one's viewpoint
+直播	直播	zhi2bo1	zhíbō	live broadcast (not recorded)
+直径	直徑	zhi2jing4	zhíjìng	diameter
+侄子	侄子	zhi2zi	zhízi	nephew; brother's son or daughter
+值班	值班	zhi2 ban1	zhí bān	be on duty; work a shift
+职能	職能	zhin2eng2	zhínéng	function; role
+职位	職位	zhi2wei4	zhíwèi	(professional) position
+职务	職務	zhi2wu4	zhíwù	post; a position; job; duties
+殖民地	殖民地	zhi2min2di4	zhímíndì	colony
+指标	指標	zhi3biao1	zhǐbiāo	target; norm; index; indicator
+指定	指定	zhi3ding4	zhǐdìng	appoint; designate
+指甲	指甲	zhi3jia	zhǐjia	fingernail
+指令	指令	zhi3ling4	zhǐlìng	order; command; instruction
+指南针	指南針	zhin3an2zhen1	zhǐnánzhēn	compass
+指示	指示	zhi3shi4	zhǐshì	indicate; instruct; instructions
+指望	指望	zhi3wang4	zhǐwàng	hope for; count on; hope
+指责	指責	zhi3ze2	zhǐzé	to censure; criticize; find fault with
+志气	志氣	zhi4qi4	zhìqì	ambition; resolve; backbone; drive; spirit
+制裁	制裁	zhi4cai2	zhìcái	punish; (economic) sanctions
+制服	制服	zhi4fu2	zhìfú	uniform; to subdue; to bring under control
+制约	制約	zhi4yue1	zhìyuē	restrict; condition
+制止	制止	zhi4zhi3	zhìzhǐ	to curb; to put a stop to
+治安	治安	zhi4'an1	zhì'ān	law and order; public security
+治理	治理	zhi4li3	zhìlǐ	to bring under control; to govern; to manage
+致辞	致辭	zhi4ci2	zhìcí	make/deliver a speech
+致力	致力	zhi4li4	zhìlì	work for; devote one's efforts
+致使	致使	zhi4shi3	zhìshǐ	cause; result in
+智力	智力	zhi4li4	zhìlì	intelligence; intellect
+智能	智能	zhin4eng2	zhìnéng	intelligent; capability; smart (phone, system, bomb, etc.)
+智商	智商	zhi4shang1	zhìshāng	IQ (intelligence quotient)
+滞留	滯留	zhi4liu2	zhìliú	detain; retention
+中断	中斷	zhong1duan4	zhōngduàn	interrupt; break off
+中立	中立	zhong1li4	zhōnglì	neutral; neutrality
+中央	中央	zhong1yang1	zhōngyāng	central; middle; center
+忠诚	忠誠	zhong1cheng2	zhōngchéng	honest; loyalty; devoted
+忠实	忠實	zhong1shi2	zhōngshí	faithful; dependable
+终点	終點	zhong1dian3	zhōngdiǎn	the end; end point; destination; finish line (in a race)
+终究	終究	zhong1jiu1	zhōngjiū	in the end; after all is said and done; eventually
+终身	終身	zhong1shen1	zhōngshēn	lifelong
+终止	終止	zhong1zhi3	zhōngzhǐ	stop; cease; terminate (legal)
+衷心	衷心	zhong1xin1	zhōngxīn	heartfelt; wholehearted; cordial
+肿瘤	腫瘤	zhong3liu2	zhǒngliú	tumor; neoplasm
+种子	種子	zhong3zi	zhǒngzi	seed
+种族	種族	zhong3zu2	zhǒngzú	race; ethnicity
+众所周知	衆所周知	zhong4 suo3 zhou1 zhi1	zhòng suǒ zhōu zhī	as everyone knows; (saying) as is known to everyone
+种植	種植	zhong4zhi2	zhòngzhí	plant; grow; crop
+重心	重心	zhong4xin1	zhòngxīn	center of gravity; central core; main part
+舟	舟	zhou1	zhōu	boat (Kangxi radical 137)
+州	州	zhou1	zhōu	province; sub-prefecture; (United States) state
+周边	周邊	zhou1bian1	zhōubiān	surrounding
+周密	周密	zhou1mi4	zhōumì	meticulous; careful; thorough
+周年	周年	zhou1nian2	zhōunián	anniversary; annual
+周期	周期	zhou1qi1	zhōuqī	period; cycle; rhythm
+周折	周折	zhou1zhe2	zhōuzhé	setback; twists and turns; problem; complication
+周转	周轉	zhou1zhuan3	zhōuzhuǎn	turnover (in cash or personnel); have enough resources to cover a need
+粥	粥	zhou1	zhōu	porridge; congee; gruel
+昼夜	晝夜	zhou4ye4	zhòuyè	day and night; continuously without stop
+皱纹	皺紋	zhou4wen2	zhòuwén	wrinkle; furrow
+株	株	zhu1	zhū	stem; root; trunk; (mw for plants)
+诸位	諸位	zhu1wei4	zhūwèi	(pronoun) everyone; ladies and gentlemen
+逐年	逐年	zhun2ian2	zhúnián	year after year; on an annual basis
+主办	主辦	zhu3ban4	zhǔbàn	to host (a conference or sports event)
+主导	主導	zhu3dao3	zhǔdǎo	leading; dominant; guiding
+主管	主管	zhu3guan3	zhǔguǎn	person in charge of (a position, etc.); preside over; Chief Operating Officer (COO)
+主流	主流	zhu3liu2	zhǔliú	main stream (of a river); the essential point
+主权	主權	zhu3quan2	zhǔquán	sovereignty
+主义	主義	zhu3yi4	zhǔyì	-ism; ideology
+拄	拄	zhu3	zhǔ	post; lean on a stick; prop
+嘱咐	囑咐	zhu3fu4	zhǔfù	enjoin; to tell; exhort
+助理	助理	zhu4li3	zhùlǐ	assistant
+助手	助手	zhu4shou3	zhùshǒu	assistant; helper
+住宅	住宅	zhu4zhai2	zhùzhái	residence; tenement
+注射	注射	zhu4she4	zhùshè	injection; inject (medicine)
+注视	注視	zhu4shi4	zhùshì	watch attentively; gaze at; stare
+注释	注釋	zhu4shi4	zhùshì	annotate; annotation; note; make notes in the margin
+注重	注重	zhu4zhong4	zhùzhòng	pay attention; emphasize; put stress on
+驻扎	駐紮	zhu4zha1	zhùzhā	to station; to garrison (troops)
+著作	著作	zhu4zuo4	zhùzuò	work; book; writing
+铸造	鑄造	zhu4zao4	zhùzào	cast (pour metal into a mold)
+拽	拽	zhuai4	zhuài	drag; haul
+专长	專長	zhuan1chang2	zhuāncháng	specialty; special knowledge or ability
+专程	專程	zhuan1cheng2	zhuānchéng	special-purpose trip
+专利	專利	zhuan1li4	zhuānlì	patent
+专题	專題	zhuan1ti2	zhuāntí	special topic; questions; special matter or subject
+砖	磚	zhuan1	zhuān	brick
+转达	轉達	zhuan3da2	zhuǎndá	pass on; convey; communicate
+转让	轉讓	zhuan3rang4	zhuǎnràng	transfer (technology, good, etc.); make over
+转移	轉移	zhuan3yi2	zhuǎnyí	to shift; divert; migrate
+转折	轉折	zhuan3zhe2	zhuǎnzhé	turning point; shift in the trend of events; plot twist in a book
+传记	傳記	zhuan4ji4	zhuànjì	biography
+庄稼	莊稼	zhuang1jia	zhuāngjia	farm crops
+庄严	莊嚴	zhuang1yan2	zhuāngyán	stately; dignified
+庄重	莊重	zhuang1zhong4	zhuāngzhòng	grave; solemn; dignified
+装备	裝備	zhuang1bei4	zhuāngbèi	equipment; to equip; to outfit
+装卸	裝卸	zhuang1xie4	zhuāngxiè	load and unload; to transfer
+壮观	壯觀	zhuang4guan1	zhuàngguān	spectacular; grand (of buildings, monuments, scenery, etc.)
+壮丽	壯麗	zhuang4li4	zhuànglì	magnificence; splendid; majestic
+壮烈	壯烈	zhuang4lie4	zhuàngliè	brave and honorable
+幢	幢	zhuang4	zhuàng	(mw for houses, buildings); tent
+追悼	追悼	zhui1dao4	zhuīdào	mourning; memorial (service, etc.)
+追究	追究	zhui1jiu1	zhuījiū	investigate; look into; find out
+坠	墜	zhui4	zhuì	fall; drop
+准则	准則	zhun3ze2	zhǔnzé	principle; standard or norm; criterion
+卓越	卓越	zhuo2yue4	zhuóyuè	distinction; excellence; splendid
+着手	著手	zhuo2shou3	zhuóshǒu	put one's hand to; commence
+着想	著想	zhuo2xiang3	zhuóxiǎng	give consideration to; consider (other people's) needs
+着重	著重	zhuo2zhong4	zhuózhòng	put emphasis on; to stress
+琢磨	琢磨	zuo2mo	zuómo	ponder; (also zhuómó: to polish (gems or literary works))
+姿态	姿態	zi1tai4	zītài	attitude; posture; stance
+资本	資本	zi1ben3	zīběn	(Economics) capital; asset
+资产	資産	zi1chan3	zīchǎn	property; assets
+资深	資深	zi1shen1	zīshēn	experienced; senior
+资助	資助	zi1zhu4	zīzhù	subsidy; provide financial aid
+滋润	滋潤	zi1run4	zīrùn	quenched; moist
+滋味	滋味	zi1wei4	zīwèi	taste; flavor; the way one feels
+子弹	子彈	zi3dan4	zǐdàn	bullet; cartridge
+自卑	自卑	zi4bei1	zìbēi	feel inferior; be self-abased
+自发	自發	zi4fa1	zìfā	spontaneous; unprompted
+自力更生	自力更生	zi4 li4 geng1 sheng1	zì lì gēng shēng	(idiom) self reliance
+自满	自滿	zi4man3	zìmǎn	complacent; self-satisfied
+自主	自主	zi4zhu3	zìzhǔ	independent; to act for oneself; autonomous
+宗教	宗教	zong1jiao4	zōngjiào	religion
+宗旨	宗旨	zong1zhi3	zōngzhǐ	purpose; objective; aim; goal
+棕色	棕色	zong1se4	zōngsè	brown (the color)
+踪迹	蹤迹	zong1ji4	zōngjì	tracks; trail; footprint; trace; vestige
+总而言之	總而言之	zong3er2yan2zhi1	zǒngéryánzhī	in short; in a word
+总和	總和	zong3he2	zǒnghé	sum
+纵横	縱橫	zong4heng2	zònghéng	able to move unhindered; length and breadth
+走廊	走廊	zou3lang2	zǒuláng	corridor; hallway
+走漏	走漏	zou3lou4	zǒulòu	leak (information, liquid, etc); divulge; reveal
+走私	走私	zou3 si1	zǒu sī	smuggle; have an illicit affair
+揍	揍	zou4	zòu	(informal) beat; hit; (regional) smash; break
+租赁	租賃	zu1lin4	zūlìn	rent; lease
+足以	足以	zu2yi3	zúyǐ	sufficient to ...; so much so that; sufficiently
+阻碍	阻礙	zu3'ai4	zǔ'ài	obstruct; hinder; impede
+阻拦	阻攔	zu3lan2	zǔlán	to stop; obstruct; block off
+阻挠	阻撓	zun3ao2	zǔnáo	thwart; to obstruct (something); stand in the way
+祖父	祖父	zu3fu4	zǔfù	paternal grandfather
+祖国	祖國	zu3guo2	zǔguó	homeland; motherland; fatherland
+祖先	祖先	zu3xian1	zǔxiān	ancestor; forbearer
+钻研	鑽研	zuan1yan2	zuānyán	study intensively; delve into
+钻石	鑽石	zuan4shi2	zuànshí	diamond
+嘴唇	嘴唇	zui3chun2	zuǐchún	lip
+罪犯	罪犯	zui4fan4	zuìfàn	criminal
+尊严	尊嚴	zun1yan2	zūnyán	dignity; sanctity; honor
+遵循	遵循	zun1xun2	zūnxún	follow; abide by
+作弊	作弊	zuo4bi4	zuòbì	practice fraud; cheat
+作废	作廢	zuo4fei4	zuòfèi	cancellation; delete; to nullify; to expire and thus lose validity
+作风	作風	zuo4feng1	zuòfēng	work style; way
+作息	作息	zuo4xi1	zuòxī	work and rest
+座右铭	座右銘	zuo4you4ming2	zuòyòumíng	motto
+做主	做主	zuo4zhu3	zuòzhǔ	decide; take the responsibility for a decision

--- a/vocab/mandarin/hsk/6/vocab.json
+++ b/vocab/mandarin/hsk/6/vocab.json
@@ -1,0 +1,17502 @@
+[
+    {
+        "intermediate_1": "ai1",
+        "intermediate_2": "āi",
+        "native_1": "get close to; in sequence",
+        "primary_1": "挨",
+        "primary_2": "挨"
+    },
+    {
+        "intermediate_1": "ai2zheng4",
+        "intermediate_2": "áizhèng",
+        "native_1": "cancer",
+        "primary_1": "癌症",
+        "primary_2": "癌症"
+    },
+    {
+        "intermediate_1": "ai4bu2shi4shou3",
+        "intermediate_2": "àibúshìshǒu",
+        "native_1": "love something too much to part with it",
+        "primary_1": "爱不释手",
+        "primary_2": "愛不釋手"
+    },
+    {
+        "intermediate_1": "ai4dai4",
+        "intermediate_2": "àidài",
+        "native_1": "love and respect",
+        "primary_1": "爱戴",
+        "primary_2": "愛戴"
+    },
+    {
+        "intermediate_1": "ai4mei4",
+        "intermediate_2": "àimèi",
+        "native_1": "ambiguous; shady",
+        "primary_1": "暧昧",
+        "primary_2": "暧昧"
+    },
+    {
+        "intermediate_1": "an1ning2",
+        "intermediate_2": "ānníng",
+        "native_1": "peaceful; calm; tranquil; composed",
+        "primary_1": "安宁",
+        "primary_2": "安甯"
+    },
+    {
+        "intermediate_1": "an1xiang2",
+        "intermediate_2": "ānxiáng",
+        "native_1": "serene; composed",
+        "primary_1": "安详",
+        "primary_2": "安詳"
+    },
+    {
+        "intermediate_1": "an1zhi4",
+        "intermediate_2": "ānzhì",
+        "native_1": "find a place for; help settle down; arrange for",
+        "primary_1": "安置",
+        "primary_2": "安置"
+    },
+    {
+        "intermediate_1": "an4mo2",
+        "intermediate_2": "ànmó",
+        "native_1": "massage",
+        "primary_1": "按摩",
+        "primary_2": "按摩"
+    },
+    {
+        "intermediate_1": "an4jian4",
+        "intermediate_2": "ànjiàn",
+        "native_1": "legal case; judicial case",
+        "primary_1": "案件",
+        "primary_2": "案件"
+    },
+    {
+        "intermediate_1": "an4li4",
+        "intermediate_2": "ànlì",
+        "native_1": "(Law) case",
+        "primary_1": "案例",
+        "primary_2": "案例"
+    },
+    {
+        "intermediate_1": "an4shi4",
+        "intermediate_2": "ànshì",
+        "native_1": "drop a hint; suggest",
+        "primary_1": "暗示",
+        "primary_2": "暗示"
+    },
+    {
+        "intermediate_1": "ang2gui4",
+        "intermediate_2": "ángguì",
+        "native_1": "expensive; costly",
+        "primary_1": "昂贵",
+        "primary_2": "昂貴"
+    },
+    {
+        "intermediate_1": "ao1tu1",
+        "intermediate_2": "āotū",
+        "native_1": "(of a surface) uneven; bumpy",
+        "primary_1": "凹凸",
+        "primary_2": "凹凸"
+    },
+    {
+        "intermediate_1": "ao2",
+        "intermediate_2": "áo",
+        "native_1": "endure; to boil",
+        "primary_1": "熬",
+        "primary_2": "熬"
+    },
+    {
+        "intermediate_1": "ao4mi4",
+        "intermediate_2": "àomì",
+        "native_1": "mystery; enigma; profound; deep",
+        "primary_1": "奥秘",
+        "primary_2": "奧秘"
+    },
+    {
+        "intermediate_1": "ba1bu4de2",
+        "intermediate_2": "bābùdé",
+        "native_1": "eagerly look forward to; earnestly wish; be only too anxious to",
+        "primary_1": "巴不得",
+        "primary_2": "巴不得"
+    },
+    {
+        "intermediate_1": "ba1jie",
+        "intermediate_2": "bājie",
+        "native_1": "to fawn on; curry favor with",
+        "primary_1": "巴结",
+        "primary_2": "巴結"
+    },
+    {
+        "intermediate_1": "ba1",
+        "intermediate_2": "bā",
+        "native_1": "dig up; pull down; take off",
+        "primary_1": "扒",
+        "primary_2": "扒"
+    },
+    {
+        "intermediate_1": "ba1",
+        "intermediate_2": "bā",
+        "native_1": "scar",
+        "primary_1": "疤",
+        "primary_2": "疤"
+    },
+    {
+        "intermediate_1": "ba2miao2zhu4zhang3",
+        "intermediate_2": "bámiáozhùzhǎng",
+        "native_1": "(literally) help shoots grow by pulling them out; spoil things by excessive enthusiasm",
+        "primary_1": "拔苗助长",
+        "primary_2": "拔苗助長"
+    },
+    {
+        "intermediate_1": "ba3 guan1",
+        "intermediate_2": "bǎ guān",
+        "native_1": "guard a pass; check on",
+        "primary_1": "把关",
+        "primary_2": "把關"
+    },
+    {
+        "intermediate_1": "ba3shou",
+        "intermediate_2": "bǎshou",
+        "native_1": "knob; handle; grip",
+        "primary_1": "把手",
+        "primary_2": "把手"
+    },
+    {
+        "intermediate_1": "ba4 gong1",
+        "intermediate_2": "bà gōng",
+        "native_1": "to strike; go on strike",
+        "primary_1": "罢工",
+        "primary_2": "罷工"
+    },
+    {
+        "intermediate_1": "ba4dao4",
+        "intermediate_2": "bàdào",
+        "native_1": "overbearing; despotic hegemony; rule by force; (of liquor, medicine, etc.) strong",
+        "primary_1": "霸道",
+        "primary_2": "霸道"
+    },
+    {
+        "intermediate_1": "bai1",
+        "intermediate_2": "bāi",
+        "native_1": "break with both hands",
+        "primary_1": "掰",
+        "primary_2": "掰"
+    },
+    {
+        "intermediate_1": "bai3tuo1",
+        "intermediate_2": "bǎituō",
+        "native_1": "break away; free oneself from; cast off",
+        "primary_1": "摆脱",
+        "primary_2": "擺脫"
+    },
+    {
+        "intermediate_1": "bai4huai4",
+        "intermediate_2": "bàihuài",
+        "native_1": "ruin; corrupt; undermine",
+        "primary_1": "败坏",
+        "primary_2": "敗壞"
+    },
+    {
+        "intermediate_1": "bai4fang3",
+        "intermediate_2": "bàifǎng",
+        "native_1": "pay a visit; call on",
+        "primary_1": "拜访",
+        "primary_2": "拜訪"
+    },
+    {
+        "intermediate_1": "bai4 nian2",
+        "intermediate_2": "bài nián",
+        "native_1": "congratulate the New Year; wish sb. a Happy New Year",
+        "primary_1": "拜年",
+        "primary_2": "拜年"
+    },
+    {
+        "intermediate_1": "bai4tuo1",
+        "intermediate_2": "bàituō",
+        "native_1": "ask a favor; request; please!",
+        "primary_1": "拜托",
+        "primary_2": "拜托"
+    },
+    {
+        "intermediate_1": "ban1bu4",
+        "intermediate_2": "bānbù",
+        "native_1": "promulgate; to issue; publish (e.g a decree)",
+        "primary_1": "颁布",
+        "primary_2": "頒布"
+    },
+    {
+        "intermediate_1": "ban1fa1",
+        "intermediate_2": "bānfā",
+        "native_1": "issue; promulgate; award",
+        "primary_1": "颁发",
+        "primary_2": "頒發"
+    },
+    {
+        "intermediate_1": "ban1",
+        "intermediate_2": "bān",
+        "native_1": "variety; speckled; spot; colored patch; stripe",
+        "primary_1": "斑",
+        "primary_2": "斑"
+    },
+    {
+        "intermediate_1": "ban3ben3",
+        "intermediate_2": "bǎnběn",
+        "native_1": "edition",
+        "primary_1": "版本",
+        "primary_2": "版本"
+    },
+    {
+        "intermediate_1": "ban4 tu2 er2 fei4",
+        "intermediate_2": "bàn tú ér fèi",
+        "native_1": "give up halfway; leave sth. unfinished",
+        "primary_1": "半途而废",
+        "primary_2": "半途而廢"
+    },
+    {
+        "intermediate_1": "ban4yan3",
+        "intermediate_2": "bànyǎn",
+        "native_1": "play the part of; act",
+        "primary_1": "扮演",
+        "primary_2": "扮演"
+    },
+    {
+        "intermediate_1": "ban4lü3",
+        "intermediate_2": "bànlǚ",
+        "native_1": "companion; partner; mate",
+        "primary_1": "伴侣",
+        "primary_2": "伴侶"
+    },
+    {
+        "intermediate_1": "ban4sui2",
+        "intermediate_2": "bànsuí",
+        "native_1": "accompany; go with; follow",
+        "primary_1": "伴随",
+        "primary_2": "伴隨"
+    },
+    {
+        "intermediate_1": "bang3jia4",
+        "intermediate_2": "bǎngjià",
+        "native_1": "kidnap; staking",
+        "primary_1": "绑架",
+        "primary_2": "綁架"
+    },
+    {
+        "intermediate_1": "bang3yang4",
+        "intermediate_2": "bǎngyàng",
+        "native_1": "example; model",
+        "primary_1": "榜样",
+        "primary_2": "榜樣"
+    },
+    {
+        "intermediate_1": "bang4",
+        "intermediate_2": "bàng",
+        "native_1": "pound; weigh; scale",
+        "primary_1": "磅",
+        "primary_2": "磅"
+    },
+    {
+        "intermediate_1": "bao1bi4",
+        "intermediate_2": "bāobì",
+        "native_1": "to shield; to harbor; cover up",
+        "primary_1": "包庇",
+        "primary_2": "包庇"
+    },
+    {
+        "intermediate_1": "bao1fu",
+        "intermediate_2": "bāofu",
+        "native_1": "bundle wrapped in cloth; cloth-wrapper",
+        "primary_1": "包袱",
+        "primary_2": "包袱"
+    },
+    {
+        "intermediate_1": "bao1wei2",
+        "intermediate_2": "bāowéi",
+        "native_1": "surround; encircle; hem in",
+        "primary_1": "包围",
+        "primary_2": "包圍"
+    },
+    {
+        "intermediate_1": "bao1zhuang1",
+        "intermediate_2": "bāozhuāng",
+        "native_1": "to pack; package; make up",
+        "primary_1": "包装",
+        "primary_2": "包裝"
+    },
+    {
+        "intermediate_1": "bao3he2",
+        "intermediate_2": "bǎohé",
+        "native_1": "saturation",
+        "primary_1": "饱和",
+        "primary_2": "飽和"
+    },
+    {
+        "intermediate_1": "bao3jing1cang1sang1",
+        "intermediate_2": "bǎojīngcāngsāng",
+        "native_1": "experienced many changes",
+        "primary_1": "饱经沧桑",
+        "primary_2": "飽經滄桑"
+    },
+    {
+        "intermediate_1": "bao3guan3",
+        "intermediate_2": "bǎoguǎn",
+        "native_1": "assure; take care of; surely",
+        "primary_1": "保管",
+        "primary_2": "保管"
+    },
+    {
+        "intermediate_1": "bao3 mi4",
+        "intermediate_2": "bǎo mì",
+        "native_1": "keep secret/confidential",
+        "primary_1": "保密",
+        "primary_2": "保密"
+    },
+    {
+        "intermediate_1": "bao3mu3",
+        "intermediate_2": "bǎomǔ",
+        "native_1": "nanny; housekeeper",
+        "primary_1": "保姆",
+        "primary_2": "保姆"
+    },
+    {
+        "intermediate_1": "bao3shou3",
+        "intermediate_2": "bǎoshǒu",
+        "native_1": "conservative (ideas, estimates, politically, etc.); to guard; to keep",
+        "primary_1": "保守",
+        "primary_2": "保守"
+    },
+    {
+        "intermediate_1": "bao3wei4",
+        "intermediate_2": "bǎowèi",
+        "native_1": "defend; to safeguard",
+        "primary_1": "保卫",
+        "primary_2": "保衛"
+    },
+    {
+        "intermediate_1": "bao3yang3",
+        "intermediate_2": "bǎoyǎng",
+        "native_1": "take good care of (or conserve) one's health; keep in good repair",
+        "primary_1": "保养",
+        "primary_2": "保養"
+    },
+    {
+        "intermediate_1": "bao3zhang4",
+        "intermediate_2": "bǎozhàng",
+        "native_1": "ensure; to guarantee; protect",
+        "primary_1": "保障",
+        "primary_2": "保障"
+    },
+    {
+        "intermediate_1": "bao3zhong4",
+        "intermediate_2": "bǎozhòng",
+        "native_1": "take care (of oneself)",
+        "primary_1": "保重",
+        "primary_2": "保重"
+    },
+    {
+        "intermediate_1": "bao4chou2",
+        "intermediate_2": "bàochóu",
+        "native_1": "retaliate; to revenge; avenge",
+        "primary_1": "报仇",
+        "primary_2": "報仇"
+    },
+    {
+        "intermediate_1": "bao4chou",
+        "intermediate_2": "bàochou",
+        "native_1": "reward; remuneration",
+        "primary_1": "报酬",
+        "primary_2": "報酬"
+    },
+    {
+        "intermediate_1": "bao4da2",
+        "intermediate_2": "bàodá",
+        "native_1": "repay; requite",
+        "primary_1": "报答",
+        "primary_2": "報答"
+    },
+    {
+        "intermediate_1": "bao4fu",
+        "intermediate_2": "bàofu",
+        "native_1": "retaliate; revenge",
+        "primary_1": "报复",
+        "primary_2": "報複"
+    },
+    {
+        "intermediate_1": "bao4jing3",
+        "intermediate_2": "bàojǐng",
+        "native_1": "report (an incident) to the police",
+        "primary_1": "报警",
+        "primary_2": "報警"
+    },
+    {
+        "intermediate_1": "bao4xiao1",
+        "intermediate_2": "bàoxiāo",
+        "native_1": "submit an expense account; apply for reimbursement; write off",
+        "primary_1": "报销",
+        "primary_2": "報銷"
+    },
+    {
+        "intermediate_1": "bao4fu4",
+        "intermediate_2": "bàofù",
+        "native_1": "aspiration; ambition",
+        "primary_1": "抱负",
+        "primary_2": "抱負"
+    },
+    {
+        "intermediate_1": "bao4li4",
+        "intermediate_2": "bàolì",
+        "native_1": "violence; (use) force",
+        "primary_1": "暴力",
+        "primary_2": "暴力"
+    },
+    {
+        "intermediate_1": "bao4lu4",
+        "intermediate_2": "bàolù",
+        "native_1": "expose; reveal; lay bare",
+        "primary_1": "暴露",
+        "primary_2": "暴露"
+    },
+    {
+        "intermediate_1": "bao4guang1",
+        "intermediate_2": "bàoguāng",
+        "native_1": "to expose; to make public",
+        "primary_1": "曝光",
+        "primary_2": "曝光"
+    },
+    {
+        "intermediate_1": "bao4fa1",
+        "intermediate_2": "bàofā",
+        "native_1": "break out; erupt; explode",
+        "primary_1": "爆发",
+        "primary_2": "爆發"
+    },
+    {
+        "intermediate_1": "bao4zha4",
+        "intermediate_2": "bàozhà",
+        "native_1": "explode; explosion; blow up",
+        "primary_1": "爆炸",
+        "primary_2": "爆炸"
+    },
+    {
+        "intermediate_1": "bei1bi3",
+        "intermediate_2": "bēibǐ",
+        "native_1": "base; mean; despicable; contemptible; unprincipled",
+        "primary_1": "卑鄙",
+        "primary_2": "卑鄙"
+    },
+    {
+        "intermediate_1": "bei1'ai1",
+        "intermediate_2": "bēi'āi",
+        "native_1": "grieved; sorrowful; sad",
+        "primary_1": "悲哀",
+        "primary_2": "悲哀"
+    },
+    {
+        "intermediate_1": "bei1can3",
+        "intermediate_2": "bēicǎn",
+        "native_1": "miserable; tragic",
+        "primary_1": "悲惨",
+        "primary_2": "悲慘"
+    },
+    {
+        "intermediate_1": "bei3ji2",
+        "intermediate_2": "běijí",
+        "native_1": "the North Pole",
+        "primary_1": "北极",
+        "primary_2": "北極"
+    },
+    {
+        "intermediate_1": "bei4ke2",
+        "intermediate_2": "bèiké",
+        "native_1": "shell; conch; cowry",
+        "primary_1": "贝壳",
+        "primary_2": "貝殼"
+    },
+    {
+        "intermediate_1": "bei4fen4",
+        "intermediate_2": "bèifèn",
+        "native_1": "to back up; a backup",
+        "primary_1": "备份",
+        "primary_2": "備份"
+    },
+    {
+        "intermediate_1": "bei4wang4lu4",
+        "intermediate_2": "bèiwànglù",
+        "native_1": "memorandum; aide-memoire; diplomacy memorandum; memorandum book",
+        "primary_1": "备忘录",
+        "primary_2": "備忘錄"
+    },
+    {
+        "intermediate_1": "bei4pan4",
+        "intermediate_2": "bèipàn",
+        "native_1": "betray; forsake",
+        "primary_1": "背叛",
+        "primary_2": "背叛"
+    },
+    {
+        "intermediate_1": "bei4song4",
+        "intermediate_2": "bèisòng",
+        "native_1": "recite",
+        "primary_1": "背诵",
+        "primary_2": "背誦"
+    },
+    {
+        "intermediate_1": "bei4dong4",
+        "intermediate_2": "bèidòng",
+        "native_1": "passive",
+        "primary_1": "被动",
+        "primary_2": "被動"
+    },
+    {
+        "intermediate_1": "bei4gao4",
+        "intermediate_2": "bèigào",
+        "native_1": "defendant",
+        "primary_1": "被告",
+        "primary_2": "被告"
+    },
+    {
+        "intermediate_1": "ben1bo1",
+        "intermediate_2": "bēnbō",
+        "native_1": "rush about; be busy running about",
+        "primary_1": "奔波",
+        "primary_2": "奔波"
+    },
+    {
+        "intermediate_1": "ben1chi2",
+        "intermediate_2": "bēnchí",
+        "native_1": "run quickly; speed; Mercedes-Benz (German vehicle manufacturer)",
+        "primary_1": "奔驰",
+        "primary_2": "奔馳"
+    },
+    {
+        "intermediate_1": "ben3neng2",
+        "intermediate_2": "běnnéng",
+        "native_1": "instinct",
+        "primary_1": "本能",
+        "primary_2": "本能"
+    },
+    {
+        "intermediate_1": "ben3qian2",
+        "intermediate_2": "běnqián",
+        "native_1": "capital (financial)",
+        "primary_1": "本钱",
+        "primary_2": "本錢"
+    },
+    {
+        "intermediate_1": "ben3ren2",
+        "intermediate_2": "běnrén",
+        "native_1": "I; me; myself; oneself; in person",
+        "primary_1": "本人",
+        "primary_2": "本人"
+    },
+    {
+        "intermediate_1": "ben3shen1",
+        "intermediate_2": "běnshēn",
+        "native_1": "itself; in itself; per se",
+        "primary_1": "本身",
+        "primary_2": "本身"
+    },
+    {
+        "intermediate_1": "ben3shi",
+        "intermediate_2": "běnshi",
+        "native_1": "ability; skill; capability; (-shì: this matter; literary source)",
+        "primary_1": "本事",
+        "primary_2": "本事"
+    },
+    {
+        "intermediate_1": "ben4zhuo1",
+        "intermediate_2": "bènzhuō",
+        "native_1": "clumsy; awkward; stupid",
+        "primary_1": "笨拙",
+        "primary_2": "笨拙"
+    },
+    {
+        "intermediate_1": "beng1kui4",
+        "intermediate_2": "bēngkuì",
+        "native_1": "collapse; crumble; fall apart",
+        "primary_1": "崩溃",
+        "primary_2": "崩潰"
+    },
+    {
+        "intermediate_1": "beng2",
+        "intermediate_2": "béng",
+        "native_1": "need not; (contraction of 不 and 用)",
+        "primary_1": "甭",
+        "primary_2": "甭"
+    },
+    {
+        "intermediate_1": "beng4fa1",
+        "intermediate_2": "bèngfā",
+        "native_1": "burst forth; burst out",
+        "primary_1": "迸发",
+        "primary_2": "迸發"
+    },
+    {
+        "intermediate_1": "beng4",
+        "intermediate_2": "bèng",
+        "native_1": "jump; bounce; hop",
+        "primary_1": "蹦",
+        "primary_2": "蹦"
+    },
+    {
+        "intermediate_1": "bi1po4",
+        "intermediate_2": "bīpò",
+        "native_1": "to force; compel; coerce",
+        "primary_1": "逼迫",
+        "primary_2": "逼迫"
+    },
+    {
+        "intermediate_1": "bi2ti4",
+        "intermediate_2": "bítì",
+        "native_1": "nasal mucus; snivel",
+        "primary_1": "鼻涕",
+        "primary_2": "鼻涕"
+    },
+    {
+        "intermediate_1": "bi3fang",
+        "intermediate_2": "bǐfang",
+        "native_1": "instance; analogy; example",
+        "primary_1": "比方",
+        "primary_2": "比方"
+    },
+    {
+        "intermediate_1": "bi3yu4",
+        "intermediate_2": "bǐyù",
+        "native_1": "metaphor; analogy; figure of speech",
+        "primary_1": "比喻",
+        "primary_2": "比喻"
+    },
+    {
+        "intermediate_1": "bi3zhong4",
+        "intermediate_2": "bǐzhòng",
+        "native_1": "proportion; specific gravity",
+        "primary_1": "比重",
+        "primary_2": "比重"
+    },
+    {
+        "intermediate_1": "bi3shi4",
+        "intermediate_2": "bǐshì",
+        "native_1": "despise; disdain; look down upon",
+        "primary_1": "鄙视",
+        "primary_2": "鄙視"
+    },
+    {
+        "intermediate_1": "bi4se4",
+        "intermediate_2": "bìsè",
+        "native_1": "stop up; shelter from; hard to get to; unenlightened",
+        "primary_1": "闭塞",
+        "primary_2": "閉塞"
+    },
+    {
+        "intermediate_1": "bi4bing4",
+        "intermediate_2": "bìbìng",
+        "native_1": "malady; evil; malpractice; drawback",
+        "primary_1": "弊病",
+        "primary_2": "弊病"
+    },
+    {
+        "intermediate_1": "bi4duan1",
+        "intermediate_2": "bìduān",
+        "native_1": "malpractice; abuse; corrupt practice",
+        "primary_1": "弊端",
+        "primary_2": "弊端"
+    },
+    {
+        "intermediate_1": "bi4",
+        "intermediate_2": "bì",
+        "native_1": "arm",
+        "primary_1": "臂",
+        "primary_2": "臂"
+    },
+    {
+        "intermediate_1": "bian1jiang1",
+        "intermediate_2": "biānjiāng",
+        "native_1": "border area; borderland; frontier; frontier region",
+        "primary_1": "边疆",
+        "primary_2": "邊疆"
+    },
+    {
+        "intermediate_1": "bian1jie4",
+        "intermediate_2": "biānjiè",
+        "native_1": "boundary; border",
+        "primary_1": "边界",
+        "primary_2": "邊界"
+    },
+    {
+        "intermediate_1": "bian1jing4",
+        "intermediate_2": "biānjìng",
+        "native_1": "frontier",
+        "primary_1": "边境",
+        "primary_2": "邊境"
+    },
+    {
+        "intermediate_1": "bian1yuan2",
+        "intermediate_2": "biānyuán",
+        "native_1": "edge; fringe; verge; brink",
+        "primary_1": "边缘",
+        "primary_2": "邊緣"
+    },
+    {
+        "intermediate_1": "bian1zhi1",
+        "intermediate_2": "biānzhī",
+        "native_1": "to weave; to knit; to plait; to braid; to crochet",
+        "primary_1": "编织",
+        "primary_2": "編織"
+    },
+    {
+        "intermediate_1": "bian1ce4",
+        "intermediate_2": "biāncè",
+        "native_1": "spur on; urge on",
+        "primary_1": "鞭策",
+        "primary_2": "鞭策"
+    },
+    {
+        "intermediate_1": "bian3di1",
+        "intermediate_2": "biǎndī",
+        "native_1": "to belittle; depreciate; disparage",
+        "primary_1": "贬低",
+        "primary_2": "貶低"
+    },
+    {
+        "intermediate_1": "bian3yi4",
+        "intermediate_2": "biǎnyì",
+        "native_1": "negative connotation; derogatory sense",
+        "primary_1": "贬义",
+        "primary_2": "貶義"
+    },
+    {
+        "intermediate_1": "bian3",
+        "intermediate_2": "biǎn",
+        "native_1": "flat",
+        "primary_1": "扁",
+        "primary_2": "扁"
+    },
+    {
+        "intermediate_1": "biang4u4",
+        "intermediate_2": "biàngù",
+        "native_1": "unforeseen event; accident",
+        "primary_1": "变故",
+        "primary_2": "變故"
+    },
+    {
+        "intermediate_1": "bian4qian1",
+        "intermediate_2": "biànqiān",
+        "native_1": "changes; vicissitude",
+        "primary_1": "变迁",
+        "primary_2": "變遷"
+    },
+    {
+        "intermediate_1": "bian4 zhi4",
+        "intermediate_2": "biàn zhì",
+        "native_1": "go bad; deteriorate; metamorphism",
+        "primary_1": "变质",
+        "primary_2": "變質"
+    },
+    {
+        "intermediate_1": "bian4li4",
+        "intermediate_2": "biànlì",
+        "native_1": "convenient; easy; facilitate",
+        "primary_1": "便利",
+        "primary_2": "便利"
+    },
+    {
+        "intermediate_1": "bian4tiao2",
+        "intermediate_2": "biàntiáo",
+        "native_1": "informal note",
+        "primary_1": "便条",
+        "primary_2": "便條"
+    },
+    {
+        "intermediate_1": "bian4yu2",
+        "intermediate_2": "biànyú",
+        "native_1": "be easy; be convenient for",
+        "primary_1": "便于",
+        "primary_2": "便于"
+    },
+    {
+        "intermediate_1": "bian4bu4",
+        "intermediate_2": "biànbù",
+        "native_1": "to cover the whole (area); found everywhere; spread all over",
+        "primary_1": "遍布",
+        "primary_2": "遍布"
+    },
+    {
+        "intermediate_1": "bian4ren4",
+        "intermediate_2": "biànrèn",
+        "native_1": "distinguish; identify; recognize",
+        "primary_1": "辨认",
+        "primary_2": "辨認"
+    },
+    {
+        "intermediate_1": "bian4hu4",
+        "intermediate_2": "biànhù",
+        "native_1": "speak in defense of; argue in favor of; defend",
+        "primary_1": "辩护",
+        "primary_2": "辯護"
+    },
+    {
+        "intermediate_1": "bian4jie3",
+        "intermediate_2": "biànjiě",
+        "native_1": "explain; justify; defend (a point of view, etc.)",
+        "primary_1": "辩解",
+        "primary_2": "辯解"
+    },
+    {
+        "intermediate_1": "bian4zheng4",
+        "intermediate_2": "biànzhèng",
+        "native_1": "investigate; dialectical",
+        "primary_1": "辩证",
+        "primary_2": "辯證"
+    },
+    {
+        "intermediate_1": "bian4zi",
+        "intermediate_2": "biànzi",
+        "native_1": "plait; braid; pigtail",
+        "primary_1": "辫子",
+        "primary_2": "辮子"
+    },
+    {
+        "intermediate_1": "biao1ben3",
+        "intermediate_2": "biāoběn",
+        "native_1": "specimen; sample; the root cause and symptoms of a disease",
+        "primary_1": "标本",
+        "primary_2": "標本"
+    },
+    {
+        "intermediate_1": "biao1ji4",
+        "intermediate_2": "biāojì",
+        "native_1": "sign; mark; symbol",
+        "primary_1": "标记",
+        "primary_2": "標記"
+    },
+    {
+        "intermediate_1": "biao1ti2",
+        "intermediate_2": "biāotí",
+        "native_1": "title; header; headline; caption",
+        "primary_1": "标题",
+        "primary_2": "標題"
+    },
+    {
+        "intermediate_1": "biao3jue2",
+        "intermediate_2": "biǎojué",
+        "native_1": "decide by vote; vote",
+        "primary_1": "表决",
+        "primary_2": "表決"
+    },
+    {
+        "intermediate_1": "biao3tai4",
+        "intermediate_2": "biǎotài",
+        "native_1": "make known one's position; declare where one stands",
+        "primary_1": "表态",
+        "primary_2": "表態"
+    },
+    {
+        "intermediate_1": "biao3zhang1",
+        "intermediate_2": "biǎozhāng",
+        "native_1": "cite (in dispatches); commend",
+        "primary_1": "表彰",
+        "primary_2": "表彰"
+    },
+    {
+        "intermediate_1": "bie1",
+        "intermediate_2": "biē",
+        "native_1": "hold in (urine); hold (breath); choke",
+        "primary_1": "憋",
+        "primary_2": "憋"
+    },
+    {
+        "intermediate_1": "bie2shu4",
+        "intermediate_2": "biéshù",
+        "native_1": "villa",
+        "primary_1": "别墅",
+        "primary_2": "別墅"
+    },
+    {
+        "intermediate_1": "bie2zhi4",
+        "intermediate_2": "biézhì",
+        "native_1": "unique; unconventional; fancy",
+        "primary_1": "别致",
+        "primary_2": "別致"
+    },
+    {
+        "intermediate_1": "bien4iu",
+        "intermediate_2": "bièniu",
+        "native_1": "awkward; unnatural",
+        "primary_1": "别扭",
+        "primary_2": "別扭"
+    },
+    {
+        "intermediate_1": "bin1lin2",
+        "intermediate_2": "bīnlín",
+        "native_1": "on the verge of",
+        "primary_1": "濒临",
+        "primary_2": "瀕臨"
+    },
+    {
+        "intermediate_1": "bing1bao2",
+        "intermediate_2": "bīngbáo",
+        "native_1": "hail",
+        "primary_1": "冰雹",
+        "primary_2": "冰雹"
+    },
+    {
+        "intermediate_1": "bing3",
+        "intermediate_2": "bǐng",
+        "native_1": "bright; fire (3rd Heavenly Stem)",
+        "primary_1": "丙",
+        "primary_2": "丙"
+    },
+    {
+        "intermediate_1": "bing4fei1",
+        "intermediate_2": "bìngfēi",
+        "native_1": "really isn't",
+        "primary_1": "并非",
+        "primary_2": "並非"
+    },
+    {
+        "intermediate_1": "bing4lie4",
+        "intermediate_2": "bìngliè",
+        "native_1": "stand side by side; be juxtaposed",
+        "primary_1": "并列",
+        "primary_2": "並列"
+    },
+    {
+        "intermediate_1": "bo1",
+        "intermediate_2": "bō",
+        "native_1": "to dial; move with a hand/foot; stir; poke; allocate (money)",
+        "primary_1": "拨",
+        "primary_2": "撥"
+    },
+    {
+        "intermediate_1": "bo1lang4",
+        "intermediate_2": "bōlàng",
+        "native_1": "wave",
+        "primary_1": "波浪",
+        "primary_2": "波浪"
+    },
+    {
+        "intermediate_1": "bo1tao1",
+        "intermediate_2": "bōtāo",
+        "native_1": "great waves; billows",
+        "primary_1": "波涛",
+        "primary_2": "波濤"
+    },
+    {
+        "intermediate_1": "bo1xue1",
+        "intermediate_2": "bōxuē",
+        "native_1": "to exploit",
+        "primary_1": "剥削",
+        "primary_2": "剝削"
+    },
+    {
+        "intermediate_1": "bo1zhong3",
+        "intermediate_2": "bōzhǒng",
+        "native_1": "sow seeds; sowing; seed",
+        "primary_1": "播种",
+        "primary_2": "播種"
+    },
+    {
+        "intermediate_1": "bo2mu3",
+        "intermediate_2": "bómǔ",
+        "native_1": "aunt; wife of father's older brother",
+        "primary_1": "伯母",
+        "primary_2": "伯母"
+    },
+    {
+        "intermediate_1": "bo2da4jing1shen1",
+        "intermediate_2": "bódàjīngshēn",
+        "native_1": "broad and profound",
+        "primary_1": "博大精深",
+        "primary_2": "博大精深"
+    },
+    {
+        "intermediate_1": "bo2lan3hui4",
+        "intermediate_2": "bólǎnhuì",
+        "native_1": "(international) exhibition",
+        "primary_1": "博览会",
+        "primary_2": "博覽會"
+    },
+    {
+        "intermediate_1": "bo2dou4",
+        "intermediate_2": "bódòu",
+        "native_1": "fight; struggle; wrestle",
+        "primary_1": "搏斗",
+        "primary_2": "搏鬥"
+    },
+    {
+        "intermediate_1": "bo2ruo4",
+        "intermediate_2": "bóruò",
+        "native_1": "weak; frail",
+        "primary_1": "薄弱",
+        "primary_2": "薄弱"
+    },
+    {
+        "intermediate_1": "bu3chang2",
+        "intermediate_2": "bǔcháng",
+        "native_1": "compensation; make up",
+        "primary_1": "补偿",
+        "primary_2": "補償"
+    },
+    {
+        "intermediate_1": "bu3jiu4",
+        "intermediate_2": "bǔjiù",
+        "native_1": "remedy; repair",
+        "primary_1": "补救",
+        "primary_2": "補救"
+    },
+    {
+        "intermediate_1": "bu3tie1",
+        "intermediate_2": "bǔtiē",
+        "native_1": "subsidy; allowance",
+        "primary_1": "补贴",
+        "primary_2": "補貼"
+    },
+    {
+        "intermediate_1": "bu3zhuo1",
+        "intermediate_2": "bǔzhuō",
+        "native_1": "catch; to seize",
+        "primary_1": "捕捉",
+        "primary_2": "捕捉"
+    },
+    {
+        "intermediate_1": "bu3ru3",
+        "intermediate_2": "bǔrǔ",
+        "native_1": "breast-feeding; to suckle",
+        "primary_1": "哺乳",
+        "primary_2": "哺乳"
+    },
+    {
+        "intermediate_1": "bu4de2yi3",
+        "intermediate_2": "bùdéyǐ",
+        "native_1": "act against one's will; have no alternative",
+        "primary_1": "不得已",
+        "primary_2": "不得已"
+    },
+    {
+        "intermediate_1": "bu4fang2",
+        "intermediate_2": "bùfáng",
+        "native_1": "there is no harm in; might as well",
+        "primary_1": "不妨",
+        "primary_2": "不妨"
+    },
+    {
+        "intermediate_1": "bu4 gan3dang1",
+        "intermediate_2": "bù gǎndāng",
+        "native_1": "(literally) I dare not accept the honor; you flatter me",
+        "primary_1": "不敢当",
+        "primary_2": "不敢當"
+    },
+    {
+        "intermediate_1": "bu2gu4",
+        "intermediate_2": "búgù",
+        "native_1": "in spite of; regardless of; to disregard",
+        "primary_1": "不顾",
+        "primary_2": "不顧"
+    },
+    {
+        "intermediate_1": "bu4jin1",
+        "intermediate_2": "bùjīn",
+        "native_1": "cannot help; can't refrain from",
+        "primary_1": "不禁",
+        "primary_2": "不禁"
+    },
+    {
+        "intermediate_1": "bu4kan1",
+        "intermediate_2": "bùkān",
+        "native_1": "cannot bear/stand; utterly",
+        "primary_1": "不堪",
+        "primary_2": "不堪"
+    },
+    {
+        "intermediate_1": "bu4ke3si1yi4",
+        "intermediate_2": "bùkěsīyì",
+        "native_1": "unimaginable; inconceivable",
+        "primary_1": "不可思议",
+        "primary_2": "不可思議"
+    },
+    {
+        "intermediate_1": "bu2kui4",
+        "intermediate_2": "búkuì",
+        "native_1": "be worthy of; deserve to be called; prove oneself to be",
+        "primary_1": "不愧",
+        "primary_2": "不愧"
+    },
+    {
+        "intermediate_1": "bu2liao4",
+        "intermediate_2": "búliào",
+        "native_1": "unexpectedly; to one's surprise",
+        "primary_1": "不料",
+        "primary_2": "不料"
+    },
+    {
+        "intermediate_1": "bu4mian3",
+        "intermediate_2": "bùmiǎn",
+        "native_1": "unavoidable",
+        "primary_1": "不免",
+        "primary_2": "不免"
+    },
+    {
+        "intermediate_1": "bu4shi2",
+        "intermediate_2": "bùshí",
+        "native_1": "frequently; often; at any time",
+        "primary_1": "不时",
+        "primary_2": "不時"
+    },
+    {
+        "intermediate_1": "bu4xi1",
+        "intermediate_2": "bùxī",
+        "native_1": "to not hesitate; not spare",
+        "primary_1": "不惜",
+        "primary_2": "不惜"
+    },
+    {
+        "intermediate_1": "bu4 xiang1 shang4 xia4",
+        "intermediate_2": "bù xiāng shàng xià",
+        "native_1": "equally matched; about the same",
+        "primary_1": "不相上下",
+        "primary_2": "不相上下"
+    },
+    {
+        "intermediate_1": "bu2xiang4hua4",
+        "intermediate_2": "búxiànghuà",
+        "native_1": "unreasonable; absurd; outrageous",
+        "primary_1": "不像话",
+        "primary_2": "不像話"
+    },
+    {
+        "intermediate_1": "bu2xie4yi2gu4",
+        "intermediate_2": "búxièyígù",
+        "native_1": "not worth seeing; disdain as beneath contempt",
+        "primary_1": "不屑一顾",
+        "primary_2": "不屑一顧"
+    },
+    {
+        "intermediate_1": "bu4yan2'er2yu4",
+        "intermediate_2": "bùyán'éryù",
+        "native_1": "it goes without saying; it is self-evident",
+        "primary_1": "不言而喻",
+        "primary_2": "不言而喻"
+    },
+    {
+        "intermediate_1": "bu4you2de",
+        "intermediate_2": "bùyóude",
+        "native_1": "can't help; cannot but",
+        "primary_1": "不由得",
+        "primary_2": "不由得"
+    },
+    {
+        "intermediate_1": "bu4ze2shou3duan4",
+        "intermediate_2": "bùzéshǒuduàn",
+        "native_1": "by fair means or foul",
+        "primary_1": "不择手段",
+        "primary_2": "不擇手段"
+    },
+    {
+        "intermediate_1": "bu4zhi3",
+        "intermediate_2": "bùzhǐ",
+        "native_1": "incessantly; more than",
+        "primary_1": "不止",
+        "primary_2": "不止"
+    },
+    {
+        "intermediate_1": "bu4gao4",
+        "intermediate_2": "bùgào",
+        "native_1": "notice; bulletin",
+        "primary_1": "布告",
+        "primary_2": "布告"
+    },
+    {
+        "intermediate_1": "bu4ju2",
+        "intermediate_2": "bùjú",
+        "native_1": "arrangement; composition; layout",
+        "primary_1": "布局",
+        "primary_2": "布局"
+    },
+    {
+        "intermediate_1": "bu4zhi4",
+        "intermediate_2": "bùzhì",
+        "native_1": "arrange; decorate; decoration",
+        "primary_1": "布置",
+        "primary_2": "布置"
+    },
+    {
+        "intermediate_1": "bu4fa2",
+        "intermediate_2": "bùfá",
+        "native_1": "pace; (measured) step; march",
+        "primary_1": "步伐",
+        "primary_2": "步伐"
+    },
+    {
+        "intermediate_1": "bu4shu3",
+        "intermediate_2": "bùshǔ",
+        "native_1": "dispose; deploy",
+        "primary_1": "部署",
+        "primary_2": "部署"
+    },
+    {
+        "intermediate_1": "bu4wei4",
+        "intermediate_2": "bùwèi",
+        "native_1": "position; place",
+        "primary_1": "部位",
+        "primary_2": "部位"
+    },
+    {
+        "intermediate_1": "cai2gan4",
+        "intermediate_2": "cáigàn",
+        "native_1": "ability; competence",
+        "primary_1": "才干",
+        "primary_2": "才幹"
+    },
+    {
+        "intermediate_1": "cai2fu4",
+        "intermediate_2": "cáifù",
+        "native_1": "wealth; riches; fortune",
+        "primary_1": "财富",
+        "primary_2": "財富"
+    },
+    {
+        "intermediate_1": "cai2wu4",
+        "intermediate_2": "cáiwù",
+        "native_1": "financial affairs",
+        "primary_1": "财务",
+        "primary_2": "財務"
+    },
+    {
+        "intermediate_1": "cai2zheng4",
+        "intermediate_2": "cáizhèng",
+        "native_1": "public finances; financial",
+        "primary_1": "财政",
+        "primary_2": "財政"
+    },
+    {
+        "intermediate_1": "cai2feng",
+        "intermediate_2": "cáifeng",
+        "native_1": "tailor; dressmaker",
+        "primary_1": "裁缝",
+        "primary_2": "裁縫"
+    },
+    {
+        "intermediate_1": "cai2pan4",
+        "intermediate_2": "cáipàn",
+        "native_1": "judge; to referee; judgment",
+        "primary_1": "裁判",
+        "primary_2": "裁判"
+    },
+    {
+        "intermediate_1": "cai2yuan2",
+        "intermediate_2": "cáiyuán",
+        "native_1": "cut staff; lay off employees",
+        "primary_1": "裁员",
+        "primary_2": "裁員"
+    },
+    {
+        "intermediate_1": "cai3gou4",
+        "intermediate_2": "cǎigòu",
+        "native_1": "make purchases for an organization; go shopping",
+        "primary_1": "采购",
+        "primary_2": "采購"
+    },
+    {
+        "intermediate_1": "cai3ji2",
+        "intermediate_2": "cǎijí",
+        "native_1": "gather; collect",
+        "primary_1": "采集",
+        "primary_2": "采集"
+    },
+    {
+        "intermediate_1": "cai3na4",
+        "intermediate_2": "cǎinà",
+        "native_1": "accept; adopt",
+        "primary_1": "采纳",
+        "primary_2": "采納"
+    },
+    {
+        "intermediate_1": "cai3piao4",
+        "intermediate_2": "cǎipiào",
+        "native_1": "lottery; lottery ticket",
+        "primary_1": "彩票",
+        "primary_2": "彩票"
+    },
+    {
+        "intermediate_1": "can1mou2",
+        "intermediate_2": "cānmóu",
+        "native_1": "advisor; give advice",
+        "primary_1": "参谋",
+        "primary_2": "參謀"
+    },
+    {
+        "intermediate_1": "can1zhao4",
+        "intermediate_2": "cānzhào",
+        "native_1": "consult a reference; refer to (another document)",
+        "primary_1": "参照",
+        "primary_2": "參照"
+    },
+    {
+        "intermediate_1": "can2ji",
+        "intermediate_2": "cánji",
+        "native_1": "deformity; handicapped; crippled",
+        "primary_1": "残疾",
+        "primary_2": "殘疾"
+    },
+    {
+        "intermediate_1": "can2ku4",
+        "intermediate_2": "cánkù",
+        "native_1": "cruel",
+        "primary_1": "残酷",
+        "primary_2": "殘酷"
+    },
+    {
+        "intermediate_1": "can2liu2",
+        "intermediate_2": "cánliú",
+        "native_1": "to remain; be left over; surplus; remnant",
+        "primary_1": "残留",
+        "primary_2": "殘留"
+    },
+    {
+        "intermediate_1": "can2ren3",
+        "intermediate_2": "cánrěn",
+        "native_1": "brutal; bloody; merciless",
+        "primary_1": "残忍",
+        "primary_2": "殘忍"
+    },
+    {
+        "intermediate_1": "can4lan4",
+        "intermediate_2": "cànlàn",
+        "native_1": "to glitter; brilliant; splendid",
+        "primary_1": "灿烂",
+        "primary_2": "燦爛"
+    },
+    {
+        "intermediate_1": "cang1cu4",
+        "intermediate_2": "cāngcù",
+        "native_1": "hurried",
+        "primary_1": "仓促",
+        "primary_2": "倉促"
+    },
+    {
+        "intermediate_1": "cang1ku4",
+        "intermediate_2": "cāngkù",
+        "native_1": "depot; storehouse; warehouse",
+        "primary_1": "仓库",
+        "primary_2": "倉庫"
+    },
+    {
+        "intermediate_1": "cang1bai2",
+        "intermediate_2": "cāngbái",
+        "native_1": "pale; wan; pallid",
+        "primary_1": "苍白",
+        "primary_2": "蒼白"
+    },
+    {
+        "intermediate_1": "cang1",
+        "intermediate_2": "cāng",
+        "native_1": "cabin; hold (of a ship or airplane)",
+        "primary_1": "舱",
+        "primary_2": "艙"
+    },
+    {
+        "intermediate_1": "cao1lao2",
+        "intermediate_2": "cāoláo",
+        "native_1": "work hard; look after",
+        "primary_1": "操劳",
+        "primary_2": "操勞"
+    },
+    {
+        "intermediate_1": "cao1lian4",
+        "intermediate_2": "cāoliàn",
+        "native_1": "to drill; to practice",
+        "primary_1": "操练",
+        "primary_2": "操練"
+    },
+    {
+        "intermediate_1": "cao1zong4",
+        "intermediate_2": "cāozòng",
+        "native_1": "operate; control; manipulation",
+        "primary_1": "操纵",
+        "primary_2": "操縱"
+    },
+    {
+        "intermediate_1": "cao1zuo4",
+        "intermediate_2": "cāozuò",
+        "native_1": "operate; manipulate",
+        "primary_1": "操作",
+        "primary_2": "操作"
+    },
+    {
+        "intermediate_1": "cao2za2",
+        "intermediate_2": "cáozá",
+        "native_1": "noisy; raucous",
+        "primary_1": "嘈杂",
+        "primary_2": "嘈雜"
+    },
+    {
+        "intermediate_1": "cao3'an4",
+        "intermediate_2": "cǎo'àn",
+        "native_1": "draft (legislation, proposal, etc.)",
+        "primary_1": "草案",
+        "primary_2": "草案"
+    },
+    {
+        "intermediate_1": "cao3shuai4",
+        "intermediate_2": "cǎoshuài",
+        "native_1": "cursory; careless; negligent; sloppy; not serious",
+        "primary_1": "草率",
+        "primary_2": "草率"
+    },
+    {
+        "intermediate_1": "ce4mian4",
+        "intermediate_2": "cèmiàn",
+        "native_1": "side; profile; flank; face in profile",
+        "primary_1": "侧面",
+        "primary_2": "側面"
+    },
+    {
+        "intermediate_1": "ce4liang2",
+        "intermediate_2": "cèliáng",
+        "native_1": "to survey; to measure",
+        "primary_1": "测量",
+        "primary_2": "測量"
+    },
+    {
+        "intermediate_1": "ce4hua4",
+        "intermediate_2": "cèhuà",
+        "native_1": "plot; scheme; bring about",
+        "primary_1": "策划",
+        "primary_2": "策劃"
+    },
+    {
+        "intermediate_1": "ce4lüe4",
+        "intermediate_2": "cèlüè",
+        "native_1": "tactics; plot",
+        "primary_1": "策略",
+        "primary_2": "策略"
+    },
+    {
+        "intermediate_1": "ceng2 chu1 bu4 qiong2",
+        "intermediate_2": "céng chū bù qióng",
+        "native_1": "(idiom) emerge more and more; innumerable succession; breeding like flies",
+        "primary_1": "层出不穷",
+        "primary_2": "層出不窮"
+    },
+    {
+        "intermediate_1": "ceng2ci4",
+        "intermediate_2": "céngcì",
+        "native_1": "level; rank order; standing; layer",
+        "primary_1": "层次",
+        "primary_2": "層次"
+    },
+    {
+        "intermediate_1": "cha1bie2",
+        "intermediate_2": "chābié",
+        "native_1": "difference; disparity",
+        "primary_1": "差别",
+        "primary_2": "差別"
+    },
+    {
+        "intermediate_1": "cha1zuo4",
+        "intermediate_2": "chāzuò",
+        "native_1": "power socket",
+        "primary_1": "插座",
+        "primary_2": "插座"
+    },
+    {
+        "intermediate_1": "cha2huo4",
+        "intermediate_2": "cháhuò",
+        "native_1": "investigate and capture a criminal; discover",
+        "primary_1": "查获",
+        "primary_2": "查獲"
+    },
+    {
+        "intermediate_1": "cha4",
+        "intermediate_2": "chà",
+        "native_1": "fork in the road; turn off; diverge",
+        "primary_1": "岔",
+        "primary_2": "岔"
+    },
+    {
+        "intermediate_1": "chan4a4",
+        "intermediate_2": "chànà",
+        "native_1": "an instant (Sanskrit: ksana); split second",
+        "primary_1": "刹那",
+        "primary_2": "刹那"
+    },
+    {
+        "intermediate_1": "cha4yi4",
+        "intermediate_2": "chàyì",
+        "native_1": "flabbergasted; astonished",
+        "primary_1": "诧异",
+        "primary_2": "詫異"
+    },
+    {
+        "intermediate_1": "chai2you2",
+        "intermediate_2": "cháiyóu",
+        "native_1": "diesel fuel; kerosene",
+        "primary_1": "柴油",
+        "primary_2": "柴油"
+    },
+    {
+        "intermediate_1": "chan1",
+        "intermediate_2": "chān",
+        "native_1": "assist by the arm; mix; support; sustain",
+        "primary_1": "搀",
+        "primary_2": "攙"
+    },
+    {
+        "intermediate_1": "chan2",
+        "intermediate_2": "chán",
+        "native_1": "gluttonous; greedy",
+        "primary_1": "馋",
+        "primary_2": "饞"
+    },
+    {
+        "intermediate_1": "chan2rao4",
+        "intermediate_2": "chánrào",
+        "native_1": "bind; wind; twirl; twist; intertwine",
+        "primary_1": "缠绕",
+        "primary_2": "纏繞"
+    },
+    {
+        "intermediate_1": "chan3ye4",
+        "intermediate_2": "chǎnyè",
+        "native_1": "industry; estate; property",
+        "primary_1": "产业",
+        "primary_2": "産業"
+    },
+    {
+        "intermediate_1": "chan3shu4",
+        "intermediate_2": "chǎnshù",
+        "native_1": "expound (a position); elaborate (on a topic)",
+        "primary_1": "阐述",
+        "primary_2": "闡述"
+    },
+    {
+        "intermediate_1": "chan4dou3",
+        "intermediate_2": "chàndǒu",
+        "native_1": "tremble; to shiver; to shake",
+        "primary_1": "颤抖",
+        "primary_2": "顫抖"
+    },
+    {
+        "intermediate_1": "chang1sheng4",
+        "intermediate_2": "chāngshèng",
+        "native_1": "prosperous",
+        "primary_1": "昌盛",
+        "primary_2": "昌盛"
+    },
+    {
+        "intermediate_1": "chang2shi4",
+        "intermediate_2": "chángshì",
+        "native_1": "to try; attempt",
+        "primary_1": "尝试",
+        "primary_2": "嘗試"
+    },
+    {
+        "intermediate_1": "chang2huan2",
+        "intermediate_2": "chánghuán",
+        "native_1": "repay; reimburse",
+        "primary_1": "偿还",
+        "primary_2": "償還"
+    },
+    {
+        "intermediate_1": "chang3he2",
+        "intermediate_2": "chǎnghé",
+        "native_1": "occasion; situation",
+        "primary_1": "场合",
+        "primary_2": "場合"
+    },
+    {
+        "intermediate_1": "chang3mian4",
+        "intermediate_2": "chǎngmiàn",
+        "native_1": "scene; occasion",
+        "primary_1": "场面",
+        "primary_2": "場面"
+    },
+    {
+        "intermediate_1": "chang3suo3",
+        "intermediate_2": "chǎngsuǒ",
+        "native_1": "location; place",
+        "primary_1": "场所",
+        "primary_2": "場所"
+    },
+    {
+        "intermediate_1": "chang3kai1",
+        "intermediate_2": "chǎngkāi",
+        "native_1": "open wide",
+        "primary_1": "敞开",
+        "primary_2": "敞開"
+    },
+    {
+        "intermediate_1": "chang4tong1",
+        "intermediate_2": "chàngtōng",
+        "native_1": "unimpeded; unclogged; free-flowing; straight path; to expedite",
+        "primary_1": "畅通",
+        "primary_2": "暢通"
+    },
+    {
+        "intermediate_1": "chang4xiao1",
+        "intermediate_2": "chàngxiāo",
+        "native_1": "best seller; chart-topping; very marketable",
+        "primary_1": "畅销",
+        "primary_2": "暢銷"
+    },
+    {
+        "intermediate_1": "chang4dao3",
+        "intermediate_2": "chàngdǎo",
+        "native_1": "to advocate; propose",
+        "primary_1": "倡导",
+        "primary_2": "倡導"
+    },
+    {
+        "intermediate_1": "chang4yi4",
+        "intermediate_2": "chàngyì",
+        "native_1": "suggest; propose",
+        "primary_1": "倡议",
+        "primary_2": "倡議"
+    },
+    {
+        "intermediate_1": "chao1piao4",
+        "intermediate_2": "chāopiào",
+        "native_1": "paper money; bill",
+        "primary_1": "钞票",
+        "primary_2": "鈔票"
+    },
+    {
+        "intermediate_1": "chao1yue4",
+        "intermediate_2": "chāoyuè",
+        "native_1": "surpass; exceed; transcend",
+        "primary_1": "超越",
+        "primary_2": "超越"
+    },
+    {
+        "intermediate_1": "chao2xue2",
+        "intermediate_2": "cháoxué",
+        "native_1": "lair; nest; den; hideout",
+        "primary_1": "巢穴",
+        "primary_2": "巢穴"
+    },
+    {
+        "intermediate_1": "chao2dai4",
+        "intermediate_2": "cháodài",
+        "native_1": "dynasty; reign (of a king)",
+        "primary_1": "朝代",
+        "primary_2": "朝代"
+    },
+    {
+        "intermediate_1": "chao2xiao4",
+        "intermediate_2": "cháoxiào",
+        "native_1": "jeer; mock; scoff",
+        "primary_1": "嘲笑",
+        "primary_2": "嘲笑"
+    },
+    {
+        "intermediate_1": "chao2liu2",
+        "intermediate_2": "cháoliú",
+        "native_1": "tide; current; trend",
+        "primary_1": "潮流",
+        "primary_2": "潮流"
+    },
+    {
+        "intermediate_1": "che4tui4",
+        "intermediate_2": "chètuì",
+        "native_1": "retreat",
+        "primary_1": "撤退",
+        "primary_2": "撤退"
+    },
+    {
+        "intermediate_1": "che4xiao1",
+        "intermediate_2": "chèxiāo",
+        "native_1": "repeal",
+        "primary_1": "撤销",
+        "primary_2": "撤銷"
+    },
+    {
+        "intermediate_1": "chen2dian4",
+        "intermediate_2": "chéndiàn",
+        "native_1": "to precipitate (solid sediment out of a solution); to settle",
+        "primary_1": "沉淀",
+        "primary_2": "沈澱"
+    },
+    {
+        "intermediate_1": "chen2men4",
+        "intermediate_2": "chénmèn",
+        "native_1": "oppressive (of weather); heavy; depressed; not happy",
+        "primary_1": "沉闷",
+        "primary_2": "沈悶"
+    },
+    {
+        "intermediate_1": "chen2si1",
+        "intermediate_2": "chénsī",
+        "native_1": "ponder; contemplate; meditation",
+        "primary_1": "沉思",
+        "primary_2": "沈思"
+    },
+    {
+        "intermediate_1": "chen2zhong4",
+        "intermediate_2": "chénzhòng",
+        "native_1": "heavy; hard; serious",
+        "primary_1": "沉重",
+        "primary_2": "沈重"
+    },
+    {
+        "intermediate_1": "chen2zhuo2",
+        "intermediate_2": "chénzhuó",
+        "native_1": "calm and collected; not nervous",
+        "primary_1": "沉着",
+        "primary_2": "沈著"
+    },
+    {
+        "intermediate_1": "chen2jiu4",
+        "intermediate_2": "chénjiù",
+        "native_1": "old fashioned; outmoded; obsolete",
+        "primary_1": "陈旧",
+        "primary_2": "陳舊"
+    },
+    {
+        "intermediate_1": "chen2lie4",
+        "intermediate_2": "chénliè",
+        "native_1": "to display; to exhibit",
+        "primary_1": "陈列",
+        "primary_2": "陳列"
+    },
+    {
+        "intermediate_1": "chen2shu4",
+        "intermediate_2": "chénshù",
+        "native_1": "allegation; assertation; to declare; to state",
+        "primary_1": "陈述",
+        "primary_2": "陳述"
+    },
+    {
+        "intermediate_1": "chen4tuo1",
+        "intermediate_2": "chèntuō",
+        "native_1": "to set off; serve as a foil to",
+        "primary_1": "衬托",
+        "primary_2": "襯托"
+    },
+    {
+        "intermediate_1": "chen4xin1ru2yi4",
+        "intermediate_2": "chènxīnrúyì",
+        "native_1": "find sth. satisfactory",
+        "primary_1": "称心如意",
+        "primary_2": "稱心如意"
+    },
+    {
+        "intermediate_1": "cheng1hao4",
+        "intermediate_2": "chēnghào",
+        "native_1": "title; term of address",
+        "primary_1": "称号",
+        "primary_2": "稱號"
+    },
+    {
+        "intermediate_1": "cheng2ben3",
+        "intermediate_2": "chéngběn",
+        "native_1": "cost (manufacturing, production, etc.)",
+        "primary_1": "成本",
+        "primary_2": "成本"
+    },
+    {
+        "intermediate_1": "cheng2jiao1",
+        "intermediate_2": "chéngjiāo",
+        "native_1": "complete a contract; clinch a deal; to seal",
+        "primary_1": "成交",
+        "primary_2": "成交"
+    },
+    {
+        "intermediate_1": "cheng2tian1",
+        "intermediate_2": "chéngtiān",
+        "native_1": "all day long; all the time",
+        "primary_1": "成天",
+        "primary_2": "成天"
+    },
+    {
+        "intermediate_1": "cheng2xiao4",
+        "intermediate_2": "chéngxiào",
+        "native_1": "effect; result",
+        "primary_1": "成效",
+        "primary_2": "成效"
+    },
+    {
+        "intermediate_1": "cheng2xin1",
+        "intermediate_2": "chéngxīn",
+        "native_1": "intentional; deliberate; with prior intent",
+        "primary_1": "成心",
+        "primary_2": "成心"
+    },
+    {
+        "intermediate_1": "cheng2yuan2",
+        "intermediate_2": "chéngyuán",
+        "native_1": "member",
+        "primary_1": "成员",
+        "primary_2": "成員"
+    },
+    {
+        "intermediate_1": "cheng2xian4",
+        "intermediate_2": "chéngxiàn",
+        "native_1": "appear; emerge; present (a certain appearance)",
+        "primary_1": "呈现",
+        "primary_2": "呈現"
+    },
+    {
+        "intermediate_1": "cheng2zhi4",
+        "intermediate_2": "chéngzhì",
+        "native_1": "sincere; cordial; earnest",
+        "primary_1": "诚挚",
+        "primary_2": "誠摯"
+    },
+    {
+        "intermediate_1": "cheng2ban4",
+        "intermediate_2": "chéngbàn",
+        "native_1": "undertake; accept an assignment",
+        "primary_1": "承办",
+        "primary_2": "承辦"
+    },
+    {
+        "intermediate_1": "cheng2bao1",
+        "intermediate_2": "chéngbāo",
+        "native_1": "to contract (to undertake a job)",
+        "primary_1": "承包",
+        "primary_2": "承包"
+    },
+    {
+        "intermediate_1": "cheng2nuo4",
+        "intermediate_2": "chéngnuò",
+        "native_1": "to promise",
+        "primary_1": "承诺",
+        "primary_2": "承諾"
+    },
+    {
+        "intermediate_1": "cheng2bao3",
+        "intermediate_2": "chéngbǎo",
+        "native_1": "castle",
+        "primary_1": "城堡",
+        "primary_2": "城堡"
+    },
+    {
+        "intermediate_1": "cheng2",
+        "intermediate_2": "chéng",
+        "native_1": "to ride; to mount; make use of; multiply",
+        "primary_1": "乘",
+        "primary_2": "乘"
+    },
+    {
+        "intermediate_1": "cheng2, sheng4",
+        "intermediate_2": "chéng, shèng",
+        "native_1": "contain; to ladle; to fill | flourishing; grand; abundant",
+        "primary_1": "盛",
+        "primary_2": "盛"
+    },
+    {
+        "intermediate_1": "cheng2fa2",
+        "intermediate_2": "chéngfá",
+        "native_1": "penalty; punishment; to punish; to penalize",
+        "primary_1": "惩罚",
+        "primary_2": "懲罰"
+    },
+    {
+        "intermediate_1": "cheng2qing1",
+        "intermediate_2": "chéngqīng",
+        "native_1": "(of liquid) settle; become clear; (Chem.) precipitate",
+        "primary_1": "澄清",
+        "primary_2": "澄清"
+    },
+    {
+        "intermediate_1": "cheng2",
+        "intermediate_2": "chéng",
+        "native_1": "orange (color); orange (fruit, tree)",
+        "primary_1": "橙",
+        "primary_2": "橙"
+    },
+    {
+        "intermediate_1": "cheng4",
+        "intermediate_2": "chèng",
+        "native_1": "balance; scale; steelyard",
+        "primary_1": "秤",
+        "primary_2": "秤"
+    },
+    {
+        "intermediate_1": "chi1 ku3",
+        "intermediate_2": "chī kǔ",
+        "native_1": "bear hardships; suffer",
+        "primary_1": "吃苦",
+        "primary_2": "吃苦"
+    },
+    {
+        "intermediate_1": "chi1li4",
+        "intermediate_2": "chīlì",
+        "native_1": "strenuous; exhausted",
+        "primary_1": "吃力",
+        "primary_2": "吃力"
+    },
+    {
+        "intermediate_1": "chi2dun4",
+        "intermediate_2": "chídùn",
+        "native_1": "slow (witted); stupid; dull",
+        "primary_1": "迟钝",
+        "primary_2": "遲鈍"
+    },
+    {
+        "intermediate_1": "chi2huan3",
+        "intermediate_2": "chíhuǎn",
+        "native_1": "slow; sluggish",
+        "primary_1": "迟缓",
+        "primary_2": "遲緩"
+    },
+    {
+        "intermediate_1": "chi2yi2",
+        "intermediate_2": "chíyí",
+        "native_1": "hesitate",
+        "primary_1": "迟疑",
+        "primary_2": "遲疑"
+    },
+    {
+        "intermediate_1": "chi2jiu3",
+        "intermediate_2": "chíjiǔ",
+        "native_1": "duration; enduring; lasting; persistent",
+        "primary_1": "持久",
+        "primary_2": "持久"
+    },
+    {
+        "intermediate_1": "chi4dao4",
+        "intermediate_2": "chìdào",
+        "native_1": "the equator",
+        "primary_1": "赤道",
+        "primary_2": "赤道"
+    },
+    {
+        "intermediate_1": "chi4zi4",
+        "intermediate_2": "chìzì",
+        "native_1": "(financial) deficit; red ink",
+        "primary_1": "赤字",
+        "primary_2": "赤字"
+    },
+    {
+        "intermediate_1": "chong1dong4",
+        "intermediate_2": "chōngdòng",
+        "native_1": "impulsive; act on impulse",
+        "primary_1": "冲动",
+        "primary_2": "沖動"
+    },
+    {
+        "intermediate_1": "chong1ji1",
+        "intermediate_2": "chōngjī",
+        "native_1": "attack; impact; a shock",
+        "primary_1": "冲击",
+        "primary_2": "沖擊"
+    },
+    {
+        "intermediate_1": "chong1tu1",
+        "intermediate_2": "chōngtū",
+        "native_1": "conflict; clash",
+        "primary_1": "冲突",
+        "primary_2": "沖突"
+    },
+    {
+        "intermediate_1": "chong1dang1",
+        "intermediate_2": "chōngdāng",
+        "native_1": "serve as; play the part of",
+        "primary_1": "充当",
+        "primary_2": "充當"
+    },
+    {
+        "intermediate_1": "chong1pei4",
+        "intermediate_2": "chōngpèi",
+        "native_1": "abundant; plentiful; vigorous",
+        "primary_1": "充沛",
+        "primary_2": "充沛"
+    },
+    {
+        "intermediate_1": "chong1shi2",
+        "intermediate_2": "chōngshí",
+        "native_1": "substantial; rich; enrich; substantiate",
+        "primary_1": "充实",
+        "primary_2": "充實"
+    },
+    {
+        "intermediate_1": "chong1zu2",
+        "intermediate_2": "chōngzú",
+        "native_1": "adequate; sufficient; abundant",
+        "primary_1": "充足",
+        "primary_2": "充足"
+    },
+    {
+        "intermediate_1": "chong2die2",
+        "intermediate_2": "chóngdié",
+        "native_1": "to overlap",
+        "primary_1": "重叠",
+        "primary_2": "重疊"
+    },
+    {
+        "intermediate_1": "chong2bai4",
+        "intermediate_2": "chóngbài",
+        "native_1": "worship; adore",
+        "primary_1": "崇拜",
+        "primary_2": "崇拜"
+    },
+    {
+        "intermediate_1": "chong2gao1",
+        "intermediate_2": "chónggāo",
+        "native_1": "lofty; sublime",
+        "primary_1": "崇高",
+        "primary_2": "崇高"
+    },
+    {
+        "intermediate_1": "chong2jing4",
+        "intermediate_2": "chóngjìng",
+        "native_1": "revere; admire; veneration",
+        "primary_1": "崇敬",
+        "primary_2": "崇敬"
+    },
+    {
+        "intermediate_1": "chou2mi4",
+        "intermediate_2": "chóumì",
+        "native_1": "dense; thick",
+        "primary_1": "稠密",
+        "primary_2": "稠密"
+    },
+    {
+        "intermediate_1": "chou2bei4",
+        "intermediate_2": "chóubèi",
+        "native_1": "make preparations; get ready for something",
+        "primary_1": "筹备",
+        "primary_2": "籌備"
+    },
+    {
+        "intermediate_1": "chou3'e4",
+        "intermediate_2": "chǒu'è",
+        "native_1": "ugly; repulsive; odiousness",
+        "primary_1": "丑恶",
+        "primary_2": "醜惡"
+    },
+    {
+        "intermediate_1": "chu1lu4",
+        "intermediate_2": "chūlù",
+        "native_1": "a way out; outlet",
+        "primary_1": "出路",
+        "primary_2": "出路"
+    },
+    {
+        "intermediate_1": "chu1mai4",
+        "intermediate_2": "chūmài",
+        "native_1": "sell; betray; sell out",
+        "primary_1": "出卖",
+        "primary_2": "出賣"
+    },
+    {
+        "intermediate_1": "chu1shen1",
+        "intermediate_2": "chūshēn",
+        "native_1": "family background; class origin",
+        "primary_1": "出身",
+        "primary_2": "出身"
+    },
+    {
+        "intermediate_1": "chu1 shen2",
+        "intermediate_2": "chū shén",
+        "native_1": "be lost in thought; entranced; preoccupation; Trance (music genre)",
+        "primary_1": "出神",
+        "primary_2": "出神"
+    },
+    {
+        "intermediate_1": "chu1xi",
+        "intermediate_2": "chūxi",
+        "native_1": "future prospects; aspiration; promise",
+        "primary_1": "出息",
+        "primary_2": "出息"
+    },
+    {
+        "intermediate_1": "chu1bu4",
+        "intermediate_2": "chūbù",
+        "native_1": "initial; preliminary; tentative",
+        "primary_1": "初步",
+        "primary_2": "初步"
+    },
+    {
+        "intermediate_1": "chu2",
+        "intermediate_2": "chú",
+        "native_1": "besides; except; remove; to divide (mathematics)",
+        "primary_1": "除",
+        "primary_2": "除"
+    },
+    {
+        "intermediate_1": "chu3fen4",
+        "intermediate_2": "chǔfèn",
+        "native_1": "punish; punishment; discipline; disposal",
+        "primary_1": "处分",
+        "primary_2": "處分"
+    },
+    {
+        "intermediate_1": "chu3jing4",
+        "intermediate_2": "chǔjìng",
+        "native_1": "plight; unfavorable situation",
+        "primary_1": "处境",
+        "primary_2": "處境"
+    },
+    {
+        "intermediate_1": "chu3zhi4",
+        "intermediate_2": "chǔzhì",
+        "native_1": "to handle; take care of; punish",
+        "primary_1": "处置",
+        "primary_2": "處置"
+    },
+    {
+        "intermediate_1": "chu3bei4",
+        "intermediate_2": "chǔbèi",
+        "native_1": "reserves; store up",
+        "primary_1": "储备",
+        "primary_2": "儲備"
+    },
+    {
+        "intermediate_1": "chu3cun2",
+        "intermediate_2": "chǔcún",
+        "native_1": "stockpile; to store",
+        "primary_1": "储存",
+        "primary_2": "儲存"
+    },
+    {
+        "intermediate_1": "chu3xu4",
+        "intermediate_2": "chǔxù",
+        "native_1": "to save; to deposit",
+        "primary_1": "储蓄",
+        "primary_2": "儲蓄"
+    },
+    {
+        "intermediate_1": "chu4fan4",
+        "intermediate_2": "chùfàn",
+        "native_1": "offend; violate",
+        "primary_1": "触犯",
+        "primary_2": "觸犯"
+    },
+    {
+        "intermediate_1": "chuan1 liu2 bu4 xi1",
+        "intermediate_2": "chuān liú bù xī",
+        "native_1": "(saying) flowing of an endless stream",
+        "primary_1": "川流不息",
+        "primary_2": "川流不息"
+    },
+    {
+        "intermediate_1": "chuan1yue4",
+        "intermediate_2": "chuānyuè",
+        "native_1": "pass through; cut across",
+        "primary_1": "穿越",
+        "primary_2": "穿越"
+    },
+    {
+        "intermediate_1": "chuan2da2",
+        "intermediate_2": "chuándá",
+        "native_1": "convey; transmit; communicate",
+        "primary_1": "传达",
+        "primary_2": "傳達"
+    },
+    {
+        "intermediate_1": "chuan2dan1",
+        "intermediate_2": "chuándān",
+        "native_1": "leaflet; flier; pamphlet",
+        "primary_1": "传单",
+        "primary_2": "傳單"
+    },
+    {
+        "intermediate_1": "chuan2shou4",
+        "intermediate_2": "chuánshòu",
+        "native_1": "impart; pass on; teach",
+        "primary_1": "传授",
+        "primary_2": "傳授"
+    },
+    {
+        "intermediate_1": "chuan2bo2",
+        "intermediate_2": "chuánbó",
+        "native_1": "ships; boats; watercraft",
+        "primary_1": "船舶",
+        "primary_2": "船舶"
+    },
+    {
+        "intermediate_1": "chuan3qi4",
+        "intermediate_2": "chuǎnqì",
+        "native_1": "to pant; gasp for breath",
+        "primary_1": "喘气",
+        "primary_2": "喘氣"
+    },
+    {
+        "intermediate_1": "chuan4",
+        "intermediate_2": "chuàn",
+        "native_1": "string together; conspire; gang up; mix up; bunch",
+        "primary_1": "串",
+        "primary_2": "串"
+    },
+    {
+        "intermediate_1": "chuang2dan1",
+        "intermediate_2": "chuángdān",
+        "native_1": "bed sheet",
+        "primary_1": "床单",
+        "primary_2": "床單"
+    },
+    {
+        "intermediate_1": "chuang4li4",
+        "intermediate_2": "chuànglì",
+        "native_1": "to found; establish",
+        "primary_1": "创立",
+        "primary_2": "創立"
+    },
+    {
+        "intermediate_1": "chuang4xin1",
+        "intermediate_2": "chuàngxīn",
+        "native_1": "innovate; innovation",
+        "primary_1": "创新",
+        "primary_2": "創新"
+    },
+    {
+        "intermediate_1": "chuang4ye4",
+        "intermediate_2": "chuàngyè",
+        "native_1": "begin an undertaking; start a major task; start a company",
+        "primary_1": "创业",
+        "primary_2": "創業"
+    },
+    {
+        "intermediate_1": "chuang4zuo4",
+        "intermediate_2": "chuàngzuò",
+        "native_1": "create; to produce; creative work",
+        "primary_1": "创作",
+        "primary_2": "創作"
+    },
+    {
+        "intermediate_1": "chui1 niu2",
+        "intermediate_2": "chuī niú",
+        "native_1": "to brag; (regional) to chat",
+        "primary_1": "吹牛",
+        "primary_2": "吹牛"
+    },
+    {
+        "intermediate_1": "chui1peng3",
+        "intermediate_2": "chuīpěng",
+        "native_1": "flatter sb.; extol sb.'s accomplishments",
+        "primary_1": "吹捧",
+        "primary_2": "吹捧"
+    },
+    {
+        "intermediate_1": "chui1yan1",
+        "intermediate_2": "chuīyān",
+        "native_1": "smoke from kitchen chimneys",
+        "primary_1": "炊烟",
+        "primary_2": "炊煙"
+    },
+    {
+        "intermediate_1": "chui2zhi2",
+        "intermediate_2": "chuízhí",
+        "native_1": "perpendicular; vertical",
+        "primary_1": "垂直",
+        "primary_2": "垂直"
+    },
+    {
+        "intermediate_1": "chui2",
+        "intermediate_2": "chuí",
+        "native_1": "hammer; weight",
+        "primary_1": "锤",
+        "primary_2": "錘"
+    },
+    {
+        "intermediate_1": "chun2cui4",
+        "intermediate_2": "chúncuì",
+        "native_1": "purely; pure",
+        "primary_1": "纯粹",
+        "primary_2": "純粹"
+    },
+    {
+        "intermediate_1": "chun2jie2",
+        "intermediate_2": "chúnjié",
+        "native_1": "pure; unadulterated; cleanse",
+        "primary_1": "纯洁",
+        "primary_2": "純潔"
+    },
+    {
+        "intermediate_1": "ci2shan4",
+        "intermediate_2": "císhàn",
+        "native_1": "philanthropic; benevolent; charitable",
+        "primary_1": "慈善",
+        "primary_2": "慈善"
+    },
+    {
+        "intermediate_1": "ci2xiang2",
+        "intermediate_2": "cíxiáng",
+        "native_1": "a kindly person; benevolent (often of older people)",
+        "primary_1": "慈祥",
+        "primary_2": "慈祥"
+    },
+    {
+        "intermediate_1": "ci2dai4",
+        "intermediate_2": "cídài",
+        "native_1": "cassette tape",
+        "primary_1": "磁带",
+        "primary_2": "磁帶"
+    },
+    {
+        "intermediate_1": "ci2xiong2",
+        "intermediate_2": "cíxióng",
+        "native_1": "male and female; winners and losers",
+        "primary_1": "雌雄",
+        "primary_2": "雌雄"
+    },
+    {
+        "intermediate_1": "ci4pin3",
+        "intermediate_2": "cìpǐn",
+        "native_1": "defective or substandard products",
+        "primary_1": "次品",
+        "primary_2": "次品"
+    },
+    {
+        "intermediate_1": "ci4xu4",
+        "intermediate_2": "cìxù",
+        "native_1": "sequence; order",
+        "primary_1": "次序",
+        "primary_2": "次序"
+    },
+    {
+        "intermediate_1": "ci4hou",
+        "intermediate_2": "cìhou",
+        "native_1": "serve; wait upon; act as a valet",
+        "primary_1": "伺候",
+        "primary_2": "伺候"
+    },
+    {
+        "intermediate_1": "ci4",
+        "intermediate_2": "cì",
+        "native_1": "thorn; to sting; to prick; pierce; stab",
+        "primary_1": "刺",
+        "primary_2": "刺"
+    },
+    {
+        "intermediate_1": "cong2rong2",
+        "intermediate_2": "cóngróng",
+        "native_1": "leisurely; calm",
+        "primary_1": "从容",
+        "primary_2": "從容"
+    },
+    {
+        "intermediate_1": "cong2",
+        "intermediate_2": "cóng",
+        "native_1": "crowd together; thicket; collection",
+        "primary_1": "丛",
+        "primary_2": "叢"
+    },
+    {
+        "intermediate_1": "cou4he",
+        "intermediate_2": "còuhe",
+        "native_1": "bring together; make do in a bad situation; improvise",
+        "primary_1": "凑合",
+        "primary_2": "湊合"
+    },
+    {
+        "intermediate_1": "cu1lu3",
+        "intermediate_2": "cūlǔ",
+        "native_1": "crude; coarse; rough; language",
+        "primary_1": "粗鲁",
+        "primary_2": "粗魯"
+    },
+    {
+        "intermediate_1": "cuan4",
+        "intermediate_2": "cuàn",
+        "native_1": "to flee; to escape; run away",
+        "primary_1": "窜",
+        "primary_2": "竄"
+    },
+    {
+        "intermediate_1": "cui1can2",
+        "intermediate_2": "cuīcán",
+        "native_1": "to ruin; devastate; vandalize",
+        "primary_1": "摧残",
+        "primary_2": "摧殘"
+    },
+    {
+        "intermediate_1": "cui4ruo4",
+        "intermediate_2": "cuìruò",
+        "native_1": "weak; fragile; flimsy; frail",
+        "primary_1": "脆弱",
+        "primary_2": "脆弱"
+    },
+    {
+        "intermediate_1": "cuo1",
+        "intermediate_2": "cuō",
+        "native_1": "rub or roll between the hands or fingers; to twist",
+        "primary_1": "搓",
+        "primary_2": "搓"
+    },
+    {
+        "intermediate_1": "cuo1shang1",
+        "intermediate_2": "cuōshāng",
+        "native_1": "discuss seriously; consult; negotiate",
+        "primary_1": "磋商",
+        "primary_2": "磋商"
+    },
+    {
+        "intermediate_1": "cuo4zhe2",
+        "intermediate_2": "cuòzhé",
+        "native_1": "setback; defeat; frustration",
+        "primary_1": "挫折",
+        "primary_2": "挫折"
+    },
+    {
+        "intermediate_1": "da1",
+        "intermediate_2": "dā",
+        "native_1": "to erect; to build; travel by (car, plane, etc.); to hang; to join",
+        "primary_1": "搭",
+        "primary_2": "搭"
+    },
+    {
+        "intermediate_1": "da1dang4",
+        "intermediate_2": "dādàng",
+        "native_1": "team up; cooperate; work together",
+        "primary_1": "搭档",
+        "primary_2": "搭檔"
+    },
+    {
+        "intermediate_1": "da1pei4",
+        "intermediate_2": "dāpèi",
+        "native_1": "pair up; arrange in pairs; to add sth. into a group; to suit",
+        "primary_1": "搭配",
+        "primary_2": "搭配"
+    },
+    {
+        "intermediate_1": "da2 cheng2",
+        "intermediate_2": "dá chéng",
+        "native_1": "to reach (an agreement); achieve",
+        "primary_1": "达成",
+        "primary_2": "達成"
+    },
+    {
+        "intermediate_1": "da2bian4",
+        "intermediate_2": "dábiàn",
+        "native_1": "reply (to an accusation)",
+        "primary_1": "答辩",
+        "primary_2": "答辯"
+    },
+    {
+        "intermediate_1": "da2fu4",
+        "intermediate_2": "dáfù",
+        "native_1": "to answer; to reply",
+        "primary_1": "答复",
+        "primary_2": "答複"
+    },
+    {
+        "intermediate_1": "da3bao1",
+        "intermediate_2": "dǎbāo",
+        "native_1": "get a doggy bag (at a restaurant); pack up",
+        "primary_1": "打包",
+        "primary_2": "打包"
+    },
+    {
+        "intermediate_1": "da3 guan1si",
+        "intermediate_2": "dǎ guānsi",
+        "native_1": "go to court",
+        "primary_1": "打官司",
+        "primary_2": "打官司"
+    },
+    {
+        "intermediate_1": "da3ji1",
+        "intermediate_2": "dǎjī",
+        "native_1": "to strike; to hit; to attack",
+        "primary_1": "打击",
+        "primary_2": "打擊"
+    },
+    {
+        "intermediate_1": "da3 jia4",
+        "intermediate_2": "dǎ jià",
+        "native_1": "to fight; scuffle; to come to blows",
+        "primary_1": "打架",
+        "primary_2": "打架"
+    },
+    {
+        "intermediate_1": "da3liang",
+        "intermediate_2": "dǎliang",
+        "native_1": "take measure of; size up",
+        "primary_1": "打量",
+        "primary_2": "打量"
+    },
+    {
+        "intermediate_1": "da3 lie4",
+        "intermediate_2": "dǎ liè",
+        "native_1": "hunt; to go hunting",
+        "primary_1": "打猎",
+        "primary_2": "打獵"
+    },
+    {
+        "intermediate_1": "da3zhang4",
+        "intermediate_2": "dǎzhàng",
+        "native_1": "fight; go to war; fight a battle",
+        "primary_1": "打仗",
+        "primary_2": "打仗"
+    },
+    {
+        "intermediate_1": "da4buliao3",
+        "intermediate_2": "dàbuliǎo",
+        "native_1": "at the worst; if worst comes to worst; serious, alarming",
+        "primary_1": "大不了",
+        "primary_2": "大不了"
+    },
+    {
+        "intermediate_1": "da4chen2",
+        "intermediate_2": "dàchén",
+        "native_1": "chancellor",
+        "primary_1": "大臣",
+        "primary_2": "大臣"
+    },
+    {
+        "intermediate_1": "da4huo3r",
+        "intermediate_2": "dàhuǒr",
+        "native_1": "everyone",
+        "primary_1": "大伙儿",
+        "primary_2": "大夥兒"
+    },
+    {
+        "intermediate_1": "da4si4",
+        "intermediate_2": "dàsì",
+        "native_1": "wantonly; without any constraint",
+        "primary_1": "大肆",
+        "primary_2": "大肆"
+    },
+    {
+        "intermediate_1": "da4ti3",
+        "intermediate_2": "dàtǐ",
+        "native_1": "in general; more or less; on the whole",
+        "primary_1": "大体",
+        "primary_2": "大體"
+    },
+    {
+        "intermediate_1": "da4yi4",
+        "intermediate_2": "dàyì",
+        "native_1": "main idea; general idea; gist",
+        "primary_1": "大意",
+        "primary_2": "大意"
+    },
+    {
+        "intermediate_1": "da4zhi4",
+        "intermediate_2": "dàzhì",
+        "native_1": "more or less; roughly; approximately",
+        "primary_1": "大致",
+        "primary_2": "大致"
+    },
+    {
+        "intermediate_1": "dai3tu2",
+        "intermediate_2": "dǎitú",
+        "native_1": "evil person who commits crimes; villain; gangster",
+        "primary_1": "歹徒",
+        "primary_2": "歹徒"
+    },
+    {
+        "intermediate_1": "dai4jia4",
+        "intermediate_2": "dàijià",
+        "native_1": "price; cost; expense",
+        "primary_1": "代价",
+        "primary_2": "代價"
+    },
+    {
+        "intermediate_1": "dai4li3",
+        "intermediate_2": "dàilǐ",
+        "native_1": "acting (temporarily filling a position); agent",
+        "primary_1": "代理",
+        "primary_2": "代理"
+    },
+    {
+        "intermediate_1": "dai4ling3",
+        "intermediate_2": "dàilǐng",
+        "native_1": "to guide; to lead",
+        "primary_1": "带领",
+        "primary_2": "帶領"
+    },
+    {
+        "intermediate_1": "dai4man4",
+        "intermediate_2": "dàimàn",
+        "native_1": "to slight; give somebody a cold shoulder; treat somebody in a cold manner",
+        "primary_1": "怠慢",
+        "primary_2": "怠慢"
+    },
+    {
+        "intermediate_1": "dai4bu3",
+        "intermediate_2": "dàibǔ",
+        "native_1": "to arrest; to capture",
+        "primary_1": "逮捕",
+        "primary_2": "逮捕"
+    },
+    {
+        "intermediate_1": "dan1bao3",
+        "intermediate_2": "dānbǎo",
+        "native_1": "guarantee; vouch for",
+        "primary_1": "担保",
+        "primary_2": "擔保"
+    },
+    {
+        "intermediate_1": "dan3qie4",
+        "intermediate_2": "dǎnqiè",
+        "native_1": "timid; coward",
+        "primary_1": "胆怯",
+        "primary_2": "膽怯"
+    },
+    {
+        "intermediate_1": "dan4chen2",
+        "intermediate_2": "dànchén",
+        "native_1": "birthday",
+        "primary_1": "诞辰",
+        "primary_2": "誕辰"
+    },
+    {
+        "intermediate_1": "dan4sheng1",
+        "intermediate_2": "dànshēng",
+        "native_1": "be born; come into being",
+        "primary_1": "诞生",
+        "primary_2": "誕生"
+    },
+    {
+        "intermediate_1": "dan4ji4",
+        "intermediate_2": "dànjì",
+        "native_1": "off season; slow business season",
+        "primary_1": "淡季",
+        "primary_2": "淡季"
+    },
+    {
+        "intermediate_1": "dan4shui3",
+        "intermediate_2": "dànshuǐ",
+        "native_1": "fresh water; potable water (water with low salt content)",
+        "primary_1": "淡水",
+        "primary_2": "淡水"
+    },
+    {
+        "intermediate_1": "dan4bai2zhi4",
+        "intermediate_2": "dànbáizhì",
+        "native_1": "protein",
+        "primary_1": "蛋白质",
+        "primary_2": "蛋白質"
+    },
+    {
+        "intermediate_1": "dang1chang3",
+        "intermediate_2": "dāngchǎng",
+        "native_1": "at the scene; on the spot",
+        "primary_1": "当场",
+        "primary_2": "當場"
+    },
+    {
+        "intermediate_1": "dang1chu1",
+        "intermediate_2": "dāngchū",
+        "native_1": "at that time; at the outset; originally",
+        "primary_1": "当初",
+        "primary_2": "當初"
+    },
+    {
+        "intermediate_1": "dang1dai4",
+        "intermediate_2": "dāngdài",
+        "native_1": "present day; contemporary",
+        "primary_1": "当代",
+        "primary_2": "當代"
+    },
+    {
+        "intermediate_1": "dang1 mian4",
+        "intermediate_2": "dāng miàn",
+        "native_1": "to sb.'s face; in sb.'s presence",
+        "primary_1": "当面",
+        "primary_2": "當面"
+    },
+    {
+        "intermediate_1": "dang1qian2",
+        "intermediate_2": "dāngqián",
+        "native_1": "current; modern; present",
+        "primary_1": "当前",
+        "primary_2": "當前"
+    },
+    {
+        "intermediate_1": "dang1shi4ren2",
+        "intermediate_2": "dāngshìrén",
+        "native_1": "persons involved or implicated; party (to an affair)",
+        "primary_1": "当事人",
+        "primary_2": "當事人"
+    },
+    {
+        "intermediate_1": "dang1wu4zhi1ji2",
+        "intermediate_2": "dāngwùzhījí",
+        "native_1": "the most pressing matter of the moment; a top priority task; urgent matter",
+        "primary_1": "当务之急",
+        "primary_2": "當務之急"
+    },
+    {
+        "intermediate_1": "dang1xuan3",
+        "intermediate_2": "dāngxuǎn",
+        "native_1": "be elected",
+        "primary_1": "当选",
+        "primary_2": "當選"
+    },
+    {
+        "intermediate_1": "dang3",
+        "intermediate_2": "dǎng",
+        "native_1": "party; club; association",
+        "primary_1": "党",
+        "primary_2": "黨"
+    },
+    {
+        "intermediate_1": "dang4'an4",
+        "intermediate_2": "dàng'àn",
+        "native_1": "file; record; archive",
+        "primary_1": "档案",
+        "primary_2": "檔案"
+    },
+    {
+        "intermediate_1": "dang4ci4",
+        "intermediate_2": "dàngcì",
+        "native_1": "grade; quality; class; level",
+        "primary_1": "档次",
+        "primary_2": "檔次"
+    },
+    {
+        "intermediate_1": "dao3dan4",
+        "intermediate_2": "dǎodàn",
+        "native_1": "guided missile; cruise missile",
+        "primary_1": "导弹",
+        "primary_2": "導彈"
+    },
+    {
+        "intermediate_1": "dao3hang2",
+        "intermediate_2": "dǎoháng",
+        "native_1": "navigation",
+        "primary_1": "导航",
+        "primary_2": "導航"
+    },
+    {
+        "intermediate_1": "dao3xiang4",
+        "intermediate_2": "dǎoxiàng",
+        "native_1": "guidance; lead to; direct something towards",
+        "primary_1": "导向",
+        "primary_2": "導向"
+    },
+    {
+        "intermediate_1": "dao3 luan4",
+        "intermediate_2": "dǎo luàn",
+        "native_1": "cause a disturbance; look for trouble",
+        "primary_1": "捣乱",
+        "primary_2": "搗亂"
+    },
+    {
+        "intermediate_1": "dao3bi4",
+        "intermediate_2": "dǎobì",
+        "native_1": "go bankrupt; close down",
+        "primary_1": "倒闭",
+        "primary_2": "倒閉"
+    },
+    {
+        "intermediate_1": "dao4qie4",
+        "intermediate_2": "dàoqiè",
+        "native_1": "steal; pilfer",
+        "primary_1": "盗窃",
+        "primary_2": "盜竊"
+    },
+    {
+        "intermediate_1": "dao4gu3",
+        "intermediate_2": "dàogǔ",
+        "native_1": "rice crops/paddy",
+        "primary_1": "稻谷",
+        "primary_2": "稻谷"
+    },
+    {
+        "intermediate_1": "de2 bu4 chang2 shi1",
+        "intermediate_2": "dé bù cháng shī",
+        "native_1": "the gains do not outweigh the losses",
+        "primary_1": "得不偿失",
+        "primary_2": "得不償失"
+    },
+    {
+        "intermediate_1": "de2li4",
+        "intermediate_2": "délì",
+        "native_1": "able; competent",
+        "primary_1": "得力",
+        "primary_2": "得力"
+    },
+    {
+        "intermediate_1": "de2tian1du2hou4",
+        "intermediate_2": "détiāndúhòu",
+        "native_1": "enjoy exceptional advantages; richly endowed by nature",
+        "primary_1": "得天独厚",
+        "primary_2": "得天獨厚"
+    },
+    {
+        "intermediate_1": "de2zui4",
+        "intermediate_2": "dézuì",
+        "native_1": "offend; a faux pas",
+        "primary_1": "得罪",
+        "primary_2": "得罪"
+    },
+    {
+        "intermediate_1": "deng1long",
+        "intermediate_2": "dēnglong",
+        "native_1": "lantern",
+        "primary_1": "灯笼",
+        "primary_2": "燈籠"
+    },
+    {
+        "intermediate_1": "deng1lu4",
+        "intermediate_2": "dēnglù",
+        "native_1": "to land; come ashore; sign/log in",
+        "primary_1": "登陆",
+        "primary_2": "登陸"
+    },
+    {
+        "intermediate_1": "deng1lu4",
+        "intermediate_2": "dēnglù",
+        "native_1": "sign-in",
+        "primary_1": "登录",
+        "primary_2": "登錄"
+    },
+    {
+        "intermediate_1": "deng1",
+        "intermediate_2": "dēng",
+        "native_1": "press down with the foot; step back or into something",
+        "primary_1": "蹬",
+        "primary_2": "蹬"
+    },
+    {
+        "intermediate_1": "deng3hou4",
+        "intermediate_2": "děnghòu",
+        "native_1": "wait; queue",
+        "primary_1": "等候",
+        "primary_2": "等候"
+    },
+    {
+        "intermediate_1": "deng3ji2",
+        "intermediate_2": "děngjí",
+        "native_1": "degree; rate",
+        "primary_1": "等级",
+        "primary_2": "等級"
+    },
+    {
+        "intermediate_1": "deng4",
+        "intermediate_2": "dèng",
+        "native_1": "stare at; to glower",
+        "primary_1": "瞪",
+        "primary_2": "瞪"
+    },
+    {
+        "intermediate_1": "di1ba4",
+        "intermediate_2": "dībà",
+        "native_1": "dam; dyke",
+        "primary_1": "堤坝",
+        "primary_2": "堤壩"
+    },
+    {
+        "intermediate_1": "di2shi4",
+        "intermediate_2": "díshì",
+        "native_1": "be hostile; adopt a negative attitude towards",
+        "primary_1": "敌视",
+        "primary_2": "敵視"
+    },
+    {
+        "intermediate_1": "di3da2",
+        "intermediate_2": "dǐdá",
+        "native_1": "arrive; to reach (a destination); touch down",
+        "primary_1": "抵达",
+        "primary_2": "抵達"
+    },
+    {
+        "intermediate_1": "di3kang4",
+        "intermediate_2": "dǐkàng",
+        "native_1": "resist; resistance",
+        "primary_1": "抵抗",
+        "primary_2": "抵抗"
+    },
+    {
+        "intermediate_1": "di3zhi4",
+        "intermediate_2": "dǐzhì",
+        "native_1": "resistance; refusal (to cooperate); boycott",
+        "primary_1": "抵制",
+        "primary_2": "抵制"
+    },
+    {
+        "intermediate_1": "di4bu4",
+        "intermediate_2": "dìbù",
+        "native_1": "condition; plight; extent",
+        "primary_1": "地步",
+        "primary_2": "地步"
+    },
+    {
+        "intermediate_1": "di4shi4",
+        "intermediate_2": "dìshì",
+        "native_1": "terrain; topography of a place",
+        "primary_1": "地势",
+        "primary_2": "地勢"
+    },
+    {
+        "intermediate_1": "di4zhi4",
+        "intermediate_2": "dìzhì",
+        "native_1": "geology",
+        "primary_1": "地质",
+        "primary_2": "地質"
+    },
+    {
+        "intermediate_1": "di4zeng1",
+        "intermediate_2": "dìzēng",
+        "native_1": "increase step by step; steadily increase",
+        "primary_1": "递增",
+        "primary_2": "遞增"
+    },
+    {
+        "intermediate_1": "dian1bo3",
+        "intermediate_2": "diānbǒ",
+        "native_1": "shake; to jolt; bump",
+        "primary_1": "颠簸",
+        "primary_2": "顛簸"
+    },
+    {
+        "intermediate_1": "dian1dao3",
+        "intermediate_2": "diāndǎo",
+        "native_1": "turn upside down; upend",
+        "primary_1": "颠倒",
+        "primary_2": "顛倒"
+    },
+    {
+        "intermediate_1": "dian3li3",
+        "intermediate_2": "diǎnlǐ",
+        "native_1": "celebration; ceremony",
+        "primary_1": "典礼",
+        "primary_2": "典禮"
+    },
+    {
+        "intermediate_1": "dian3xing2",
+        "intermediate_2": "diǎnxíng",
+        "native_1": "typical case; model",
+        "primary_1": "典型",
+        "primary_2": "典型"
+    },
+    {
+        "intermediate_1": "dian3zhui4",
+        "intermediate_2": "diǎnzhuì",
+        "native_1": "decorate; an ornament; beautify; embellish; be the finishing touch",
+        "primary_1": "点缀",
+        "primary_2": "點綴"
+    },
+    {
+        "intermediate_1": "dian4yuan2",
+        "intermediate_2": "diànyuán",
+        "native_1": "electric power supply",
+        "primary_1": "电源",
+        "primary_2": "電源"
+    },
+    {
+        "intermediate_1": "dian4",
+        "intermediate_2": "diàn",
+        "native_1": "cushion; to pad; pay for somebody and expect to be repaid",
+        "primary_1": "垫",
+        "primary_2": "墊"
+    },
+    {
+        "intermediate_1": "dian4ji4",
+        "intermediate_2": "diànjì",
+        "native_1": "to remember with concern; to be concerned about; to think about; to keep thinking about; to worry about",
+        "primary_1": "惦记",
+        "primary_2": "惦記"
+    },
+    {
+        "intermediate_1": "dian4ding4",
+        "intermediate_2": "diàndìng",
+        "native_1": "establish; to found; to settle",
+        "primary_1": "奠定",
+        "primary_2": "奠定"
+    },
+    {
+        "intermediate_1": "diao1",
+        "intermediate_2": "diāo",
+        "native_1": "hold sth. in the mouth",
+        "primary_1": "叼",
+        "primary_2": "叼"
+    },
+    {
+        "intermediate_1": "diao1ke4",
+        "intermediate_2": "diāokè",
+        "native_1": "carve; engrave; sculpt",
+        "primary_1": "雕刻",
+        "primary_2": "雕刻"
+    },
+    {
+        "intermediate_1": "diao1su4",
+        "intermediate_2": "diāosù",
+        "native_1": "sculpture; a statue; a Buddhist image",
+        "primary_1": "雕塑",
+        "primary_2": "雕塑"
+    },
+    {
+        "intermediate_1": "diao4",
+        "intermediate_2": "diào",
+        "native_1": "hang; suspend",
+        "primary_1": "吊",
+        "primary_2": "吊"
+    },
+    {
+        "intermediate_1": "diao4dong4",
+        "intermediate_2": "diàodòng",
+        "native_1": "to transfer; to maneuver (troops, etc.)",
+        "primary_1": "调动",
+        "primary_2": "調動"
+    },
+    {
+        "intermediate_1": "die1",
+        "intermediate_2": "diē",
+        "native_1": "to fall down; to drop",
+        "primary_1": "跌",
+        "primary_2": "跌"
+    },
+    {
+        "intermediate_1": "ding1",
+        "intermediate_2": "dīng",
+        "native_1": "male adult; robust; cubes (of food); T-shaped (4th Heavenly Stem)",
+        "primary_1": "丁",
+        "primary_2": "丁"
+    },
+    {
+        "intermediate_1": "ding1zhu3",
+        "intermediate_2": "dīngzhǔ",
+        "native_1": "urge again and again; exhort; repeatedly warn",
+        "primary_1": "叮嘱",
+        "primary_2": "叮囑"
+    },
+    {
+        "intermediate_1": "ding1",
+        "intermediate_2": "dīng",
+        "native_1": "to stare; to gaze",
+        "primary_1": "盯",
+        "primary_2": "盯"
+    },
+    {
+        "intermediate_1": "ding4qi1",
+        "intermediate_2": "dìngqī",
+        "native_1": "regularly; at regular intervals",
+        "primary_1": "定期",
+        "primary_2": "定期"
+    },
+    {
+        "intermediate_1": "ding4yi4",
+        "intermediate_2": "dìngyì",
+        "native_1": "definition",
+        "primary_1": "定义",
+        "primary_2": "定義"
+    },
+    {
+        "intermediate_1": "diu1 ren2",
+        "intermediate_2": "diū rén",
+        "native_1": "lose face; be disgraced",
+        "primary_1": "丢人",
+        "primary_2": "丟人"
+    },
+    {
+        "intermediate_1": "diu1san1 la4si4",
+        "intermediate_2": "diūsān làsì",
+        "native_1": "forgetful; scatterbrained",
+        "primary_1": "丢三落四",
+        "primary_2": "丟三落四"
+    },
+    {
+        "intermediate_1": "dong1dao4zhu3",
+        "intermediate_2": "dōngdàozhǔ",
+        "native_1": "host for a party or conference",
+        "primary_1": "东道主",
+        "primary_2": "東道主"
+    },
+    {
+        "intermediate_1": "dong1zhang1xi1wang4",
+        "intermediate_2": "dōngzhāngxīwàng",
+        "native_1": "look in all directions; glance around",
+        "primary_1": "东张西望",
+        "primary_2": "東張西望"
+    },
+    {
+        "intermediate_1": "dong3shi4zhang3",
+        "intermediate_2": "dǒngshìzhǎng",
+        "native_1": "chairman of the board",
+        "primary_1": "董事长",
+        "primary_2": "董事長"
+    },
+    {
+        "intermediate_1": "dong4dang4",
+        "intermediate_2": "dòngdàng",
+        "native_1": "(social or political) turmoil; unrest; upheaval",
+        "primary_1": "动荡",
+        "primary_2": "動蕩"
+    },
+    {
+        "intermediate_1": "dong4ji1",
+        "intermediate_2": "dòngjī",
+        "native_1": "motive; motivation; intention",
+        "primary_1": "动机",
+        "primary_2": "動機"
+    },
+    {
+        "intermediate_1": "dong4jing4",
+        "intermediate_2": "dòngjìng",
+        "native_1": "sound of activity; activity",
+        "primary_1": "动静",
+        "primary_2": "動靜"
+    },
+    {
+        "intermediate_1": "dong4li4",
+        "intermediate_2": "dònglì",
+        "native_1": "power; motion; impetus; driving force",
+        "primary_1": "动力",
+        "primary_2": "動力"
+    },
+    {
+        "intermediate_1": "dong4mai4",
+        "intermediate_2": "dòngmài",
+        "native_1": "artery",
+        "primary_1": "动脉",
+        "primary_2": "動脈"
+    },
+    {
+        "intermediate_1": "dong4 shen1",
+        "intermediate_2": "dòng shēn",
+        "native_1": "go on a journey; leave",
+        "primary_1": "动身",
+        "primary_2": "動身"
+    },
+    {
+        "intermediate_1": "dong4shou3",
+        "intermediate_2": "dòngshǒu",
+        "native_1": "get to work; to touch; strike a blow",
+        "primary_1": "动手",
+        "primary_2": "動手"
+    },
+    {
+        "intermediate_1": "dong4tai4",
+        "intermediate_2": "dòngtài",
+        "native_1": "development; trend; dynamic state",
+        "primary_1": "动态",
+        "primary_2": "動態"
+    },
+    {
+        "intermediate_1": "dong4yuan2",
+        "intermediate_2": "dòngyuán",
+        "native_1": "mobilize",
+        "primary_1": "动员",
+        "primary_2": "動員"
+    },
+    {
+        "intermediate_1": "dong4jie2",
+        "intermediate_2": "dòngjié",
+        "native_1": "(loan, wage, price) freeze",
+        "primary_1": "冻结",
+        "primary_2": "凍結"
+    },
+    {
+        "intermediate_1": "dong4",
+        "intermediate_2": "dòng",
+        "native_1": "roof beam; (mw for buildings)",
+        "primary_1": "栋",
+        "primary_2": "棟"
+    },
+    {
+        "intermediate_1": "dou1",
+        "intermediate_2": "dōu",
+        "native_1": "pocket; bag; wrap up (in a piece of cloth); move around (in a circle); canvass (solicit); take responsibility",
+        "primary_1": "兜",
+        "primary_2": "兜"
+    },
+    {
+        "intermediate_1": "dou3qiao4",
+        "intermediate_2": "dǒuqiào",
+        "native_1": "steep; precipitous",
+        "primary_1": "陡峭",
+        "primary_2": "陡峭"
+    },
+    {
+        "intermediate_1": "dou4zheng1",
+        "intermediate_2": "dòuzhēng",
+        "native_1": "to struggle; to fight for; to battle",
+        "primary_1": "斗争",
+        "primary_2": "鬥爭"
+    },
+    {
+        "intermediate_1": "du1cu4",
+        "intermediate_2": "dūcù",
+        "native_1": "supervise and urge sb. to complete a task",
+        "primary_1": "督促",
+        "primary_2": "督促"
+    },
+    {
+        "intermediate_1": "du2pin3",
+        "intermediate_2": "dúpǐn",
+        "native_1": "drugs; narcotics; poison",
+        "primary_1": "毒品",
+        "primary_2": "毒品"
+    },
+    {
+        "intermediate_1": "du2cai2",
+        "intermediate_2": "dúcái",
+        "native_1": "dictatorship",
+        "primary_1": "独裁",
+        "primary_2": "獨裁"
+    },
+    {
+        "intermediate_1": "du3se4",
+        "intermediate_2": "dǔsè",
+        "native_1": "block; stop",
+        "primary_1": "堵塞",
+        "primary_2": "堵塞"
+    },
+    {
+        "intermediate_1": "du3bo2",
+        "intermediate_2": "dǔbó",
+        "native_1": "to gamble",
+        "primary_1": "赌博",
+        "primary_2": "賭博"
+    },
+    {
+        "intermediate_1": "du4jue2",
+        "intermediate_2": "dùjué",
+        "native_1": "put an end to",
+        "primary_1": "杜绝",
+        "primary_2": "杜絕"
+    },
+    {
+        "intermediate_1": "duan1",
+        "intermediate_2": "duān",
+        "native_1": "end; beginning; extremity; carry holding something from the sides",
+        "primary_1": "端",
+        "primary_2": "端"
+    },
+    {
+        "intermediate_1": "Duan1wu3 Jie2",
+        "intermediate_2": "Duānwǔ Jié",
+        "native_1": "Dragon Boat Festival",
+        "primary_1": "端午节",
+        "primary_2": "端午節"
+    },
+    {
+        "intermediate_1": "duan1zheng4",
+        "intermediate_2": "duānzhèng",
+        "native_1": "upright; regular; proper; correct",
+        "primary_1": "端正",
+        "primary_2": "端正"
+    },
+    {
+        "intermediate_1": "duan3cu4",
+        "intermediate_2": "duǎncù",
+        "native_1": "short in time duration; fleeting; brief",
+        "primary_1": "短促",
+        "primary_2": "短促"
+    },
+    {
+        "intermediate_1": "duan4ding4",
+        "intermediate_2": "duàndìng",
+        "native_1": "conclude; determine; figure out",
+        "primary_1": "断定",
+        "primary_2": "斷定"
+    },
+    {
+        "intermediate_1": "duan4jue2",
+        "intermediate_2": "duànjué",
+        "native_1": "sever; break off",
+        "primary_1": "断绝",
+        "primary_2": "斷絕"
+    },
+    {
+        "intermediate_1": "dui1ji1",
+        "intermediate_2": "duījī",
+        "native_1": "pile up; accumulate",
+        "primary_1": "堆积",
+        "primary_2": "堆積"
+    },
+    {
+        "intermediate_1": "dui4wu",
+        "intermediate_2": "duìwu",
+        "native_1": "ranks; troops",
+        "primary_1": "队伍",
+        "primary_2": "隊伍"
+    },
+    {
+        "intermediate_1": "dui4ce4",
+        "intermediate_2": "duìcè",
+        "native_1": "countermeasure for dealing with a situation",
+        "primary_1": "对策",
+        "primary_2": "對策"
+    },
+    {
+        "intermediate_1": "dui4chen4",
+        "intermediate_2": "duìchèn",
+        "native_1": "symmetry",
+        "primary_1": "对称",
+        "primary_2": "對稱"
+    },
+    {
+        "intermediate_1": "dui4fu",
+        "intermediate_2": "duìfu",
+        "native_1": "to handle; deal with",
+        "primary_1": "对付",
+        "primary_2": "對付"
+    },
+    {
+        "intermediate_1": "dui4kang4",
+        "intermediate_2": "duìkàng",
+        "native_1": "withstand; resist; antagonize",
+        "primary_1": "对抗",
+        "primary_2": "對抗"
+    },
+    {
+        "intermediate_1": "dui4li4",
+        "intermediate_2": "duìlì",
+        "native_1": "oppose; to counter",
+        "primary_1": "对立",
+        "primary_2": "對立"
+    },
+    {
+        "intermediate_1": "dui4lian2",
+        "intermediate_2": "duìlián",
+        "native_1": "rhyming couplet; vertical written couplet usually placed along either side of a doorway",
+        "primary_1": "对联",
+        "primary_2": "對聯"
+    },
+    {
+        "intermediate_1": "dui4ying4",
+        "intermediate_2": "duìyìng",
+        "native_1": "corresponding; counterpart",
+        "primary_1": "对应",
+        "primary_2": "對應"
+    },
+    {
+        "intermediate_1": "dui4zhao4",
+        "intermediate_2": "duìzhào",
+        "native_1": "contrast; compare",
+        "primary_1": "对照",
+        "primary_2": "對照"
+    },
+    {
+        "intermediate_1": "dui4xian4",
+        "intermediate_2": "duìxiàn",
+        "native_1": "cash a check; honor a commitment",
+        "primary_1": "兑现",
+        "primary_2": "兌現"
+    },
+    {
+        "intermediate_1": "dun4shi2",
+        "intermediate_2": "dùnshí",
+        "native_1": "immediately; suddenly",
+        "primary_1": "顿时",
+        "primary_2": "頓時"
+    },
+    {
+        "intermediate_1": "duo1yuan2hua4",
+        "intermediate_2": "duōyuánhuà",
+        "native_1": "diversify; diversification",
+        "primary_1": "多元化",
+        "primary_2": "多元化"
+    },
+    {
+        "intermediate_1": "duo1suo",
+        "intermediate_2": "duōsuo",
+        "native_1": "tremble; to shiver; to quiver",
+        "primary_1": "哆嗦",
+        "primary_2": "哆嗦"
+    },
+    {
+        "intermediate_1": "duo4luo4",
+        "intermediate_2": "duòluò",
+        "native_1": "morally degenerate; become depraved",
+        "primary_1": "堕落",
+        "primary_2": "墮落"
+    },
+    {
+        "intermediate_1": "e2wai4",
+        "intermediate_2": "éwài",
+        "native_1": "extra; added; additional",
+        "primary_1": "额外",
+        "primary_2": "額外"
+    },
+    {
+        "intermediate_1": "e3xin",
+        "intermediate_2": "ěxin",
+        "native_1": "disgusting; nauseous; make somebody embarrassed (èxīn: bad/vicious habit; vice)",
+        "primary_1": "恶心",
+        "primary_2": "惡心"
+    },
+    {
+        "intermediate_1": "e4hua4",
+        "intermediate_2": "èhuà",
+        "native_1": "worsen; deteriorate",
+        "primary_1": "恶化",
+        "primary_2": "惡化"
+    },
+    {
+        "intermediate_1": "e4zhi4",
+        "intermediate_2": "èzhì",
+        "native_1": "keep within limits; contain; restrain; hold back",
+        "primary_1": "遏制",
+        "primary_2": "遏制"
+    },
+    {
+        "intermediate_1": "en1yuan4",
+        "intermediate_2": "ēnyuàn",
+        "native_1": "grievance; old rivalry; mixture of gratitude and resentment",
+        "primary_1": "恩怨",
+        "primary_2": "恩怨"
+    },
+    {
+        "intermediate_1": "er2yi3",
+        "intermediate_2": "éryǐ",
+        "native_1": "that's all; nothing more",
+        "primary_1": "而已",
+        "primary_2": "而已"
+    },
+    {
+        "intermediate_1": "er4yang3hua4tan4",
+        "intermediate_2": "èryǎnghuàtàn",
+        "native_1": "carbon dioxide; CO2",
+        "primary_1": "二氧化碳",
+        "primary_2": "二氧化碳"
+    },
+    {
+        "intermediate_1": "fa1bu4",
+        "intermediate_2": "fābù",
+        "native_1": "issue; announce; release",
+        "primary_1": "发布",
+        "primary_2": "發布"
+    },
+    {
+        "intermediate_1": "fa1 cai2",
+        "intermediate_2": "fā cái",
+        "native_1": "get rich",
+        "primary_1": "发财",
+        "primary_2": "發財"
+    },
+    {
+        "intermediate_1": "fa1dai1",
+        "intermediate_2": "fādāi",
+        "native_1": "stare blankly; daze off",
+        "primary_1": "发呆",
+        "primary_2": "發呆"
+    },
+    {
+        "intermediate_1": "fa1dong4",
+        "intermediate_2": "fādòng",
+        "native_1": "to start; to launch; mobilize",
+        "primary_1": "发动",
+        "primary_2": "發動"
+    },
+    {
+        "intermediate_1": "fa1jue2",
+        "intermediate_2": "fājué",
+        "native_1": "discover; detect",
+        "primary_1": "发觉",
+        "primary_2": "發覺"
+    },
+    {
+        "intermediate_1": "fa1she4",
+        "intermediate_2": "fāshè",
+        "native_1": "to launch; to shoot (a projectile); to fire (a rocket)",
+        "primary_1": "发射",
+        "primary_2": "發射"
+    },
+    {
+        "intermediate_1": "fa1shi4",
+        "intermediate_2": "fāshì",
+        "native_1": "to vow; to pledge; swear",
+        "primary_1": "发誓",
+        "primary_2": "發誓"
+    },
+    {
+        "intermediate_1": "fa1xing2",
+        "intermediate_2": "fāxíng",
+        "native_1": "publish; to issue; distribute",
+        "primary_1": "发行",
+        "primary_2": "發行"
+    },
+    {
+        "intermediate_1": "fa1yan2",
+        "intermediate_2": "fāyán",
+        "native_1": "become inflamed from infection or injury",
+        "primary_1": "发炎",
+        "primary_2": "發炎"
+    },
+    {
+        "intermediate_1": "fa1yang2",
+        "intermediate_2": "fāyáng",
+        "native_1": "develop; make full use of; to carry on",
+        "primary_1": "发扬",
+        "primary_2": "發揚"
+    },
+    {
+        "intermediate_1": "fa1yu4",
+        "intermediate_2": "fāyù",
+        "native_1": "develop; growth",
+        "primary_1": "发育",
+        "primary_2": "發育"
+    },
+    {
+        "intermediate_1": "fa3ren2",
+        "intermediate_2": "fǎrén",
+        "native_1": "legal entity (i.e., a corporation)",
+        "primary_1": "法人",
+        "primary_2": "法人"
+    },
+    {
+        "intermediate_1": "fan1",
+        "intermediate_2": "fān",
+        "native_1": "(mw for acts or deeds); foreign",
+        "primary_1": "番",
+        "primary_2": "番"
+    },
+    {
+        "intermediate_1": "fan2shi4",
+        "intermediate_2": "fánshì",
+        "native_1": "every; any; all; without exception",
+        "primary_1": "凡是",
+        "primary_2": "凡是"
+    },
+    {
+        "intermediate_1": "fan2hua2",
+        "intermediate_2": "fánhuá",
+        "native_1": "flourishing; bustling; prosperous",
+        "primary_1": "繁华",
+        "primary_2": "繁華"
+    },
+    {
+        "intermediate_1": "fan2mang2",
+        "intermediate_2": "fánmáng",
+        "native_1": "busy; bustling",
+        "primary_1": "繁忙",
+        "primary_2": "繁忙"
+    },
+    {
+        "intermediate_1": "fan2ti3zi4",
+        "intermediate_2": "fántǐzì",
+        "native_1": "traditional Chinese character",
+        "primary_1": "繁体字",
+        "primary_2": "繁體字"
+    },
+    {
+        "intermediate_1": "fan2zhi2",
+        "intermediate_2": "fánzhí",
+        "native_1": "propagate; to breed; reproduce",
+        "primary_1": "繁殖",
+        "primary_2": "繁殖"
+    },
+    {
+        "intermediate_1": "fan3bo2",
+        "intermediate_2": "fǎnbó",
+        "native_1": "retort; refute",
+        "primary_1": "反驳",
+        "primary_2": "反駁"
+    },
+    {
+        "intermediate_1": "fan3chang2",
+        "intermediate_2": "fǎncháng",
+        "native_1": "abnormal; unusual",
+        "primary_1": "反常",
+        "primary_2": "反常"
+    },
+    {
+        "intermediate_1": "fang3an3",
+        "intermediate_2": "fǎngǎn",
+        "native_1": "(strongly) dislike",
+        "primary_1": "反感",
+        "primary_2": "反感"
+    },
+    {
+        "intermediate_1": "fan3kang4",
+        "intermediate_2": "fǎnkàng",
+        "native_1": "resist; to revolt",
+        "primary_1": "反抗",
+        "primary_2": "反抗"
+    },
+    {
+        "intermediate_1": "fan3kui4",
+        "intermediate_2": "fǎnkuì",
+        "native_1": "feedback; send information back",
+        "primary_1": "反馈",
+        "primary_2": "反饋"
+    },
+    {
+        "intermediate_1": "fan3mian4",
+        "intermediate_2": "fǎnmiàn",
+        "native_1": "the reverse side of sth.; opposite side of a topic",
+        "primary_1": "反面",
+        "primary_2": "反面"
+    },
+    {
+        "intermediate_1": "fan3she4",
+        "intermediate_2": "fǎnshè",
+        "native_1": "reflex; reflection (from a mirror, etc.)",
+        "primary_1": "反射",
+        "primary_2": "反射"
+    },
+    {
+        "intermediate_1": "fan3si1",
+        "intermediate_2": "fǎnsī",
+        "native_1": "think back over something that happened; to reflect; introspection",
+        "primary_1": "反思",
+        "primary_2": "反思"
+    },
+    {
+        "intermediate_1": "fan3wen4",
+        "intermediate_2": "fǎnwèn",
+        "native_1": "ask a rhetorical question; answer a question with a question",
+        "primary_1": "反问",
+        "primary_2": "反問"
+    },
+    {
+        "intermediate_1": "fan3zhi1",
+        "intermediate_2": "fǎnzhī",
+        "native_1": "whereas...; on the other hand ...; conversely ...",
+        "primary_1": "反之",
+        "primary_2": "反之"
+    },
+    {
+        "intermediate_1": "fan4lan4",
+        "intermediate_2": "fànlàn",
+        "native_1": "to be in flood; to overflow (the banks); to inundate; to spread unchecked",
+        "primary_1": "泛滥",
+        "primary_2": "泛濫"
+    },
+    {
+        "intermediate_1": "fan4chou2",
+        "intermediate_2": "fànchóu",
+        "native_1": "category",
+        "primary_1": "范畴",
+        "primary_2": "範疇"
+    },
+    {
+        "intermediate_1": "fan4mai4",
+        "intermediate_2": "fànmài",
+        "native_1": "sell; peddle; (often derogatory) to traffic in",
+        "primary_1": "贩卖",
+        "primary_2": "販賣"
+    },
+    {
+        "intermediate_1": "fang1wei4",
+        "intermediate_2": "fāngwèi",
+        "native_1": "position; direction; points of the compass; bearing",
+        "primary_1": "方位",
+        "primary_2": "方位"
+    },
+    {
+        "intermediate_1": "fang1yan2",
+        "intermediate_2": "fāngyán",
+        "native_1": "dialect",
+        "primary_1": "方言",
+        "primary_2": "方言"
+    },
+    {
+        "intermediate_1": "fang1yuan2",
+        "intermediate_2": "fāngyuán",
+        "native_1": "circumference; neighborhood; vicinity",
+        "primary_1": "方圆",
+        "primary_2": "方圓"
+    },
+    {
+        "intermediate_1": "fang1zhen1",
+        "intermediate_2": "fāngzhēn",
+        "native_1": "policy; guidelines",
+        "primary_1": "方针",
+        "primary_2": "方針"
+    },
+    {
+        "intermediate_1": "fang2shou3",
+        "intermediate_2": "fángshǒu",
+        "native_1": "to defend; protect; to guard",
+        "primary_1": "防守",
+        "primary_2": "防守"
+    },
+    {
+        "intermediate_1": "fang2yu4",
+        "intermediate_2": "fángyù",
+        "native_1": "defense; resist; to guard",
+        "primary_1": "防御",
+        "primary_2": "防禦"
+    },
+    {
+        "intermediate_1": "fang2zhi3",
+        "intermediate_2": "fángzhǐ",
+        "native_1": "prevent; protect; guard against; avoid",
+        "primary_1": "防止",
+        "primary_2": "防止"
+    },
+    {
+        "intermediate_1": "fang2zhi4",
+        "intermediate_2": "fángzhì",
+        "native_1": "prevent and cure",
+        "primary_1": "防治",
+        "primary_2": "防治"
+    },
+    {
+        "intermediate_1": "fang3wen4",
+        "intermediate_2": "fǎngwèn",
+        "native_1": "to visit; call on; to interview",
+        "primary_1": "访问",
+        "primary_2": "訪問"
+    },
+    {
+        "intermediate_1": "fang3zhi1",
+        "intermediate_2": "fǎngzhī",
+        "native_1": "spinning and weaving; textile",
+        "primary_1": "纺织",
+        "primary_2": "紡織"
+    },
+    {
+        "intermediate_1": "fang4da4",
+        "intermediate_2": "fàngdà",
+        "native_1": "enlarge; amplify",
+        "primary_1": "放大",
+        "primary_2": "放大"
+    },
+    {
+        "intermediate_1": "fang4she4",
+        "intermediate_2": "fàngshè",
+        "native_1": "radiate; radioactive",
+        "primary_1": "放射",
+        "primary_2": "放射"
+    },
+    {
+        "intermediate_1": "fei1qin2zou3shou4",
+        "intermediate_2": "fēiqínzǒushòu",
+        "native_1": "birds and animals; the beasts of the field and the birds of the air",
+        "primary_1": "飞禽走兽",
+        "primary_2": "飛禽走獸"
+    },
+    {
+        "intermediate_1": "fei1xiang2",
+        "intermediate_2": "fēixiáng",
+        "native_1": "fly; hover",
+        "primary_1": "飞翔",
+        "primary_2": "飛翔"
+    },
+    {
+        "intermediate_1": "fei1yue4",
+        "intermediate_2": "fēiyuè",
+        "native_1": "to leap",
+        "primary_1": "飞跃",
+        "primary_2": "飛躍"
+    },
+    {
+        "intermediate_1": "fei1fa3",
+        "intermediate_2": "fēifǎ",
+        "native_1": "illegal",
+        "primary_1": "非法",
+        "primary_2": "非法"
+    },
+    {
+        "intermediate_1": "fei2wo4",
+        "intermediate_2": "féiwò",
+        "native_1": "fertile",
+        "primary_1": "肥沃",
+        "primary_2": "肥沃"
+    },
+    {
+        "intermediate_1": "fei3bang4",
+        "intermediate_2": "fěibàng",
+        "native_1": "slander; libel",
+        "primary_1": "诽谤",
+        "primary_2": "誹謗"
+    },
+    {
+        "intermediate_1": "fei4",
+        "intermediate_2": "fèi",
+        "native_1": "lung",
+        "primary_1": "肺",
+        "primary_2": "肺"
+    },
+    {
+        "intermediate_1": "fei4chu2",
+        "intermediate_2": "fèichú",
+        "native_1": "abolish; annul; abrogate",
+        "primary_1": "废除",
+        "primary_2": "廢除"
+    },
+    {
+        "intermediate_1": "fei4qin3wang4shi2",
+        "intermediate_2": "fèiqǐnwàngshí",
+        "native_1": "to forget even sleeping and eating",
+        "primary_1": "废寝忘食",
+        "primary_2": "廢寢忘食"
+    },
+    {
+        "intermediate_1": "fei4xu1",
+        "intermediate_2": "fèixū",
+        "native_1": "ruins",
+        "primary_1": "废墟",
+        "primary_2": "廢墟"
+    },
+    {
+        "intermediate_1": "fei4teng2",
+        "intermediate_2": "fèiténg",
+        "native_1": "to boil; boiling",
+        "primary_1": "沸腾",
+        "primary_2": "沸騰"
+    },
+    {
+        "intermediate_1": "fen1bian4",
+        "intermediate_2": "fēnbiàn",
+        "native_1": "distinguish; differentiate; resolve",
+        "primary_1": "分辨",
+        "primary_2": "分辨"
+    },
+    {
+        "intermediate_1": "fen1cun",
+        "intermediate_2": "fēncun",
+        "native_1": "propriety; the limits of proper speech or action",
+        "primary_1": "分寸",
+        "primary_2": "分寸"
+    },
+    {
+        "intermediate_1": "fen1 hong2",
+        "intermediate_2": "fēn hóng",
+        "native_1": "a bonus; to award a bonus; to draw or recieve dividends; to share profits",
+        "primary_1": "分红",
+        "primary_2": "分紅"
+    },
+    {
+        "intermediate_1": "fen1jie3",
+        "intermediate_2": "fēnjiě",
+        "native_1": "to decompose; to resolve; to break down",
+        "primary_1": "分解",
+        "primary_2": "分解"
+    },
+    {
+        "intermediate_1": "fen1lie4",
+        "intermediate_2": "fēnliè",
+        "native_1": "split up; to divide; separate",
+        "primary_1": "分裂",
+        "primary_2": "分裂"
+    },
+    {
+        "intermediate_1": "fen1mi4",
+        "intermediate_2": "fēnmì",
+        "native_1": "secrete",
+        "primary_1": "分泌",
+        "primary_2": "分泌"
+    },
+    {
+        "intermediate_1": "fen1ming2",
+        "intermediate_2": "fēnmíng",
+        "native_1": "clear; distinct; evidently; clearly",
+        "primary_1": "分明",
+        "primary_2": "分明"
+    },
+    {
+        "intermediate_1": "fen1qi2",
+        "intermediate_2": "fēnqí",
+        "native_1": "difference (of opinion/position）",
+        "primary_1": "分歧",
+        "primary_2": "分歧"
+    },
+    {
+        "intermediate_1": "fen1san4",
+        "intermediate_2": "fēnsàn",
+        "native_1": "to scatter; disperse; distribute",
+        "primary_1": "分散",
+        "primary_2": "分散"
+    },
+    {
+        "intermediate_1": "fen1fu4",
+        "intermediate_2": "fēnfù",
+        "native_1": "instruct; instructions; to tell; to order (to do something)",
+        "primary_1": "吩咐",
+        "primary_2": "吩咐"
+    },
+    {
+        "intermediate_1": "fen2mu4",
+        "intermediate_2": "fénmù",
+        "native_1": "tomb; sepulcher",
+        "primary_1": "坟墓",
+        "primary_2": "墳墓"
+    },
+    {
+        "intermediate_1": "fen3mo4",
+        "intermediate_2": "fěnmò",
+        "native_1": "fine powder; dust",
+        "primary_1": "粉末",
+        "primary_2": "粉末"
+    },
+    {
+        "intermediate_1": "fen3se4",
+        "intermediate_2": "fěnsè",
+        "native_1": "pink",
+        "primary_1": "粉色",
+        "primary_2": "粉色"
+    },
+    {
+        "intermediate_1": "fen3sui4",
+        "intermediate_2": "fěnsuì",
+        "native_1": "to crash; break up",
+        "primary_1": "粉碎",
+        "primary_2": "粉碎"
+    },
+    {
+        "intermediate_1": "fen4liang4",
+        "intermediate_2": "fènliàng",
+        "native_1": "weight; heft; amount",
+        "primary_1": "分量",
+        "primary_2": "分量"
+    },
+    {
+        "intermediate_1": "fen4nu4",
+        "intermediate_2": "fènnù",
+        "native_1": "angry; indignant; furious; anger; indignation; wrath; ire",
+        "primary_1": "愤怒",
+        "primary_2": "憤怒"
+    },
+    {
+        "intermediate_1": "feng1man3",
+        "intermediate_2": "fēngmǎn",
+        "native_1": "plump; well developed; plentiful; Fengman district of Jilin City, Jilin Province",
+        "primary_1": "丰满",
+        "primary_2": "豐滿"
+    },
+    {
+        "intermediate_1": "feng1sheng4",
+        "intermediate_2": "fēngshèng",
+        "native_1": "sumptuous; lavish",
+        "primary_1": "丰盛",
+        "primary_2": "豐盛"
+    },
+    {
+        "intermediate_1": "feng1shou1",
+        "intermediate_2": "fēngshōu",
+        "native_1": "bumper crop; have a good harvest",
+        "primary_1": "丰收",
+        "primary_2": "豐收"
+    },
+    {
+        "intermediate_1": "feng1bao4",
+        "intermediate_2": "fēngbào",
+        "native_1": "storm; violent commotion",
+        "primary_1": "风暴",
+        "primary_2": "風暴"
+    },
+    {
+        "intermediate_1": "feng1du4",
+        "intermediate_2": "fēngdù",
+        "native_1": "elegant demeanor; grace; poise; style",
+        "primary_1": "风度",
+        "primary_2": "風度"
+    },
+    {
+        "intermediate_1": "feng1guang1",
+        "intermediate_2": "fēngguāng",
+        "native_1": "a natural scenic view; sight",
+        "primary_1": "风光",
+        "primary_2": "風光"
+    },
+    {
+        "intermediate_1": "feng1qi4",
+        "intermediate_2": "fēngqì",
+        "native_1": "general mood; atmosphere; common practice",
+        "primary_1": "风气",
+        "primary_2": "風氣"
+    },
+    {
+        "intermediate_1": "feng1qu4",
+        "intermediate_2": "fēngqù",
+        "native_1": "humor; wit; humorous",
+        "primary_1": "风趣",
+        "primary_2": "風趣"
+    },
+    {
+        "intermediate_1": "feng1tu3ren2qing2",
+        "intermediate_2": "fēngtǔrénqíng",
+        "native_1": "local conditions (human and environmental)",
+        "primary_1": "风土人情",
+        "primary_2": "風土人情"
+    },
+    {
+        "intermediate_1": "feng1wei4",
+        "intermediate_2": "fēngwèi",
+        "native_1": "local flavor; local style",
+        "primary_1": "风味",
+        "primary_2": "風味"
+    },
+    {
+        "intermediate_1": "feng1bi4",
+        "intermediate_2": "fēngbì",
+        "native_1": "to seal; to close; confine",
+        "primary_1": "封闭",
+        "primary_2": "封閉"
+    },
+    {
+        "intermediate_1": "feng1jian4",
+        "intermediate_2": "fēngjiàn",
+        "native_1": "feudal; feudalism",
+        "primary_1": "封建",
+        "primary_2": "封建"
+    },
+    {
+        "intermediate_1": "feng1suo3",
+        "intermediate_2": "fēngsuǒ",
+        "native_1": "to blockade; to seal off",
+        "primary_1": "封锁",
+        "primary_2": "封鎖"
+    },
+    {
+        "intermediate_1": "feng1li4",
+        "intermediate_2": "fēnglì",
+        "native_1": "sharp (i.e. a knife blade); incisive; to the point",
+        "primary_1": "锋利",
+        "primary_2": "鋒利"
+    },
+    {
+        "intermediate_1": "feng2",
+        "intermediate_2": "féng",
+        "native_1": "to meet; come upon",
+        "primary_1": "逢",
+        "primary_2": "逢"
+    },
+    {
+        "intermediate_1": "feng4xian4",
+        "intermediate_2": "fèngxiàn",
+        "native_1": "consecrate; dedicate; devote",
+        "primary_1": "奉献",
+        "primary_2": "奉獻"
+    },
+    {
+        "intermediate_1": "fou3jue2",
+        "intermediate_2": "fǒujué",
+        "native_1": "veto; reject; overrule",
+        "primary_1": "否决",
+        "primary_2": "否決"
+    },
+    {
+        "intermediate_1": "fu1fu4",
+        "intermediate_2": "fūfù",
+        "native_1": "married couple; husband and wife",
+        "primary_1": "夫妇",
+        "primary_2": "夫婦"
+    },
+    {
+        "intermediate_1": "fu1ren2",
+        "intermediate_2": "fūrén",
+        "native_1": "lady; madam; Mrs.; wife",
+        "primary_1": "夫人",
+        "primary_2": "夫人"
+    },
+    {
+        "intermediate_1": "fu1yan3",
+        "intermediate_2": "fūyǎn",
+        "native_1": "to elaborate (on a theme); to expound (the classics); to do sth. half-heartedly or just for show; barely enough to get by; perfunctory; apathetic; to skimp; to botch",
+        "primary_1": "敷衍",
+        "primary_2": "敷衍"
+    },
+    {
+        "intermediate_1": "fu2cong2",
+        "intermediate_2": "fúcóng",
+        "native_1": "to obey; to comply",
+        "primary_1": "服从",
+        "primary_2": "服從"
+    },
+    {
+        "intermediate_1": "fu2qi4",
+        "intermediate_2": "fúqì",
+        "native_1": "be convinced",
+        "primary_1": "服气",
+        "primary_2": "服氣"
+    },
+    {
+        "intermediate_1": "fu2lu3",
+        "intermediate_2": "fúlǔ",
+        "native_1": "captive; prisoner",
+        "primary_1": "俘虏",
+        "primary_2": "俘虜"
+    },
+    {
+        "intermediate_1": "fu2hao4",
+        "intermediate_2": "fúhào",
+        "native_1": "symbol; mark; sign",
+        "primary_1": "符号",
+        "primary_2": "符號"
+    },
+    {
+        "intermediate_1": "fu2du4",
+        "intermediate_2": "fúdù",
+        "native_1": "width; margin; extent",
+        "primary_1": "幅度",
+        "primary_2": "幅度"
+    },
+    {
+        "intermediate_1": "fu2she4",
+        "intermediate_2": "fúshè",
+        "native_1": "radiation",
+        "primary_1": "辐射",
+        "primary_2": "輻射"
+    },
+    {
+        "intermediate_1": "fu2li4",
+        "intermediate_2": "fúlì",
+        "native_1": "material benefits; welfare; well-being",
+        "primary_1": "福利",
+        "primary_2": "福利"
+    },
+    {
+        "intermediate_1": "fu2qi4",
+        "intermediate_2": "fúqì",
+        "native_1": "good fortune",
+        "primary_1": "福气",
+        "primary_2": "福氣"
+    },
+    {
+        "intermediate_1": "fu3mo1",
+        "intermediate_2": "fǔmō",
+        "native_1": "gently caress and stroke; to pet; to fondle",
+        "primary_1": "抚摸",
+        "primary_2": "撫摸"
+    },
+    {
+        "intermediate_1": "fu3yang3",
+        "intermediate_2": "fǔyǎng",
+        "native_1": "foster; bring up; raise",
+        "primary_1": "抚养",
+        "primary_2": "撫養"
+    },
+    {
+        "intermediate_1": "fu3shi4",
+        "intermediate_2": "fǔshì",
+        "native_1": "look down at; overlook",
+        "primary_1": "俯视",
+        "primary_2": "俯視"
+    },
+    {
+        "intermediate_1": "fu3zhu4",
+        "intermediate_2": "fǔzhù",
+        "native_1": "assist; aide",
+        "primary_1": "辅助",
+        "primary_2": "輔助"
+    },
+    {
+        "intermediate_1": "fu3bai4",
+        "intermediate_2": "fǔbài",
+        "native_1": "corruption; corrupt; rotten",
+        "primary_1": "腐败",
+        "primary_2": "腐敗"
+    },
+    {
+        "intermediate_1": "fu3lan4",
+        "intermediate_2": "fǔlàn",
+        "native_1": "rot; become gangrenous",
+        "primary_1": "腐烂",
+        "primary_2": "腐爛"
+    },
+    {
+        "intermediate_1": "fu3shi2",
+        "intermediate_2": "fǔshí",
+        "native_1": "erode; corrode; corrupt; rusty",
+        "primary_1": "腐蚀",
+        "primary_2": "腐蝕"
+    },
+    {
+        "intermediate_1": "fu3xiu3",
+        "intermediate_2": "fǔxiǔ",
+        "native_1": "rotten; decayed; decadent; degenerate",
+        "primary_1": "腐朽",
+        "primary_2": "腐朽"
+    },
+    {
+        "intermediate_1": "fu4dan1",
+        "intermediate_2": "fùdān",
+        "native_1": "to (bear a) burden; carry; a load",
+        "primary_1": "负担",
+        "primary_2": "負擔"
+    },
+    {
+        "intermediate_1": "fu4he4",
+        "intermediate_2": "fùhè",
+        "native_1": "repeat an agreement; copy sb.'s action or words",
+        "primary_1": "附和",
+        "primary_2": "附和"
+    },
+    {
+        "intermediate_1": "fu4jian4",
+        "intermediate_2": "fùjiàn",
+        "native_1": "attachment; enclosure",
+        "primary_1": "附件",
+        "primary_2": "附件"
+    },
+    {
+        "intermediate_1": "fu4shu3",
+        "intermediate_2": "fùshǔ",
+        "native_1": "subsidiary; auxiliary; affiliate; attached",
+        "primary_1": "附属",
+        "primary_2": "附屬"
+    },
+    {
+        "intermediate_1": "fu4huo2",
+        "intermediate_2": "fùhuó",
+        "native_1": "resurrection",
+        "primary_1": "复活",
+        "primary_2": "複活"
+    },
+    {
+        "intermediate_1": "fu4xing1",
+        "intermediate_2": "fùxīng",
+        "native_1": "revive; restore",
+        "primary_1": "复兴",
+        "primary_2": "複興"
+    },
+    {
+        "intermediate_1": "fu4",
+        "intermediate_2": "fù",
+        "native_1": "vice-; secondary; auxiliary; deputy; assistant; classifier for pairs (i.e. glasses)",
+        "primary_1": "副",
+        "primary_2": "副"
+    },
+    {
+        "intermediate_1": "fu4yu3",
+        "intermediate_2": "fùyǔ",
+        "native_1": "confer upon; bestow; endow; entrust (a task)",
+        "primary_1": "赋予",
+        "primary_2": "賦予"
+    },
+    {
+        "intermediate_1": "fu4yu4",
+        "intermediate_2": "fùyù",
+        "native_1": "rich; to prosper; wealthy",
+        "primary_1": "富裕",
+        "primary_2": "富裕"
+    },
+    {
+        "intermediate_1": "fu4xie4",
+        "intermediate_2": "fùxiè",
+        "native_1": "diarrhea",
+        "primary_1": "腹泻",
+        "primary_2": "腹瀉"
+    },
+    {
+        "intermediate_1": "fu4gai4",
+        "intermediate_2": "fùgài",
+        "native_1": "to cover",
+        "primary_1": "覆盖",
+        "primary_2": "覆蓋"
+    },
+    {
+        "intermediate_1": "gai3liang2",
+        "intermediate_2": "gǎiliáng",
+        "native_1": "improve; to reform",
+        "primary_1": "改良",
+        "primary_2": "改良"
+    },
+    {
+        "intermediate_1": "gai4",
+        "intermediate_2": "gài",
+        "native_1": "calcium",
+        "primary_1": "钙",
+        "primary_2": "鈣"
+    },
+    {
+        "intermediate_1": "gai4zhang1",
+        "intermediate_2": "gàizhāng",
+        "native_1": "affix one's seal; seal; stamp",
+        "primary_1": "盖章",
+        "primary_2": "蓋章"
+    },
+    {
+        "intermediate_1": "gan1han4",
+        "intermediate_2": "gānhàn",
+        "native_1": "drought; dry",
+        "primary_1": "干旱",
+        "primary_2": "幹旱"
+    },
+    {
+        "intermediate_1": "gan1rao3",
+        "intermediate_2": "gānrǎo",
+        "native_1": "interfere; obstruction",
+        "primary_1": "干扰",
+        "primary_2": "幹擾"
+    },
+    {
+        "intermediate_1": "gan1she4",
+        "intermediate_2": "gānshè",
+        "native_1": "interfere; intervene; meddle",
+        "primary_1": "干涉",
+        "primary_2": "幹涉"
+    },
+    {
+        "intermediate_1": "gan1yu4",
+        "intermediate_2": "gānyù",
+        "native_1": "meddle; intervene; intervention",
+        "primary_1": "干预",
+        "primary_2": "幹預"
+    },
+    {
+        "intermediate_1": "gang1a4",
+        "intermediate_2": "gāngà",
+        "native_1": "awkward; embarrassed",
+        "primary_1": "尴尬",
+        "primary_2": "尴尬"
+    },
+    {
+        "intermediate_1": "gan3kai3",
+        "intermediate_2": "gǎnkǎi",
+        "native_1": "lament; with a tinge of emotion or regret",
+        "primary_1": "感慨",
+        "primary_2": "感慨"
+    },
+    {
+        "intermediate_1": "gan3ran3",
+        "intermediate_2": "gǎnrǎn",
+        "native_1": "infection; infect; influence",
+        "primary_1": "感染",
+        "primary_2": "感染"
+    },
+    {
+        "intermediate_1": "gan4jin4",
+        "intermediate_2": "gànjìn",
+        "native_1": "enthusiasm; energy; drive",
+        "primary_1": "干劲",
+        "primary_2": "幹勁"
+    },
+    {
+        "intermediate_1": "gang1ling3",
+        "intermediate_2": "gānglǐng",
+        "native_1": "program; guiding principle",
+        "primary_1": "纲领",
+        "primary_2": "綱領"
+    },
+    {
+        "intermediate_1": "gang3wei4",
+        "intermediate_2": "gǎngwèi",
+        "native_1": "a post; a job",
+        "primary_1": "岗位",
+        "primary_2": "崗位"
+    },
+    {
+        "intermediate_1": "gang3kou3",
+        "intermediate_2": "gǎngkǒu",
+        "native_1": "port; harbor",
+        "primary_1": "港口",
+        "primary_2": "港口"
+    },
+    {
+        "intermediate_1": "gang3wan1",
+        "intermediate_2": "gǎngwān",
+        "native_1": "harbor; estuary",
+        "primary_1": "港湾",
+        "primary_2": "港灣"
+    },
+    {
+        "intermediate_1": "gang4gan3",
+        "intermediate_2": "gànggǎn",
+        "native_1": "lever; pry bar; crowbar; financial leverage",
+        "primary_1": "杠杆",
+        "primary_2": "杠杆"
+    },
+    {
+        "intermediate_1": "gao1chao1",
+        "intermediate_2": "gāochāo",
+        "native_1": "excellent; superb",
+        "primary_1": "高超",
+        "primary_2": "高超"
+    },
+    {
+        "intermediate_1": "gao1chao2",
+        "intermediate_2": "gāocháo",
+        "native_1": "high tide; upsurge; climax; chorus (of a song)",
+        "primary_1": "高潮",
+        "primary_2": "高潮"
+    },
+    {
+        "intermediate_1": "gao1feng1",
+        "intermediate_2": "gāofēng",
+        "native_1": "peak; summit; apex",
+        "primary_1": "高峰",
+        "primary_2": "高峰"
+    },
+    {
+        "intermediate_1": "gao1ming2",
+        "intermediate_2": "gāomíng",
+        "native_1": "brilliant; wise",
+        "primary_1": "高明",
+        "primary_2": "高明"
+    },
+    {
+        "intermediate_1": "gao1shang4",
+        "intermediate_2": "gāoshàng",
+        "native_1": "nobly; lofty",
+        "primary_1": "高尚",
+        "primary_2": "高尚"
+    },
+    {
+        "intermediate_1": "gao1zhang3",
+        "intermediate_2": "gāozhǎng",
+        "native_1": "upsurge; (tensions, etc.) run high",
+        "primary_1": "高涨",
+        "primary_2": "高漲"
+    },
+    {
+        "intermediate_1": "gao3jian4",
+        "intermediate_2": "gǎojiàn",
+        "native_1": "rough draft of a document",
+        "primary_1": "稿件",
+        "primary_2": "稿件"
+    },
+    {
+        "intermediate_1": "gao4ci2",
+        "intermediate_2": "gàocí",
+        "native_1": "take leave; bid farewell",
+        "primary_1": "告辞",
+        "primary_2": "告辭"
+    },
+    {
+        "intermediate_1": "gao4jie4",
+        "intermediate_2": "gàojiè",
+        "native_1": "warn; admonish",
+        "primary_1": "告诫",
+        "primary_2": "告誡"
+    },
+    {
+        "intermediate_1": "ge1da",
+        "intermediate_2": "gēda",
+        "native_1": "swelling or lump on skin",
+        "primary_1": "疙瘩",
+        "primary_2": "疙瘩"
+    },
+    {
+        "intermediate_1": "ge1zi",
+        "intermediate_2": "gēzi",
+        "native_1": "dove; pigeon",
+        "primary_1": "鸽子",
+        "primary_2": "鴿子"
+    },
+    {
+        "intermediate_1": "ge1",
+        "intermediate_2": "gē",
+        "native_1": "to place; put aside",
+        "primary_1": "搁",
+        "primary_2": "擱"
+    },
+    {
+        "intermediate_1": "ge1",
+        "intermediate_2": "gē",
+        "native_1": "to cut (apart/off)",
+        "primary_1": "割",
+        "primary_2": "割"
+    },
+    {
+        "intermediate_1": "ge1song4",
+        "intermediate_2": "gēsòng",
+        "native_1": "sing the praise of; extol; eulogize",
+        "primary_1": "歌颂",
+        "primary_2": "歌頌"
+    },
+    {
+        "intermediate_1": "ge2ming4",
+        "intermediate_2": "gémìng",
+        "native_1": "revolution; revolutionary (politics); cause great social change; rise in revolt; take part in revolution",
+        "primary_1": "革命",
+        "primary_2": "革命"
+    },
+    {
+        "intermediate_1": "ge2ju2",
+        "intermediate_2": "géjú",
+        "native_1": "structure; pattern",
+        "primary_1": "格局",
+        "primary_2": "格局"
+    },
+    {
+        "intermediate_1": "ge2shi4",
+        "intermediate_2": "géshì",
+        "native_1": "form; specification; format",
+        "primary_1": "格式",
+        "primary_2": "格式"
+    },
+    {
+        "intermediate_1": "ge2he2",
+        "intermediate_2": "géhé",
+        "native_1": "estrangement; misunderstanding",
+        "primary_1": "隔阂",
+        "primary_2": "隔閡"
+    },
+    {
+        "intermediate_1": "ge2li2",
+        "intermediate_2": "gélí",
+        "native_1": "insulate; separate; isolate",
+        "primary_1": "隔离",
+        "primary_2": "隔離"
+    },
+    {
+        "intermediate_1": "ge4ti3",
+        "intermediate_2": "gètǐ",
+        "native_1": "individual",
+        "primary_1": "个体",
+        "primary_2": "個體"
+    },
+    {
+        "intermediate_1": "ge4shu1ji3jian4",
+        "intermediate_2": "gèshūjǐjiàn",
+        "native_1": "everyone gives their own view",
+        "primary_1": "各抒己见",
+        "primary_2": "各抒己見"
+    },
+    {
+        "intermediate_1": "gen1 shen1 di4 gu4",
+        "intermediate_2": "gēn shēn dì gù",
+        "native_1": "deep-rooted; ingrained; inveterate (problem, etc.)",
+        "primary_1": "根深蒂固",
+        "primary_2": "根深蒂固"
+    },
+    {
+        "intermediate_1": "gen1yuan2",
+        "intermediate_2": "gēnyuán",
+        "native_1": "origin; root; source",
+        "primary_1": "根源",
+        "primary_2": "根源"
+    },
+    {
+        "intermediate_1": "gen1qian2",
+        "intermediate_2": "gēnqián",
+        "native_1": "in front of",
+        "primary_1": "跟前",
+        "primary_2": "跟前"
+    },
+    {
+        "intermediate_1": "gen1sui2",
+        "intermediate_2": "gēnsuí",
+        "native_1": "follow; followed",
+        "primary_1": "跟随",
+        "primary_2": "跟隨"
+    },
+    {
+        "intermediate_1": "gen1zong1",
+        "intermediate_2": "gēnzōng",
+        "native_1": "follow somebody's tracks; tail; shadow",
+        "primary_1": "跟踪",
+        "primary_2": "跟蹤"
+    },
+    {
+        "intermediate_1": "geng1xin1",
+        "intermediate_2": "gēngxīn",
+        "native_1": "to replace the old with new; to renew; to renovate; to upgrade; to update; to regenerate; to rejuvenate",
+        "primary_1": "更新",
+        "primary_2": "更新"
+    },
+    {
+        "intermediate_1": "geng1zheng4",
+        "intermediate_2": "gēngzhèng",
+        "native_1": "correct; correction",
+        "primary_1": "更正",
+        "primary_2": "更正"
+    },
+    {
+        "intermediate_1": "geng1di4",
+        "intermediate_2": "gēngdì",
+        "native_1": "arable land; to plow land",
+        "primary_1": "耕地",
+        "primary_2": "耕地"
+    },
+    {
+        "intermediate_1": "gong1yi4pin3",
+        "intermediate_2": "gōngyìpǐn",
+        "native_1": "handicraft; handiwork",
+        "primary_1": "工艺品",
+        "primary_2": "工藝品"
+    },
+    {
+        "intermediate_1": "gong1an1ju2",
+        "intermediate_2": "gōngānjú",
+        "native_1": "public security bureau",
+        "primary_1": "公安局",
+        "primary_2": "公安局"
+    },
+    {
+        "intermediate_1": "gong1dao",
+        "intermediate_2": "gōngdao",
+        "native_1": "fair; equitable",
+        "primary_1": "公道",
+        "primary_2": "公道"
+    },
+    {
+        "intermediate_1": "gong1gao4",
+        "intermediate_2": "gōnggào",
+        "native_1": "post; announcement",
+        "primary_1": "公告",
+        "primary_2": "公告"
+    },
+    {
+        "intermediate_1": "gong1guan1",
+        "intermediate_2": "gōngguān",
+        "native_1": "public relations",
+        "primary_1": "公关",
+        "primary_2": "公關"
+    },
+    {
+        "intermediate_1": "gong1min2",
+        "intermediate_2": "gōngmín",
+        "native_1": "citizen",
+        "primary_1": "公民",
+        "primary_2": "公民"
+    },
+    {
+        "intermediate_1": "gong1ran2",
+        "intermediate_2": "gōngrán",
+        "native_1": "(do something) openly; undisguised",
+        "primary_1": "公然",
+        "primary_2": "公然"
+    },
+    {
+        "intermediate_1": "gong1ren4",
+        "intermediate_2": "gōngrèn",
+        "native_1": "publicly know (to be); recognize; generally acknowledged",
+        "primary_1": "公认",
+        "primary_2": "公認"
+    },
+    {
+        "intermediate_1": "gong1shi4",
+        "intermediate_2": "gōngshì",
+        "native_1": "formula",
+        "primary_1": "公式",
+        "primary_2": "公式"
+    },
+    {
+        "intermediate_1": "gong1wu4",
+        "intermediate_2": "gōngwù",
+        "native_1": "public affairs; official business",
+        "primary_1": "公务",
+        "primary_2": "公務"
+    },
+    {
+        "intermediate_1": "gong1zheng4",
+        "intermediate_2": "gōngzhèng",
+        "native_1": "just; fair",
+        "primary_1": "公正",
+        "primary_2": "公正"
+    },
+    {
+        "intermediate_1": "gong1zheng4",
+        "intermediate_2": "gōngzhèng",
+        "native_1": "notarization",
+        "primary_1": "公证",
+        "primary_2": "公證"
+    },
+    {
+        "intermediate_1": "gong1lao2",
+        "intermediate_2": "gōngláo",
+        "native_1": "contribution; meritorious; credit",
+        "primary_1": "功劳",
+        "primary_2": "功勞"
+    },
+    {
+        "intermediate_1": "gong1xiao4",
+        "intermediate_2": "gōngxiào",
+        "native_1": "efficiency; effectiveness",
+        "primary_1": "功效",
+        "primary_2": "功效"
+    },
+    {
+        "intermediate_1": "gong1ji1",
+        "intermediate_2": "gōngjī",
+        "native_1": "to attack; accuse; to charge",
+        "primary_1": "攻击",
+        "primary_2": "攻擊"
+    },
+    {
+        "intermediate_1": "gong1ke4",
+        "intermediate_2": "gōngkè",
+        "native_1": "to capture; to take",
+        "primary_1": "攻克",
+        "primary_2": "攻克"
+    },
+    {
+        "intermediate_1": "gong1 bu2 ying4 qiu2",
+        "intermediate_2": "gōng bú yìng qiú",
+        "native_1": "(saying) demand outstrips supply",
+        "primary_1": "供不应求",
+        "primary_2": "供不應求"
+    },
+    {
+        "intermediate_1": "gong1ji3",
+        "intermediate_2": "gōngjǐ",
+        "native_1": "to furnish; provide; to supply",
+        "primary_1": "供给",
+        "primary_2": "供給"
+    },
+    {
+        "intermediate_1": "gong1dian4",
+        "intermediate_2": "gōngdiàn",
+        "native_1": "palace",
+        "primary_1": "宫殿",
+        "primary_2": "宮殿"
+    },
+    {
+        "intermediate_1": "gong1jing4",
+        "intermediate_2": "gōngjìng",
+        "native_1": "dutiful; deferential",
+        "primary_1": "恭敬",
+        "primary_2": "恭敬"
+    },
+    {
+        "intermediate_1": "gong3gu4",
+        "intermediate_2": "gǒnggù",
+        "native_1": "consolidate; solidify",
+        "primary_1": "巩固",
+        "primary_2": "鞏固"
+    },
+    {
+        "intermediate_1": "gong4he2guo2",
+        "intermediate_2": "gònghéguó",
+        "native_1": "republic",
+        "primary_1": "共和国",
+        "primary_2": "共和國"
+    },
+    {
+        "intermediate_1": "gong4ji4",
+        "intermediate_2": "gòngjì",
+        "native_1": "sum up; total",
+        "primary_1": "共计",
+        "primary_2": "共計"
+    },
+    {
+        "intermediate_1": "gong4ming2",
+        "intermediate_2": "gòngmíng",
+        "native_1": "physical resonance; sympathetic response to something",
+        "primary_1": "共鸣",
+        "primary_2": "共鳴"
+    },
+    {
+        "intermediate_1": "gou1jie2",
+        "intermediate_2": "gōujié",
+        "native_1": "collude with; collaborate; gang up",
+        "primary_1": "勾结",
+        "primary_2": "勾結"
+    },
+    {
+        "intermediate_1": "gou1zi",
+        "intermediate_2": "gōuzi",
+        "native_1": "hook",
+        "primary_1": "钩子",
+        "primary_2": "鈎子"
+    },
+    {
+        "intermediate_1": "gou4si1",
+        "intermediate_2": "gòusī",
+        "native_1": "outline a story; make preliminary sketch",
+        "primary_1": "构思",
+        "primary_2": "構思"
+    },
+    {
+        "intermediate_1": "gu1du2",
+        "intermediate_2": "gūdú",
+        "native_1": "lonely; solitary",
+        "primary_1": "孤独",
+        "primary_2": "孤獨"
+    },
+    {
+        "intermediate_1": "gu1li4",
+        "intermediate_2": "gūlì",
+        "native_1": "isolate; isolated",
+        "primary_1": "孤立",
+        "primary_2": "孤立"
+    },
+    {
+        "intermediate_1": "gu1qie3",
+        "intermediate_2": "gūqiě",
+        "native_1": "temporarily; the time being",
+        "primary_1": "姑且",
+        "primary_2": "姑且"
+    },
+    {
+        "intermediate_1": "gu1fu4",
+        "intermediate_2": "gūfù",
+        "native_1": "let down; disappoint; fail to live up to",
+        "primary_1": "辜负",
+        "primary_2": "辜負"
+    },
+    {
+        "intermediate_1": "gu3dong3",
+        "intermediate_2": "gǔdǒng",
+        "native_1": "antique",
+        "primary_1": "古董",
+        "primary_2": "古董"
+    },
+    {
+        "intermediate_1": "gu3guai4",
+        "intermediate_2": "gǔguài",
+        "native_1": "eccentric; grotesque; oddly",
+        "primary_1": "古怪",
+        "primary_2": "古怪"
+    },
+    {
+        "intermediate_1": "gu3dong1",
+        "intermediate_2": "gǔdōng",
+        "native_1": "stockholder; shareholder",
+        "primary_1": "股东",
+        "primary_2": "股東"
+    },
+    {
+        "intermediate_1": "gu3fen4",
+        "intermediate_2": "gǔfèn",
+        "native_1": "a share (in a company) stock",
+        "primary_1": "股份",
+        "primary_2": "股份"
+    },
+    {
+        "intermediate_1": "gu3gan4",
+        "intermediate_2": "gǔgàn",
+        "native_1": "backbone; mainstay",
+        "primary_1": "骨干",
+        "primary_2": "骨幹"
+    },
+    {
+        "intermediate_1": "gu3dong4",
+        "intermediate_2": "gǔdòng",
+        "native_1": "agitate; instigate",
+        "primary_1": "鼓动",
+        "primary_2": "鼓動"
+    },
+    {
+        "intermediate_1": "gu4ran2",
+        "intermediate_2": "gùrán",
+        "native_1": "admittedly; it is true that; indeed",
+        "primary_1": "固然",
+        "primary_2": "固然"
+    },
+    {
+        "intermediate_1": "gu4ti3",
+        "intermediate_2": "gùtǐ",
+        "native_1": "solid",
+        "primary_1": "固体",
+        "primary_2": "固體"
+    },
+    {
+        "intermediate_1": "gu4you3",
+        "intermediate_2": "gùyǒu",
+        "native_1": "intrinsic/inherent to something; native",
+        "primary_1": "固有",
+        "primary_2": "固有"
+    },
+    {
+        "intermediate_1": "gu4zhi2",
+        "intermediate_2": "gùzhí",
+        "native_1": "persistent; stubborn",
+        "primary_1": "固执",
+        "primary_2": "固執"
+    },
+    {
+        "intermediate_1": "gu4xiang1",
+        "intermediate_2": "gùxiāng",
+        "native_1": "hometown; homeland; birthplace",
+        "primary_1": "故乡",
+        "primary_2": "故鄉"
+    },
+    {
+        "intermediate_1": "gu4zhang4",
+        "intermediate_2": "gùzhàng",
+        "native_1": "malfunction; breakdown",
+        "primary_1": "故障",
+        "primary_2": "故障"
+    },
+    {
+        "intermediate_1": "gu4lü4",
+        "intermediate_2": "gùlǜ",
+        "native_1": "misgivings; apprehensions",
+        "primary_1": "顾虑",
+        "primary_2": "顧慮"
+    },
+    {
+        "intermediate_1": "gu4wen4",
+        "intermediate_2": "gùwèn",
+        "native_1": "adviser; consultant",
+        "primary_1": "顾问",
+        "primary_2": "顧問"
+    },
+    {
+        "intermediate_1": "gu4yong1",
+        "intermediate_2": "gùyōng",
+        "native_1": "employ; hire",
+        "primary_1": "雇佣",
+        "primary_2": "雇傭"
+    },
+    {
+        "intermediate_1": "guai3zhang4",
+        "intermediate_2": "guǎizhàng",
+        "native_1": "crutch; walking stick",
+        "primary_1": "拐杖",
+        "primary_2": "拐杖"
+    },
+    {
+        "intermediate_1": "guan1huai2",
+        "intermediate_2": "guānhuái",
+        "native_1": "care; solicitude; show care for; concerned about; attentive to",
+        "primary_1": "关怀",
+        "primary_2": "關懷"
+    },
+    {
+        "intermediate_1": "guan1zhao4",
+        "intermediate_2": "guānzhào",
+        "native_1": "concern; look after; keep an eye on",
+        "primary_1": "关照",
+        "primary_2": "關照"
+    },
+    {
+        "intermediate_1": "guang1uang1",
+        "intermediate_2": "guānguāng",
+        "native_1": "sight see; tour",
+        "primary_1": "观光",
+        "primary_2": "觀光"
+    },
+    {
+        "intermediate_1": "guan1fang1",
+        "intermediate_2": "guānfāng",
+        "native_1": "official; (by the) government",
+        "primary_1": "官方",
+        "primary_2": "官方"
+    },
+    {
+        "intermediate_1": "guan3xia2",
+        "intermediate_2": "guǎnxiá",
+        "native_1": "administer; have jurisdiction (over)",
+        "primary_1": "管辖",
+        "primary_2": "管轄"
+    },
+    {
+        "intermediate_1": "guan4che4",
+        "intermediate_2": "guànchè",
+        "native_1": "to implement; put into practice; carry out",
+        "primary_1": "贯彻",
+        "primary_2": "貫徹"
+    },
+    {
+        "intermediate_1": "guan4li4",
+        "intermediate_2": "guànlì",
+        "native_1": "conventional",
+        "primary_1": "惯例",
+        "primary_2": "慣例"
+    },
+    {
+        "intermediate_1": "guang4ai4",
+        "intermediate_2": "guàngài",
+        "native_1": "irrigate",
+        "primary_1": "灌溉",
+        "primary_2": "灌溉"
+    },
+    {
+        "intermediate_1": "guan4",
+        "intermediate_2": "guàn",
+        "native_1": "can; jar; pot; pitcher; jug",
+        "primary_1": "罐",
+        "primary_2": "罐"
+    },
+    {
+        "intermediate_1": "guang1cai3",
+        "intermediate_2": "guāngcǎi",
+        "native_1": "splendor; radiance; brilliance; honor",
+        "primary_1": "光彩",
+        "primary_2": "光彩"
+    },
+    {
+        "intermediate_1": "guang1hui1",
+        "intermediate_2": "guānghuī",
+        "native_1": "radiance; brilliant; glory",
+        "primary_1": "光辉",
+        "primary_2": "光輝"
+    },
+    {
+        "intermediate_1": "guang1mang2",
+        "intermediate_2": "guāngmáng",
+        "native_1": "rays of light; brilliant rays; radiance",
+        "primary_1": "光芒",
+        "primary_2": "光芒"
+    },
+    {
+        "intermediate_1": "guang1rong2",
+        "intermediate_2": "guāngróng",
+        "native_1": "glory; honor",
+        "primary_1": "光荣",
+        "primary_2": "光榮"
+    },
+    {
+        "intermediate_1": "guang3kuo4",
+        "intermediate_2": "guǎngkuò",
+        "native_1": "wide; vast",
+        "primary_1": "广阔",
+        "primary_2": "廣闊"
+    },
+    {
+        "intermediate_1": "gui1 gen1 dao4 di3",
+        "intermediate_2": "guī gēn dào dǐ",
+        "native_1": "(saying) to sum it up ...",
+        "primary_1": "归根到底",
+        "primary_2": "歸根到底"
+    },
+    {
+        "intermediate_1": "gui1huan2",
+        "intermediate_2": "guīhuán",
+        "native_1": "return something; revert",
+        "primary_1": "归还",
+        "primary_2": "歸還"
+    },
+    {
+        "intermediate_1": "gui1fan4",
+        "intermediate_2": "guīfàn",
+        "native_1": "standard (design or model); norm; without variation; to specify",
+        "primary_1": "规范",
+        "primary_2": "規範"
+    },
+    {
+        "intermediate_1": "gui1ge2",
+        "intermediate_2": "guīgé",
+        "native_1": "standard; norm; specification",
+        "primary_1": "规格",
+        "primary_2": "規格"
+    },
+    {
+        "intermediate_1": "gui1hua4",
+        "intermediate_2": "guīhuà",
+        "native_1": "plan; program; project",
+        "primary_1": "规划",
+        "primary_2": "規劃"
+    },
+    {
+        "intermediate_1": "gui1zhang1",
+        "intermediate_2": "guīzhāng",
+        "native_1": "regulations; rule",
+        "primary_1": "规章",
+        "primary_2": "規章"
+    },
+    {
+        "intermediate_1": "gui3dao4",
+        "intermediate_2": "guǐdào",
+        "native_1": "orbit; railway; trajectory",
+        "primary_1": "轨道",
+        "primary_2": "軌道"
+    },
+    {
+        "intermediate_1": "gui4zu2",
+        "intermediate_2": "guìzú",
+        "native_1": "lord; nobility; nobleman; noblewoman",
+        "primary_1": "贵族",
+        "primary_2": "貴族"
+    },
+    {
+        "intermediate_1": "gui4",
+        "intermediate_2": "guì",
+        "native_1": "kneel",
+        "primary_1": "跪",
+        "primary_2": "跪"
+    },
+    {
+        "intermediate_1": "gun4bang4",
+        "intermediate_2": "gùnbàng",
+        "native_1": "club",
+        "primary_1": "棍棒",
+        "primary_2": "棍棒"
+    },
+    {
+        "intermediate_1": "guo2fang2",
+        "intermediate_2": "guófáng",
+        "native_1": "national defense",
+        "primary_1": "国防",
+        "primary_2": "國防"
+    },
+    {
+        "intermediate_1": "guo2wu4yuan4",
+        "intermediate_2": "guówùyuàn",
+        "native_1": "State Council (PRC); State Department (USA)",
+        "primary_1": "国务院",
+        "primary_2": "國務院"
+    },
+    {
+        "intermediate_1": "guo3duan4",
+        "intermediate_2": "guǒduàn",
+        "native_1": "firm; decisive",
+        "primary_1": "果断",
+        "primary_2": "果斷"
+    },
+    {
+        "intermediate_1": "guo4du4",
+        "intermediate_2": "guòdù",
+        "native_1": "excessive; exceeding; lavishly",
+        "primary_1": "过度",
+        "primary_2": "過度"
+    },
+    {
+        "intermediate_1": "guo4du4",
+        "intermediate_2": "guòdù",
+        "native_1": "to cross a river by ferry; transition; interim",
+        "primary_1": "过渡",
+        "primary_2": "過渡"
+    },
+    {
+        "intermediate_1": "guo4jiang3",
+        "intermediate_2": "guòjiǎng",
+        "native_1": "praise excessively; flatter",
+        "primary_1": "过奖",
+        "primary_2": "過獎"
+    },
+    {
+        "intermediate_1": "guo4lü4",
+        "intermediate_2": "guòlǜ",
+        "native_1": "to filter; filter",
+        "primary_1": "过滤",
+        "primary_2": "過濾"
+    },
+    {
+        "intermediate_1": "guo4shi1",
+        "intermediate_2": "guòshī",
+        "native_1": "defect; fault",
+        "primary_1": "过失",
+        "primary_2": "過失"
+    },
+    {
+        "intermediate_1": "guo4wen4",
+        "intermediate_2": "guòwèn",
+        "native_1": "take an interest in; get involved with",
+        "primary_1": "过问",
+        "primary_2": "過問"
+    },
+    {
+        "intermediate_1": "guo4yin3",
+        "intermediate_2": "guòyǐn",
+        "native_1": "satisfy a craving; get a kick out of sth; do to one's heart's content",
+        "primary_1": "过瘾",
+        "primary_2": "過瘾"
+    },
+    {
+        "intermediate_1": "guo4yu2",
+        "intermediate_2": "guòyú",
+        "native_1": "too much; excessively",
+        "primary_1": "过于",
+        "primary_2": "過于"
+    },
+    {
+        "intermediate_1": "hai1",
+        "intermediate_2": "hāi",
+        "native_1": "hey/hi (loanword); oh; alas;",
+        "primary_1": "嗨",
+        "primary_2": "嗨"
+    },
+    {
+        "intermediate_1": "hai3ba2",
+        "intermediate_2": "hǎibá",
+        "native_1": "height above sea level; elevation",
+        "primary_1": "海拔",
+        "primary_2": "海拔"
+    },
+    {
+        "intermediate_1": "hai3bin1",
+        "intermediate_2": "hǎibīn",
+        "native_1": "shore; seaside",
+        "primary_1": "海滨",
+        "primary_2": "海濱"
+    },
+    {
+        "intermediate_1": "han2hu",
+        "intermediate_2": "hánhu",
+        "native_1": "unclear; vague; unsure",
+        "primary_1": "含糊",
+        "primary_2": "含糊"
+    },
+    {
+        "intermediate_1": "han2yi4",
+        "intermediate_2": "hányì",
+        "native_1": "implied meaning; connotation",
+        "primary_1": "含义",
+        "primary_2": "含義"
+    },
+    {
+        "intermediate_1": "han2xuan1",
+        "intermediate_2": "hánxuān",
+        "native_1": "exchanging conventional greetings; winter and summer",
+        "primary_1": "寒暄",
+        "primary_2": "寒暄"
+    },
+    {
+        "intermediate_1": "han3jian4",
+        "intermediate_2": "hǎnjiàn",
+        "native_1": "rare; rarely seen; peculiar",
+        "primary_1": "罕见",
+        "primary_2": "罕見"
+    },
+    {
+        "intermediate_1": "han4wei4",
+        "intermediate_2": "hànwèi",
+        "native_1": "defend; uphold; safeguard",
+        "primary_1": "捍卫",
+        "primary_2": "捍衛"
+    },
+    {
+        "intermediate_1": "hang2lie4",
+        "intermediate_2": "hángliè",
+        "native_1": "procession; ranks; queue",
+        "primary_1": "行列",
+        "primary_2": "行列"
+    },
+    {
+        "intermediate_1": "hang2kong1",
+        "intermediate_2": "hángkōng",
+        "native_1": "aviation",
+        "primary_1": "航空",
+        "primary_2": "航空"
+    },
+    {
+        "intermediate_1": "hang2tian1",
+        "intermediate_2": "hángtiān",
+        "native_1": "space flight",
+        "primary_1": "航天",
+        "primary_2": "航天"
+    },
+    {
+        "intermediate_1": "hang2xing2",
+        "intermediate_2": "hángxíng",
+        "native_1": "to sail; to fly",
+        "primary_1": "航行",
+        "primary_2": "航行"
+    },
+    {
+        "intermediate_1": "hao2mi3",
+        "intermediate_2": "háomǐ",
+        "native_1": "millimeter",
+        "primary_1": "毫米",
+        "primary_2": "毫米"
+    },
+    {
+        "intermediate_1": "hao2 wu2",
+        "intermediate_2": "háo wú",
+        "native_1": "not at all; completely without; not in the least",
+        "primary_1": "毫无",
+        "primary_2": "毫無"
+    },
+    {
+        "intermediate_1": "hao2mai4",
+        "intermediate_2": "háomài",
+        "native_1": "bold and generous; heroic",
+        "primary_1": "豪迈",
+        "primary_2": "豪邁"
+    },
+    {
+        "intermediate_1": "hao4zhao4",
+        "intermediate_2": "hàozhào",
+        "native_1": "call upon; summon; to appeal",
+        "primary_1": "号召",
+        "primary_2": "號召"
+    },
+    {
+        "intermediate_1": "hao4fei4",
+        "intermediate_2": "hàofèi",
+        "native_1": "waste; spend; consume",
+        "primary_1": "耗费",
+        "primary_2": "耗費"
+    },
+    {
+        "intermediate_1": "he1",
+        "intermediate_2": "hē",
+        "native_1": "breathe out; scold",
+        "primary_1": "呵",
+        "primary_2": "呵"
+    },
+    {
+        "intermediate_1": "he2bing4",
+        "intermediate_2": "hébìng",
+        "native_1": "merge; annex",
+        "primary_1": "合并",
+        "primary_2": "合並"
+    },
+    {
+        "intermediate_1": "he2cheng2",
+        "intermediate_2": "héchéng",
+        "native_1": "compound; synthesis; mixture",
+        "primary_1": "合成",
+        "primary_2": "合成"
+    },
+    {
+        "intermediate_1": "he2huo3",
+        "intermediate_2": "héhuǒ",
+        "native_1": "to make a partnership",
+        "primary_1": "合伙",
+        "primary_2": "合夥"
+    },
+    {
+        "intermediate_1": "he2suan4",
+        "intermediate_2": "hésuàn",
+        "native_1": "worthwhile; reckon up",
+        "primary_1": "合算",
+        "primary_2": "合算"
+    },
+    {
+        "intermediate_1": "he2'ai3",
+        "intermediate_2": "hé'ǎi",
+        "native_1": "kindly; good-tempered; amiable",
+        "primary_1": "和蔼",
+        "primary_2": "和藹"
+    },
+    {
+        "intermediate_1": "he2jie3",
+        "intermediate_2": "héjiě",
+        "native_1": "settlement; to become reconciled",
+        "primary_1": "和解",
+        "primary_2": "和解"
+    },
+    {
+        "intermediate_1": "he2mu4",
+        "intermediate_2": "hémù",
+        "native_1": "peaceful relations; harmonious",
+        "primary_1": "和睦",
+        "primary_2": "和睦"
+    },
+    {
+        "intermediate_1": "he2qi",
+        "intermediate_2": "héqi",
+        "native_1": "friendly; polite; amiable",
+        "primary_1": "和气",
+        "primary_2": "和氣"
+    },
+    {
+        "intermediate_1": "he2xie2",
+        "intermediate_2": "héxié",
+        "native_1": "harmonious; concordant",
+        "primary_1": "和谐",
+        "primary_2": "和諧"
+    },
+    {
+        "intermediate_1": "hei1",
+        "intermediate_2": "hēi",
+        "native_1": "hey; interjection for calling attention",
+        "primary_1": "嘿",
+        "primary_2": "嘿"
+    },
+    {
+        "intermediate_1": "hen2ji4",
+        "intermediate_2": "hénjì",
+        "native_1": "vestige; trace",
+        "primary_1": "痕迹",
+        "primary_2": "痕迹"
+    },
+    {
+        "intermediate_1": "hen3 xin1",
+        "intermediate_2": "hěn xīn",
+        "native_1": "callous; cruel; cold-blooded",
+        "primary_1": "狠心",
+        "primary_2": "狠心"
+    },
+    {
+        "intermediate_1": "hen4 bu de",
+        "intermediate_2": "hèn bu de",
+        "native_1": "cannot bear not; be dying to",
+        "primary_1": "恨不得",
+        "primary_2": "恨不得"
+    },
+    {
+        "intermediate_1": "heng2",
+        "intermediate_2": "héng",
+        "native_1": "horizontal; across; (horizontal character stroke)",
+        "primary_1": "横",
+        "primary_2": "橫"
+    },
+    {
+        "intermediate_1": "heng1",
+        "intermediate_2": "hēng",
+        "native_1": "groan; snort; to hum; croon",
+        "primary_1": "哼",
+        "primary_2": "哼"
+    },
+    {
+        "intermediate_1": "hong1dong4",
+        "intermediate_2": "hōngdòng",
+        "native_1": "a sensation; a stir",
+        "primary_1": "轰动",
+        "primary_2": "轟動"
+    },
+    {
+        "intermediate_1": "hong1",
+        "intermediate_2": "hōng",
+        "native_1": "to dry or warm by the fire; to bake; to heat by fire; to set off by contrast",
+        "primary_1": "烘",
+        "primary_2": "烘"
+    },
+    {
+        "intermediate_1": "hong2guan1",
+        "intermediate_2": "hóngguān",
+        "native_1": "macro-; macroscopic",
+        "primary_1": "宏观",
+        "primary_2": "宏觀"
+    },
+    {
+        "intermediate_1": "hong2wei3",
+        "intermediate_2": "hóngwěi",
+        "native_1": "grand; imposing; magnificent; grand",
+        "primary_1": "宏伟",
+        "primary_2": "宏偉"
+    },
+    {
+        "intermediate_1": "hong2shui3",
+        "intermediate_2": "hóngshuǐ",
+        "native_1": "flood",
+        "primary_1": "洪水",
+        "primary_2": "洪水"
+    },
+    {
+        "intermediate_1": "hong3",
+        "intermediate_2": "hǒng",
+        "native_1": "fool; coax; to amuse (a child)",
+        "primary_1": "哄",
+        "primary_2": "哄"
+    },
+    {
+        "intermediate_1": "hou2long2",
+        "intermediate_2": "hóulóng",
+        "native_1": "throat; larynx",
+        "primary_1": "喉咙",
+        "primary_2": "喉嚨"
+    },
+    {
+        "intermediate_1": "hou3",
+        "intermediate_2": "hǒu",
+        "native_1": "roar; howl",
+        "primary_1": "吼",
+        "primary_2": "吼"
+    },
+    {
+        "intermediate_1": "hou4dai4",
+        "intermediate_2": "hòudài",
+        "native_1": "posterity; later generations; descendants",
+        "primary_1": "后代",
+        "primary_2": "後代"
+    },
+    {
+        "intermediate_1": "hou4gu4zhi1you1",
+        "intermediate_2": "hòugùzhīyōu",
+        "native_1": "fears of trouble in the rear (idiom); family worries (obstructing freedom to act); trouble back at home; worries about the future consequences; often in negative expressions, meaning no worries about anything",
+        "primary_1": "后顾之忧",
+        "primary_2": "後顧之憂"
+    },
+    {
+        "intermediate_1": "hou4qin2",
+        "intermediate_2": "hòuqín",
+        "native_1": "logistics",
+        "primary_1": "后勤",
+        "primary_2": "後勤"
+    },
+    {
+        "intermediate_1": "hou4xuan3",
+        "intermediate_2": "hòuxuǎn",
+        "native_1": "candidate",
+        "primary_1": "候选",
+        "primary_2": "候選"
+    },
+    {
+        "intermediate_1": "hu1huan4",
+        "intermediate_2": "hūhuàn",
+        "native_1": "call out (a name etc.); shout",
+        "primary_1": "呼唤",
+        "primary_2": "呼喚"
+    },
+    {
+        "intermediate_1": "hu1xiao4",
+        "intermediate_2": "hūxiào",
+        "native_1": "whistle; scream; howl",
+        "primary_1": "呼啸",
+        "primary_2": "呼嘯"
+    },
+    {
+        "intermediate_1": "hu1yu4",
+        "intermediate_2": "hūyù",
+        "native_1": "call on (someone to do something); appeal",
+        "primary_1": "呼吁",
+        "primary_2": "呼籲"
+    },
+    {
+        "intermediate_1": "hu1lüe4",
+        "intermediate_2": "hūlüè",
+        "native_1": "ignore; forget about; neglect",
+        "primary_1": "忽略",
+        "primary_2": "忽略"
+    },
+    {
+        "intermediate_1": "hu2luan4",
+        "intermediate_2": "húluàn",
+        "native_1": "carelessly; recklessly",
+        "primary_1": "胡乱",
+        "primary_2": "胡亂"
+    },
+    {
+        "intermediate_1": "hu2xu1",
+        "intermediate_2": "húxū",
+        "native_1": "beard; moustache; whiskers",
+        "primary_1": "胡须",
+        "primary_2": "胡須"
+    },
+    {
+        "intermediate_1": "hu2po1",
+        "intermediate_2": "húpō",
+        "native_1": "lake",
+        "primary_1": "湖泊",
+        "primary_2": "湖泊"
+    },
+    {
+        "intermediate_1": "hua1ban4",
+        "intermediate_2": "huābàn",
+        "native_1": "petal",
+        "primary_1": "花瓣",
+        "primary_2": "花瓣"
+    },
+    {
+        "intermediate_1": "hua1lei3",
+        "intermediate_2": "huālěi",
+        "native_1": "(flower) bud",
+        "primary_1": "花蕾",
+        "primary_2": "花蕾"
+    },
+    {
+        "intermediate_1": "hua2li4",
+        "intermediate_2": "huálì",
+        "native_1": "gorgeous; magnificent",
+        "primary_1": "华丽",
+        "primary_2": "華麗"
+    },
+    {
+        "intermediate_1": "hua2qiao2",
+        "intermediate_2": "huáqiáo",
+        "native_1": "overseas Chinese",
+        "primary_1": "华侨",
+        "primary_2": "華僑"
+    },
+    {
+        "intermediate_1": "hua4fei2",
+        "intermediate_2": "huàféi",
+        "native_1": "chemical fertilizer",
+        "primary_1": "化肥",
+        "primary_2": "化肥"
+    },
+    {
+        "intermediate_1": "hua4shi2",
+        "intermediate_2": "huàshí",
+        "native_1": "fossil",
+        "primary_1": "化石",
+        "primary_2": "化石"
+    },
+    {
+        "intermediate_1": "hua4yan4",
+        "intermediate_2": "huàyàn",
+        "native_1": "laboratory test; chemically examine",
+        "primary_1": "化验",
+        "primary_2": "化驗"
+    },
+    {
+        "intermediate_1": "hua4 zhuang1",
+        "intermediate_2": "huà zhuāng",
+        "native_1": "put on make-up",
+        "primary_1": "化妆",
+        "primary_2": "化妝"
+    },
+    {
+        "intermediate_1": "hua4fen1",
+        "intermediate_2": "huàfēn",
+        "native_1": "divide up; differentiate",
+        "primary_1": "划分",
+        "primary_2": "劃分"
+    },
+    {
+        "intermediate_1": "hua4she2tian1zu2",
+        "intermediate_2": "huàshétiānzú",
+        "native_1": "draw legs on a snake (idiom); to ruin something by adding something superfluous",
+        "primary_1": "画蛇添足",
+        "primary_2": "畫蛇添足"
+    },
+    {
+        "intermediate_1": "hua4tong3",
+        "intermediate_2": "huàtǒng",
+        "native_1": "microphone; transmitter; megaphone",
+        "primary_1": "话筒",
+        "primary_2": "話筒"
+    },
+    {
+        "intermediate_1": "huan1le4",
+        "intermediate_2": "huānlè",
+        "native_1": "gaiety; glee; delighted",
+        "primary_1": "欢乐",
+        "primary_2": "歡樂"
+    },
+    {
+        "intermediate_1": "huan2yuan2",
+        "intermediate_2": "huányuán",
+        "native_1": "restore to the original state; (Chemistry) reduce",
+        "primary_1": "还原",
+        "primary_2": "還原"
+    },
+    {
+        "intermediate_1": "huan2jie2",
+        "intermediate_2": "huánjié",
+        "native_1": "link; sector; segment (of annelid worms)",
+        "primary_1": "环节",
+        "primary_2": "環節"
+    },
+    {
+        "intermediate_1": "huan3he2",
+        "intermediate_2": "huǎnhé",
+        "native_1": "alleviate; to moderate; to ease (tension)",
+        "primary_1": "缓和",
+        "primary_2": "緩和"
+    },
+    {
+        "intermediate_1": "huan4zhe3",
+        "intermediate_2": "huànzhě",
+        "native_1": "sufferer; patient; the sick",
+        "primary_1": "患者",
+        "primary_2": "患者"
+    },
+    {
+        "intermediate_1": "huang1liang2",
+        "intermediate_2": "huāngliáng",
+        "native_1": "desolate",
+        "primary_1": "荒凉",
+        "primary_2": "荒涼"
+    },
+    {
+        "intermediate_1": "huang1miu4",
+        "intermediate_2": "huāngmiù",
+        "native_1": "ridiculous; nonsensical",
+        "primary_1": "荒谬",
+        "primary_2": "荒謬"
+    },
+    {
+        "intermediate_1": "huang1tang",
+        "intermediate_2": "huāngtang",
+        "native_1": "beyond belief; preposterous; absurd; intemperate",
+        "primary_1": "荒唐",
+        "primary_2": "荒唐"
+    },
+    {
+        "intermediate_1": "huang2di4",
+        "intermediate_2": "huángdì",
+        "native_1": "emperor",
+        "primary_1": "皇帝",
+        "primary_2": "皇帝"
+    },
+    {
+        "intermediate_1": "huang2hou4",
+        "intermediate_2": "huánghòu",
+        "native_1": "an empress",
+        "primary_1": "皇后",
+        "primary_2": "皇後"
+    },
+    {
+        "intermediate_1": "huang2hun1",
+        "intermediate_2": "huánghūn",
+        "native_1": "dusk; evening; nightfall",
+        "primary_1": "黄昏",
+        "primary_2": "黃昏"
+    },
+    {
+        "intermediate_1": "huang3ran2da4wu4",
+        "intermediate_2": "huǎngrándàwù",
+        "native_1": "suddenly see the light; suddenly realize what has happened; twig",
+        "primary_1": "恍然大悟",
+        "primary_2": "恍然大悟"
+    },
+    {
+        "intermediate_1": "huang4",
+        "intermediate_2": "huàng",
+        "native_1": "to sway; to shake",
+        "primary_1": "晃",
+        "primary_2": "晃"
+    },
+    {
+        "intermediate_1": "hui1huo4",
+        "intermediate_2": "huīhuò",
+        "native_1": "squander money without restraint; squander",
+        "primary_1": "挥霍",
+        "primary_2": "揮霍"
+    },
+    {
+        "intermediate_1": "hui1huang2",
+        "intermediate_2": "huīhuáng",
+        "native_1": "splendid; glorious",
+        "primary_1": "辉煌",
+        "primary_2": "輝煌"
+    },
+    {
+        "intermediate_1": "hui2bao4",
+        "intermediate_2": "huíbào",
+        "native_1": "repayment; payback",
+        "primary_1": "回报",
+        "primary_2": "回報"
+    },
+    {
+        "intermediate_1": "hui2bi4",
+        "intermediate_2": "huíbì",
+        "native_1": "avoid; shun; evade",
+        "primary_1": "回避",
+        "primary_2": "回避"
+    },
+    {
+        "intermediate_1": "hui2gu4",
+        "intermediate_2": "huígù",
+        "native_1": "look back; to review",
+        "primary_1": "回顾",
+        "primary_2": "回顧"
+    },
+    {
+        "intermediate_1": "hui2shou1",
+        "intermediate_2": "huíshōu",
+        "native_1": "recycle; recover and put back to use",
+        "primary_1": "回收",
+        "primary_2": "回收"
+    },
+    {
+        "intermediate_1": "hui3hen4",
+        "intermediate_2": "huǐhèn",
+        "native_1": "remorse; repentance",
+        "primary_1": "悔恨",
+        "primary_2": "悔恨"
+    },
+    {
+        "intermediate_1": "hui3mie4",
+        "intermediate_2": "huǐmiè",
+        "native_1": "perish; ruin; destroy",
+        "primary_1": "毁灭",
+        "primary_2": "毀滅"
+    },
+    {
+        "intermediate_1": "hui4bao4",
+        "intermediate_2": "huìbào",
+        "native_1": "report; give an account of; to collect information and report back",
+        "primary_1": "汇报",
+        "primary_2": "彙報"
+    },
+    {
+        "intermediate_1": "hui4wu4",
+        "intermediate_2": "huìwù",
+        "native_1": "meet; meeting; conference",
+        "primary_1": "会晤",
+        "primary_2": "會晤"
+    },
+    {
+        "intermediate_1": "hui4lu4",
+        "intermediate_2": "huìlù",
+        "native_1": "to bribe",
+        "primary_1": "贿赂",
+        "primary_2": "賄賂"
+    },
+    {
+        "intermediate_1": "hun1mi2",
+        "intermediate_2": "hūnmí",
+        "native_1": "lose consciousness; be in a coma",
+        "primary_1": "昏迷",
+        "primary_2": "昏迷"
+    },
+    {
+        "intermediate_1": "hun1",
+        "intermediate_2": "hūn",
+        "native_1": "meat or fish dish; pungent vegetables forbidden to Buddhist vegetarians",
+        "primary_1": "荤",
+        "primary_2": "葷"
+    },
+    {
+        "intermediate_1": "hun2shen1",
+        "intermediate_2": "húnshēn",
+        "native_1": "entire body; from head to foot",
+        "primary_1": "浑身",
+        "primary_2": "渾身"
+    },
+    {
+        "intermediate_1": "hun4he2",
+        "intermediate_2": "hùnhé",
+        "native_1": "to mix; to blend",
+        "primary_1": "混合",
+        "primary_2": "混合"
+    },
+    {
+        "intermediate_1": "hun4luan4",
+        "intermediate_2": "hùnluàn",
+        "native_1": "confusion; chaotic",
+        "primary_1": "混乱",
+        "primary_2": "混亂"
+    },
+    {
+        "intermediate_1": "hun4xiao2",
+        "intermediate_2": "hùnxiáo",
+        "native_1": "obscure; confuse; mix up; blur; mislead; confusing",
+        "primary_1": "混淆",
+        "primary_2": "混淆"
+    },
+    {
+        "intermediate_1": "hun4zhuo2",
+        "intermediate_2": "hùnzhuó",
+        "native_1": "muddy; dirty; turbid",
+        "primary_1": "混浊",
+        "primary_2": "混濁"
+    },
+    {
+        "intermediate_1": "huo2gai1",
+        "intermediate_2": "huógāi",
+        "native_1": "serve sb. right; deservedly; ought",
+        "primary_1": "活该",
+        "primary_2": "活該"
+    },
+    {
+        "intermediate_1": "huo2li4",
+        "intermediate_2": "huólì",
+        "native_1": "energy; vitality; vigor",
+        "primary_1": "活力",
+        "primary_2": "活力"
+    },
+    {
+        "intermediate_1": "huo3jian4",
+        "intermediate_2": "huǒjiàn",
+        "native_1": "rocket",
+        "primary_1": "火箭",
+        "primary_2": "火箭"
+    },
+    {
+        "intermediate_1": "huo3yan4",
+        "intermediate_2": "huǒyàn",
+        "native_1": "blaze; flame",
+        "primary_1": "火焰",
+        "primary_2": "火焰"
+    },
+    {
+        "intermediate_1": "huo3yao4",
+        "intermediate_2": "huǒyào",
+        "native_1": "gunpowder",
+        "primary_1": "火药",
+        "primary_2": "火藥"
+    },
+    {
+        "intermediate_1": "huo4bi4",
+        "intermediate_2": "huòbì",
+        "native_1": "currency; money",
+        "primary_1": "货币",
+        "primary_2": "貨幣"
+    },
+    {
+        "intermediate_1": "ji1xiao4",
+        "intermediate_2": "jīxiào",
+        "native_1": "sneer at; deride",
+        "primary_1": "讥笑",
+        "primary_2": "譏笑"
+    },
+    {
+        "intermediate_1": "ji1'e4",
+        "intermediate_2": "jī'è",
+        "native_1": "hunger; hungry; starve",
+        "primary_1": "饥饿",
+        "primary_2": "饑餓"
+    },
+    {
+        "intermediate_1": "ji1dong4",
+        "intermediate_2": "jīdòng",
+        "native_1": "motorized; mobile; flexible",
+        "primary_1": "机动",
+        "primary_2": "機動"
+    },
+    {
+        "intermediate_1": "ji1gou4",
+        "intermediate_2": "jīgòu",
+        "native_1": "structure; organization; institution",
+        "primary_1": "机构",
+        "primary_2": "機構"
+    },
+    {
+        "intermediate_1": "ji1ling",
+        "intermediate_2": "jīling",
+        "native_1": "clever; quick-witted; smartness",
+        "primary_1": "机灵",
+        "primary_2": "機靈"
+    },
+    {
+        "intermediate_1": "ji1mi4",
+        "intermediate_2": "jīmì",
+        "native_1": "secret; classified (information)",
+        "primary_1": "机密",
+        "primary_2": "機密"
+    },
+    {
+        "intermediate_1": "ji1xie4",
+        "intermediate_2": "jīxiè",
+        "native_1": "machine; mechanical",
+        "primary_1": "机械",
+        "primary_2": "機械"
+    },
+    {
+        "intermediate_1": "ji1yu4",
+        "intermediate_2": "jīyù",
+        "native_1": "opportunity; stroke of good luck; favorable circumstance",
+        "primary_1": "机遇",
+        "primary_2": "機遇"
+    },
+    {
+        "intermediate_1": "ji1zhi4",
+        "intermediate_2": "jīzhì",
+        "native_1": "tact; quick-witted; resourceful",
+        "primary_1": "机智",
+        "primary_2": "機智"
+    },
+    {
+        "intermediate_1": "ji1di4",
+        "intermediate_2": "jīdì",
+        "native_1": "base (of operations)",
+        "primary_1": "基地",
+        "primary_2": "基地"
+    },
+    {
+        "intermediate_1": "ji1jin1",
+        "intermediate_2": "jījīn",
+        "native_1": "fund; endowment",
+        "primary_1": "基金",
+        "primary_2": "基金"
+    },
+    {
+        "intermediate_1": "ji1yin1",
+        "intermediate_2": "jīyīn",
+        "native_1": "gene",
+        "primary_1": "基因",
+        "primary_2": "基因"
+    },
+    {
+        "intermediate_1": "ji1fa1",
+        "intermediate_2": "jīfā",
+        "native_1": "to arouse; excite",
+        "primary_1": "激发",
+        "primary_2": "激發"
+    },
+    {
+        "intermediate_1": "ji1li4",
+        "intermediate_2": "jīlì",
+        "native_1": "urge; encourage; motivation",
+        "primary_1": "激励",
+        "primary_2": "激勵"
+    },
+    {
+        "intermediate_1": "ji1qing2",
+        "intermediate_2": "jīqíng",
+        "native_1": "passion; strong emotion; fervor; enthusiasm",
+        "primary_1": "激情",
+        "primary_2": "激情"
+    },
+    {
+        "intermediate_1": "ji2zao3",
+        "intermediate_2": "jízǎo",
+        "native_1": "as soon as possible; at the earliest possible time",
+        "primary_1": "及早",
+        "primary_2": "及早"
+    },
+    {
+        "intermediate_1": "ji2xiang2",
+        "intermediate_2": "jíxiáng",
+        "native_1": "lucky",
+        "primary_1": "吉祥",
+        "primary_2": "吉祥"
+    },
+    {
+        "intermediate_1": "ji2bie2",
+        "intermediate_2": "jíbié",
+        "native_1": "rank; level; grade",
+        "primary_1": "级别",
+        "primary_2": "級別"
+    },
+    {
+        "intermediate_1": "ji2duan1",
+        "intermediate_2": "jíduān",
+        "native_1": "extreme",
+        "primary_1": "极端",
+        "primary_2": "極端"
+    },
+    {
+        "intermediate_1": "ji2xian4",
+        "intermediate_2": "jíxiàn",
+        "native_1": "limit; extreme boundary",
+        "primary_1": "极限",
+        "primary_2": "極限"
+    },
+    {
+        "intermediate_1": "ji2bian4",
+        "intermediate_2": "jíbiàn",
+        "native_1": "even if; even though",
+        "primary_1": "即便",
+        "primary_2": "即便"
+    },
+    {
+        "intermediate_1": "ji2jiang1",
+        "intermediate_2": "jíjiāng",
+        "native_1": "will shortly; soon; be on the verge of",
+        "primary_1": "即将",
+        "primary_2": "即將"
+    },
+    {
+        "intermediate_1": "ji2gong1jin4li4",
+        "intermediate_2": "jígōngjìnlì",
+        "native_1": "eager for success and profit",
+        "primary_1": "急功近利",
+        "primary_2": "急功近利"
+    },
+    {
+        "intermediate_1": "ji2ju4",
+        "intermediate_2": "jíjù",
+        "native_1": "rapid; sudden",
+        "primary_1": "急剧",
+        "primary_2": "急劇"
+    },
+    {
+        "intermediate_1": "ji2qie4",
+        "intermediate_2": "jíqiè",
+        "native_1": "eager; impatient; imperative",
+        "primary_1": "急切",
+        "primary_2": "急切"
+    },
+    {
+        "intermediate_1": "ji2yu2qiu2cheng2",
+        "intermediate_2": "jíyúqiúchéng",
+        "native_1": "impatient for success",
+        "primary_1": "急于求成",
+        "primary_2": "急于求成"
+    },
+    {
+        "intermediate_1": "ji2zao4",
+        "intermediate_2": "jízào",
+        "native_1": "irritable; impetuous; impatient",
+        "primary_1": "急躁",
+        "primary_2": "急躁"
+    },
+    {
+        "intermediate_1": "ji2bing4",
+        "intermediate_2": "jíbìng",
+        "native_1": "disease; illness; sickness; ailment",
+        "primary_1": "疾病",
+        "primary_2": "疾病"
+    },
+    {
+        "intermediate_1": "ji2tuan2",
+        "intermediate_2": "jítuán",
+        "native_1": "group; bloc; circle; clique",
+        "primary_1": "集团",
+        "primary_2": "集團"
+    },
+    {
+        "intermediate_1": "ji2du4",
+        "intermediate_2": "jídù",
+        "native_1": "to be jealous; to envy, covet; to hate; to begrudge",
+        "primary_1": "嫉妒",
+        "primary_2": "嫉妒"
+    },
+    {
+        "intermediate_1": "ji2guan4",
+        "intermediate_2": "jíguàn",
+        "native_1": "place of one's ancestry",
+        "primary_1": "籍贯",
+        "primary_2": "籍貫"
+    },
+    {
+        "intermediate_1": "ji3yu3",
+        "intermediate_2": "jǐyǔ",
+        "native_1": "to give",
+        "primary_1": "给予",
+        "primary_2": "給予"
+    },
+    {
+        "intermediate_1": "ji4jiao4",
+        "intermediate_2": "jìjiào",
+        "native_1": "focus excessively on; haggle; bicker; argue",
+        "primary_1": "计较",
+        "primary_2": "計較"
+    },
+    {
+        "intermediate_1": "ji4xing",
+        "intermediate_2": "jìxing",
+        "native_1": "memory",
+        "primary_1": "记性",
+        "primary_2": "記性"
+    },
+    {
+        "intermediate_1": "ji4zai3",
+        "intermediate_2": "jìzǎi",
+        "native_1": "write down; to record",
+        "primary_1": "记载",
+        "primary_2": "記載"
+    },
+    {
+        "intermediate_1": "ji4yao4",
+        "intermediate_2": "jìyào",
+        "native_1": "written summary of a meeting; minutes",
+        "primary_1": "纪要",
+        "primary_2": "紀要"
+    },
+    {
+        "intermediate_1": "ji4qiao3",
+        "intermediate_2": "jìqiǎo",
+        "native_1": "skill; technique",
+        "primary_1": "技巧",
+        "primary_2": "技巧"
+    },
+    {
+        "intermediate_1": "ji4hui4",
+        "intermediate_2": "jìhuì",
+        "native_1": "avoid as a taboo; abstain from; taboo",
+        "primary_1": "忌讳",
+        "primary_2": "忌諱"
+    },
+    {
+        "intermediate_1": "ji4du4",
+        "intermediate_2": "jìdù",
+        "native_1": "(financial) quarter; period of three months",
+        "primary_1": "季度",
+        "primary_2": "季度"
+    },
+    {
+        "intermediate_1": "ji4jun1",
+        "intermediate_2": "jìjūn",
+        "native_1": "third in a race; bronze medalist",
+        "primary_1": "季军",
+        "primary_2": "季軍"
+    },
+    {
+        "intermediate_1": "ji4xiang4",
+        "intermediate_2": "jìxiàng",
+        "native_1": "mark; indication; sign",
+        "primary_1": "迹象",
+        "primary_2": "迹象"
+    },
+    {
+        "intermediate_1": "ji4cheng2",
+        "intermediate_2": "jìchéng",
+        "native_1": "inherit; carry on; succeed",
+        "primary_1": "继承",
+        "primary_2": "繼承"
+    },
+    {
+        "intermediate_1": "ji4tuo1",
+        "intermediate_2": "jìtuō",
+        "native_1": "entrust somebody someone's care; consign; commit",
+        "primary_1": "寄托",
+        "primary_2": "寄托"
+    },
+    {
+        "intermediate_1": "ji4jing4",
+        "intermediate_2": "jìjìng",
+        "native_1": "quiet",
+        "primary_1": "寂静",
+        "primary_2": "寂靜"
+    },
+    {
+        "intermediate_1": "jia1 gong1",
+        "intermediate_2": "jiā gōng",
+        "native_1": "to process; processing; machining",
+        "primary_1": "加工",
+        "primary_2": "加工"
+    },
+    {
+        "intermediate_1": "jia1ju4",
+        "intermediate_2": "jiājù",
+        "native_1": "aggravate; intensify; sharpen; accelerate",
+        "primary_1": "加剧",
+        "primary_2": "加劇"
+    },
+    {
+        "intermediate_1": "jia1za2",
+        "intermediate_2": "jiāzá",
+        "native_1": "mix together; have two dissimilar substances mixed together",
+        "primary_1": "夹杂",
+        "primary_2": "夾雜"
+    },
+    {
+        "intermediate_1": "jia1yao2",
+        "intermediate_2": "jiāyáo",
+        "native_1": "delicacy",
+        "primary_1": "佳肴",
+        "primary_2": "佳肴"
+    },
+    {
+        "intermediate_1": "jia1chang2",
+        "intermediate_2": "jiācháng",
+        "native_1": "the daily life of a family; home-style (food)",
+        "primary_1": "家常",
+        "primary_2": "家常"
+    },
+    {
+        "intermediate_1": "jia1huo",
+        "intermediate_2": "jiāhuo",
+        "native_1": "guy; chap; tool; weapon",
+        "primary_1": "家伙",
+        "primary_2": "家夥"
+    },
+    {
+        "intermediate_1": "jia1shu3",
+        "intermediate_2": "jiāshǔ",
+        "native_1": "family member; a dependent",
+        "primary_1": "家属",
+        "primary_2": "家屬"
+    },
+    {
+        "intermediate_1": "jia1 yu4 hu4 xiao3",
+        "intermediate_2": "jiā yù hù xiǎo",
+        "native_1": "become a household name; well-known",
+        "primary_1": "家喻户晓",
+        "primary_2": "家喻戶曉"
+    },
+    {
+        "intermediate_1": "jian1duan1",
+        "intermediate_2": "jiānduān",
+        "native_1": "highest peak; the tip; sharp pointed end; most advanced and sophisticated",
+        "primary_1": "尖端",
+        "primary_2": "尖端"
+    },
+    {
+        "intermediate_1": "jian1rui4",
+        "intermediate_2": "jiānruì",
+        "native_1": "sharp; intense; penetrating",
+        "primary_1": "尖锐",
+        "primary_2": "尖銳"
+    },
+    {
+        "intermediate_1": "jian1ding4",
+        "intermediate_2": "jiāndìng",
+        "native_1": "firm; staunch; resolute",
+        "primary_1": "坚定",
+        "primary_2": "堅定"
+    },
+    {
+        "intermediate_1": "jiang1u4",
+        "intermediate_2": "jiāngù",
+        "native_1": "firm; strong; sturdy",
+        "primary_1": "坚固",
+        "primary_2": "堅固"
+    },
+    {
+        "intermediate_1": "jian1ren4",
+        "intermediate_2": "jiānrèn",
+        "native_1": "tough and durable; hard-bitten; firm and tenacious",
+        "primary_1": "坚韧",
+        "primary_2": "堅韌"
+    },
+    {
+        "intermediate_1": "jian1shi2",
+        "intermediate_2": "jiānshí",
+        "native_1": "firm and substantial; solid",
+        "primary_1": "坚实",
+        "primary_2": "堅實"
+    },
+    {
+        "intermediate_1": "jian1ying4",
+        "intermediate_2": "jiānyìng",
+        "native_1": "hard; solid",
+        "primary_1": "坚硬",
+        "primary_2": "堅硬"
+    },
+    {
+        "intermediate_1": "jian1nan2",
+        "intermediate_2": "jiānnán",
+        "native_1": "difficult; arduous",
+        "primary_1": "艰难",
+        "primary_2": "艱難"
+    },
+    {
+        "intermediate_1": "jian1du1",
+        "intermediate_2": "jiāndū",
+        "native_1": "control; monitor; supervise; inspect",
+        "primary_1": "监督",
+        "primary_2": "監督"
+    },
+    {
+        "intermediate_1": "jian1shi4",
+        "intermediate_2": "jiānshì",
+        "native_1": "oversee; to monitor",
+        "primary_1": "监视",
+        "primary_2": "監視"
+    },
+    {
+        "intermediate_1": "jian1yu4",
+        "intermediate_2": "jiānyù",
+        "native_1": "prison; jail",
+        "primary_1": "监狱",
+        "primary_2": "監獄"
+    },
+    {
+        "intermediate_1": "jian1",
+        "intermediate_2": "jiān",
+        "native_1": "pan-fry; fry in shallow oil",
+        "primary_1": "煎",
+        "primary_2": "煎"
+    },
+    {
+        "intermediate_1": "jian3",
+        "intermediate_2": "jiǎn",
+        "native_1": "choose; select; sort out",
+        "primary_1": "拣",
+        "primary_2": "揀"
+    },
+    {
+        "intermediate_1": "jian3tao3",
+        "intermediate_2": "jiǎntǎo",
+        "native_1": "self-criticism; analyze",
+        "primary_1": "检讨",
+        "primary_2": "檢討"
+    },
+    {
+        "intermediate_1": "jian3yan4",
+        "intermediate_2": "jiǎnyàn",
+        "native_1": "inspect; examine; to test",
+        "primary_1": "检验",
+        "primary_2": "檢驗"
+    },
+    {
+        "intermediate_1": "jian3 cai3",
+        "intermediate_2": "jiǎn cǎi",
+        "native_1": "cut the ribbon at an opening ceremony",
+        "primary_1": "剪彩",
+        "primary_2": "剪彩"
+    },
+    {
+        "intermediate_1": "jian3hua4",
+        "intermediate_2": "jiǎnhuà",
+        "native_1": "simplify; simplification",
+        "primary_1": "简化",
+        "primary_2": "簡化"
+    },
+    {
+        "intermediate_1": "jian3lou4",
+        "intermediate_2": "jiǎnlòu",
+        "native_1": "simple and crude (i.e. room or building)",
+        "primary_1": "简陋",
+        "primary_2": "簡陋"
+    },
+    {
+        "intermediate_1": "jian3ti3zi4",
+        "intermediate_2": "jiǎntǐzì",
+        "native_1": "simplified Chinese characters",
+        "primary_1": "简体字",
+        "primary_2": "簡體字"
+    },
+    {
+        "intermediate_1": "jian3yao4",
+        "intermediate_2": "jiǎnyào",
+        "native_1": "concise; brief",
+        "primary_1": "简要",
+        "primary_2": "簡要"
+    },
+    {
+        "intermediate_1": "jian4duo1shi2guang3",
+        "intermediate_2": "jiànduōshíguǎng",
+        "native_1": "experienced and knowledgeable",
+        "primary_1": "见多识广",
+        "primary_2": "見多識廣"
+    },
+    {
+        "intermediate_1": "jian4jie3",
+        "intermediate_2": "jiànjiě",
+        "native_1": "view; opinion; understanding",
+        "primary_1": "见解",
+        "primary_2": "見解"
+    },
+    {
+        "intermediate_1": "jian4wen2",
+        "intermediate_2": "jiànwén",
+        "native_1": "information",
+        "primary_1": "见闻",
+        "primary_2": "見聞"
+    },
+    {
+        "intermediate_1": "jian4yi4yong3wei2",
+        "intermediate_2": "jiànyìyǒngwéi",
+        "native_1": "to see what is right and act courageously (idiom, from Analects); to stand up bravely for the truth; acting heroically in a just cause",
+        "primary_1": "见义勇为",
+        "primary_2": "見義勇爲"
+    },
+    {
+        "intermediate_1": "jian4die2",
+        "intermediate_2": "jiàndié",
+        "native_1": "a spy; intelligence agent",
+        "primary_1": "间谍",
+        "primary_2": "間諜"
+    },
+    {
+        "intermediate_1": "jiang4e2",
+        "intermediate_2": "jiàngé",
+        "native_1": "interval; intermission; gap; be separated",
+        "primary_1": "间隔",
+        "primary_2": "間隔"
+    },
+    {
+        "intermediate_1": "jian4jie1",
+        "intermediate_2": "jiànjiē",
+        "native_1": "indirect",
+        "primary_1": "间接",
+        "primary_2": "間接"
+    },
+    {
+        "intermediate_1": "jian4",
+        "intermediate_2": "jiàn",
+        "native_1": "sword",
+        "primary_1": "剑",
+        "primary_2": "劍"
+    },
+    {
+        "intermediate_1": "jian4quan2",
+        "intermediate_2": "jiànquán",
+        "native_1": "Perfect; sound; to perfect/strengthen/amplify",
+        "primary_1": "健全",
+        "primary_2": "健全"
+    },
+    {
+        "intermediate_1": "jian4ting3",
+        "intermediate_2": "jiàntǐng",
+        "native_1": "warship; naval vessel",
+        "primary_1": "舰艇",
+        "primary_2": "艦艇"
+    },
+    {
+        "intermediate_1": "jian4ta4",
+        "intermediate_2": "jiàntà",
+        "native_1": "trample",
+        "primary_1": "践踏",
+        "primary_2": "踐踏"
+    },
+    {
+        "intermediate_1": "jian4",
+        "intermediate_2": "jiàn",
+        "native_1": "to splash",
+        "primary_1": "溅",
+        "primary_2": "濺"
+    },
+    {
+        "intermediate_1": "jian4bie2",
+        "intermediate_2": "jiànbié",
+        "native_1": "differentiate; distinguish",
+        "primary_1": "鉴别",
+        "primary_2": "鑒別"
+    },
+    {
+        "intermediate_1": "jian4ding4",
+        "intermediate_2": "jiàndìng",
+        "native_1": "appraise; identify; evaluate",
+        "primary_1": "鉴定",
+        "primary_2": "鑒定"
+    },
+    {
+        "intermediate_1": "jian4yu2",
+        "intermediate_2": "jiànyú",
+        "native_1": "in light of; in view of; seeing that",
+        "primary_1": "鉴于",
+        "primary_2": "鑒于"
+    },
+    {
+        "intermediate_1": "jiang1jin4",
+        "intermediate_2": "jiāngjìn",
+        "native_1": "almost; nearly; close to",
+        "primary_1": "将近",
+        "primary_2": "將近"
+    },
+    {
+        "intermediate_1": "jiang1jiu",
+        "intermediate_2": "jiāngjiu",
+        "native_1": "put up with; accept somewhat reluctantly",
+        "primary_1": "将就",
+        "primary_2": "將就"
+    },
+    {
+        "intermediate_1": "jiang1jun1",
+        "intermediate_2": "jiāngjūn",
+        "native_1": "a general (military officer)",
+        "primary_1": "将军",
+        "primary_2": "將軍"
+    },
+    {
+        "intermediate_1": "jiang1ying4",
+        "intermediate_2": "jiāngyìng",
+        "native_1": "stiff",
+        "primary_1": "僵硬",
+        "primary_2": "僵硬"
+    },
+    {
+        "intermediate_1": "jiang3li4",
+        "intermediate_2": "jiǎnglì",
+        "native_1": "to reward (as encouragement)",
+        "primary_1": "奖励",
+        "primary_2": "獎勵"
+    },
+    {
+        "intermediate_1": "jiang3shang3",
+        "intermediate_2": "jiǎngshǎng",
+        "native_1": "to reward",
+        "primary_1": "奖赏",
+        "primary_2": "獎賞"
+    },
+    {
+        "intermediate_1": "jiang3",
+        "intermediate_2": "jiǎng",
+        "native_1": "oar; paddle",
+        "primary_1": "桨",
+        "primary_2": "槳"
+    },
+    {
+        "intermediate_1": "jiang4lin2",
+        "intermediate_2": "jiànglín",
+        "native_1": "befall; descend",
+        "primary_1": "降临",
+        "primary_2": "降臨"
+    },
+    {
+        "intermediate_1": "jiao1cha1",
+        "intermediate_2": "jiāochā",
+        "native_1": "cross; intersect",
+        "primary_1": "交叉",
+        "primary_2": "交叉"
+    },
+    {
+        "intermediate_1": "jiao1dai4",
+        "intermediate_2": "jiāodài",
+        "native_1": "explain; account for; hand over",
+        "primary_1": "交代",
+        "primary_2": "交代"
+    },
+    {
+        "intermediate_1": "jiao1she4",
+        "intermediate_2": "jiāoshè",
+        "native_1": "negotiate; discuss a matter with the opposing side",
+        "primary_1": "交涉",
+        "primary_2": "交涉"
+    },
+    {
+        "intermediate_1": "jiao1yi4",
+        "intermediate_2": "jiāoyì",
+        "native_1": "business transaction; deal; trade",
+        "primary_1": "交易",
+        "primary_2": "交易"
+    },
+    {
+        "intermediate_1": "jiao1qi4",
+        "intermediate_2": "jiāoqì",
+        "native_1": "delicate; effeminate; squeamish",
+        "primary_1": "娇气",
+        "primary_2": "嬌氣"
+    },
+    {
+        "intermediate_1": "jiao1dian3",
+        "intermediate_2": "jiāodiǎn",
+        "native_1": "focus; focal point",
+        "primary_1": "焦点",
+        "primary_2": "焦點"
+    },
+    {
+        "intermediate_1": "jiao1ji2",
+        "intermediate_2": "jiāojí",
+        "native_1": "anxiety; worried",
+        "primary_1": "焦急",
+        "primary_2": "焦急"
+    },
+    {
+        "intermediate_1": "jiao3luo4",
+        "intermediate_2": "jiǎoluò",
+        "native_1": "corner; nook",
+        "primary_1": "角落",
+        "primary_2": "角落"
+    },
+    {
+        "intermediate_1": "jiao3xing4",
+        "intermediate_2": "jiǎoxìng",
+        "native_1": "by luck; by a fluke",
+        "primary_1": "侥幸",
+        "primary_2": "僥幸"
+    },
+    {
+        "intermediate_1": "jiao3ban4",
+        "intermediate_2": "jiǎobàn",
+        "native_1": "stir; mix up",
+        "primary_1": "搅拌",
+        "primary_2": "攪拌"
+    },
+    {
+        "intermediate_1": "jiao3na4",
+        "intermediate_2": "jiǎonà",
+        "native_1": "to pay (taxes)",
+        "primary_1": "缴纳",
+        "primary_2": "繳納"
+    },
+    {
+        "intermediate_1": "jiao4liang4",
+        "intermediate_2": "jiàoliàng",
+        "native_1": "competition; to have a contest with sb.",
+        "primary_1": "较量",
+        "primary_2": "較量"
+    },
+    {
+        "intermediate_1": "jiao4yang3",
+        "intermediate_2": "jiàoyǎng",
+        "native_1": "upbringing; education; bring up; nurture and train",
+        "primary_1": "教养",
+        "primary_2": "教養"
+    },
+    {
+        "intermediate_1": "jie1ceng2",
+        "intermediate_2": "jiēcéng",
+        "native_1": "hierarchy",
+        "primary_1": "阶层",
+        "primary_2": "階層"
+    },
+    {
+        "intermediate_1": "jie1",
+        "intermediate_2": "jiē",
+        "native_1": "all; each and every; in all cases",
+        "primary_1": "皆",
+        "primary_2": "皆"
+    },
+    {
+        "intermediate_1": "jie1lian2",
+        "intermediate_2": "jiēlián",
+        "native_1": "one after another; in a row; in succession",
+        "primary_1": "接连",
+        "primary_2": "接連"
+    },
+    {
+        "intermediate_1": "jie1lu4",
+        "intermediate_2": "jiēlù",
+        "native_1": "expose; unmask",
+        "primary_1": "揭露",
+        "primary_2": "揭露"
+    },
+    {
+        "intermediate_1": "jie2zhi4",
+        "intermediate_2": "jiézhì",
+        "native_1": "to be restrained or moderate",
+        "primary_1": "节制",
+        "primary_2": "節制"
+    },
+    {
+        "intermediate_1": "jie2zou4",
+        "intermediate_2": "jiézòu",
+        "native_1": "rhythm; cadence; tempo",
+        "primary_1": "节奏",
+        "primary_2": "節奏"
+    },
+    {
+        "intermediate_1": "jie2chu1",
+        "intermediate_2": "jiéchū",
+        "native_1": "outstanding; preeminent",
+        "primary_1": "杰出",
+        "primary_2": "傑出"
+    },
+    {
+        "intermediate_1": "jie2jing1",
+        "intermediate_2": "jiéjīng",
+        "native_1": "a crystal; to crystallize",
+        "primary_1": "结晶",
+        "primary_2": "結晶"
+    },
+    {
+        "intermediate_1": "jie2ju2",
+        "intermediate_2": "jiéjú",
+        "native_1": "conclusion; ending",
+        "primary_1": "结局",
+        "primary_2": "結局"
+    },
+    {
+        "intermediate_1": "jie2suan4",
+        "intermediate_2": "jiésuàn",
+        "native_1": "settle up the bill; close an account",
+        "primary_1": "结算",
+        "primary_2": "結算"
+    },
+    {
+        "intermediate_1": "jie2zhi3",
+        "intermediate_2": "jiézhǐ",
+        "native_1": "end; close; stop; expiration",
+        "primary_1": "截止",
+        "primary_2": "截止"
+    },
+    {
+        "intermediate_1": "jie2zhi4",
+        "intermediate_2": "jiézhì",
+        "native_1": "up until; by (a specified time",
+        "primary_1": "截至",
+        "primary_2": "截至"
+    },
+    {
+        "intermediate_1": "jie2jin4 quan2li4",
+        "intermediate_2": "jiéjìn quánlì",
+        "native_1": "to spare no efforts; do one's utmost",
+        "primary_1": "竭尽全力",
+        "primary_2": "竭盡全力"
+    },
+    {
+        "intermediate_1": "jie3chu2",
+        "intermediate_2": "jiěchú",
+        "native_1": "remove; relieve (someone of their duties); sack; get rid of",
+        "primary_1": "解除",
+        "primary_2": "解除"
+    },
+    {
+        "intermediate_1": "jie3fang4",
+        "intermediate_2": "jiěfàng",
+        "native_1": "liberate",
+        "primary_1": "解放",
+        "primary_2": "解放"
+    },
+    {
+        "intermediate_1": "jie3gu4",
+        "intermediate_2": "jiěgù",
+        "native_1": "fire; lay off; dismiss from",
+        "primary_1": "解雇",
+        "primary_2": "解雇"
+    },
+    {
+        "intermediate_1": "jie3pou1",
+        "intermediate_2": "jiěpōu",
+        "native_1": "dissect; analyze; anatomy",
+        "primary_1": "解剖",
+        "primary_2": "解剖"
+    },
+    {
+        "intermediate_1": "jie3san4",
+        "intermediate_2": "jiěsàn",
+        "native_1": "dismiss; dissolve; disband",
+        "primary_1": "解散",
+        "primary_2": "解散"
+    },
+    {
+        "intermediate_1": "jie3ti3",
+        "intermediate_2": "jiětǐ",
+        "native_1": "disintegrate",
+        "primary_1": "解体",
+        "primary_2": "解體"
+    },
+    {
+        "intermediate_1": "jie4bei4",
+        "intermediate_2": "jièbèi",
+        "native_1": "take precautions; be on the alert",
+        "primary_1": "戒备",
+        "primary_2": "戒備"
+    },
+    {
+        "intermediate_1": "jie4xian4",
+        "intermediate_2": "jièxiàn",
+        "native_1": "boundary; marginal; limit",
+        "primary_1": "界限",
+        "primary_2": "界限"
+    },
+    {
+        "intermediate_1": "jie4jian4",
+        "intermediate_2": "jièjiàn",
+        "native_1": "take example by; use other people's experience",
+        "primary_1": "借鉴",
+        "primary_2": "借鑒"
+    },
+    {
+        "intermediate_1": "jie4zhu4",
+        "intermediate_2": "jièzhù",
+        "native_1": "get help from",
+        "primary_1": "借助",
+        "primary_2": "借助"
+    },
+    {
+        "intermediate_1": "jin1rong2",
+        "intermediate_2": "jīnróng",
+        "native_1": "banking finance; financial",
+        "primary_1": "金融",
+        "primary_2": "金融"
+    },
+    {
+        "intermediate_1": "jin1jin1 you3 wei4",
+        "intermediate_2": "jīnjīn yǒu wèi",
+        "native_1": "(saying) with gusto; eagerly; with great interest",
+        "primary_1": "津津有味",
+        "primary_2": "津津有味"
+    },
+    {
+        "intermediate_1": "jin3po4",
+        "intermediate_2": "jǐnpò",
+        "native_1": "urgent; urgency",
+        "primary_1": "紧迫",
+        "primary_2": "緊迫"
+    },
+    {
+        "intermediate_1": "jin3shang4tian1hua1",
+        "intermediate_2": "jǐnshàngtiānhuā",
+        "native_1": "lit. on brocade, add flowers (idiom); to decorate sth already perfect / gilding the lily",
+        "primary_1": "锦上添花",
+        "primary_2": "錦上添花"
+    },
+    {
+        "intermediate_1": "jin4'er2",
+        "intermediate_2": "jìn'ér",
+        "native_1": "and then (what follows next)",
+        "primary_1": "进而",
+        "primary_2": "進而"
+    },
+    {
+        "intermediate_1": "jing4ong1",
+        "intermediate_2": "jìngōng",
+        "native_1": "attack (military); assault",
+        "primary_1": "进攻",
+        "primary_2": "進攻"
+    },
+    {
+        "intermediate_1": "jin4hua4",
+        "intermediate_2": "jìnhuà",
+        "native_1": "evolution",
+        "primary_1": "进化",
+        "primary_2": "進化"
+    },
+    {
+        "intermediate_1": "jin4zhan3",
+        "intermediate_2": "jìnzhǎn",
+        "native_1": "make progress; development; make headway",
+        "primary_1": "进展",
+        "primary_2": "進展"
+    },
+    {
+        "intermediate_1": "jin4lai2",
+        "intermediate_2": "jìnlái",
+        "native_1": "recently; lately",
+        "primary_1": "近来",
+        "primary_2": "近來"
+    },
+    {
+        "intermediate_1": "jin4sheng1",
+        "intermediate_2": "jìnshēng",
+        "native_1": "promote to a higher position",
+        "primary_1": "晋升",
+        "primary_2": "晉升"
+    },
+    {
+        "intermediate_1": "jin4pao4",
+        "intermediate_2": "jìnpào",
+        "native_1": "to soak",
+        "primary_1": "浸泡",
+        "primary_2": "浸泡"
+    },
+    {
+        "intermediate_1": "jing1",
+        "intermediate_2": "jīng",
+        "native_1": "stalk; stem",
+        "primary_1": "茎",
+        "primary_2": "莖"
+    },
+    {
+        "intermediate_1": "jing1fei4",
+        "intermediate_2": "jīngfèi",
+        "native_1": "funds; expenses",
+        "primary_1": "经费",
+        "primary_2": "經費"
+    },
+    {
+        "intermediate_1": "jing1wei3",
+        "intermediate_2": "jīngwěi",
+        "native_1": "warp and woof; longitude and latitude; main points",
+        "primary_1": "经纬",
+        "primary_2": "經緯"
+    },
+    {
+        "intermediate_1": "jing1dong4",
+        "intermediate_2": "jīngdòng",
+        "native_1": "alarm; alert; startle; disturb",
+        "primary_1": "惊动",
+        "primary_2": "驚動"
+    },
+    {
+        "intermediate_1": "jing1qi2",
+        "intermediate_2": "jīngqí",
+        "native_1": "amaze; astonished",
+        "primary_1": "惊奇",
+        "primary_2": "驚奇"
+    },
+    {
+        "intermediate_1": "jing1ya4",
+        "intermediate_2": "jīngyà",
+        "native_1": "surprised; astonished; astound",
+        "primary_1": "惊讶",
+        "primary_2": "驚訝"
+    },
+    {
+        "intermediate_1": "jing1jing1 ye4ye4",
+        "intermediate_2": "jīngjīng yèyè",
+        "native_1": "cautious and conscientious",
+        "primary_1": "兢兢业业",
+        "primary_2": "兢兢業業"
+    },
+    {
+        "intermediate_1": "jing1 da3 xi4 suan4",
+        "intermediate_2": "jīng dǎ xì suàn",
+        "native_1": "(saying) meticulous planning and careful accounting",
+        "primary_1": "精打细算",
+        "primary_2": "精打細算"
+    },
+    {
+        "intermediate_1": "jing1hua2",
+        "intermediate_2": "jīnghuá",
+        "native_1": "elite; best feature; most important part of an object; essence; quintessence",
+        "primary_1": "精华",
+        "primary_2": "精華"
+    },
+    {
+        "intermediate_1": "jing1jian3",
+        "intermediate_2": "jīngjiǎn",
+        "native_1": "simplify; reduce",
+        "primary_1": "精简",
+        "primary_2": "精簡"
+    },
+    {
+        "intermediate_1": "jing1mi4",
+        "intermediate_2": "jīngmì",
+        "native_1": "accuracy; exact; precise; refined",
+        "primary_1": "精密",
+        "primary_2": "精密"
+    },
+    {
+        "intermediate_1": "jing1que4",
+        "intermediate_2": "jīngquè",
+        "native_1": "accurate; precise",
+        "primary_1": "精确",
+        "primary_2": "精確"
+    },
+    {
+        "intermediate_1": "jing1tong1",
+        "intermediate_2": "jīngtōng",
+        "native_1": "proficient; have a good command of",
+        "primary_1": "精通",
+        "primary_2": "精通"
+    },
+    {
+        "intermediate_1": "jing1xin1",
+        "intermediate_2": "jīngxīn",
+        "native_1": "with utmost care; meticulous; detailed",
+        "primary_1": "精心",
+        "primary_2": "精心"
+    },
+    {
+        "intermediate_1": "jing1 yi4 qiu2 jing1",
+        "intermediate_2": "jīng yì qiú jīng",
+        "native_1": "(saying) improving and wanting to improve even more",
+        "primary_1": "精益求精",
+        "primary_2": "精益求精"
+    },
+    {
+        "intermediate_1": "jing1zhi4",
+        "intermediate_2": "jīngzhì",
+        "native_1": "exquisite; delicate; refined",
+        "primary_1": "精致",
+        "primary_2": "精致"
+    },
+    {
+        "intermediate_1": "jing3",
+        "intermediate_2": "jǐng",
+        "native_1": "a well",
+        "primary_1": "井",
+        "primary_2": "井"
+    },
+    {
+        "intermediate_1": "jing3zhui1",
+        "intermediate_2": "jǐngzhuī",
+        "native_1": "cervical vertebra; the seven cervical vertebrae in the neck of humans and most mammals",
+        "primary_1": "颈椎",
+        "primary_2": "頸椎"
+    },
+    {
+        "intermediate_1": "jing3gao4",
+        "intermediate_2": "jǐnggào",
+        "native_1": "to warn; admonish",
+        "primary_1": "警告",
+        "primary_2": "警告"
+    },
+    {
+        "intermediate_1": "jing3ti4",
+        "intermediate_2": "jǐngtì",
+        "native_1": "vigilant; alert; be on guard",
+        "primary_1": "警惕",
+        "primary_2": "警惕"
+    },
+    {
+        "intermediate_1": "jing4sai4",
+        "intermediate_2": "jìngsài",
+        "native_1": "race; contest; competition",
+        "primary_1": "竞赛",
+        "primary_2": "競賽"
+    },
+    {
+        "intermediate_1": "jing4xuan3",
+        "intermediate_2": "jìngxuǎn",
+        "native_1": "run for (electoral) office; take part in an election",
+        "primary_1": "竞选",
+        "primary_2": "競選"
+    },
+    {
+        "intermediate_1": "jing4li3",
+        "intermediate_2": "jìnglǐ",
+        "native_1": "to salute; best regards",
+        "primary_1": "敬礼",
+        "primary_2": "敬禮"
+    },
+    {
+        "intermediate_1": "jing4ye4",
+        "intermediate_2": "jìngyè",
+        "native_1": "work ethic",
+        "primary_1": "敬业",
+        "primary_2": "敬業"
+    },
+    {
+        "intermediate_1": "jing4jie4",
+        "intermediate_2": "jìngjiè",
+        "native_1": "boundary; state; realm; level",
+        "primary_1": "境界",
+        "primary_2": "境界"
+    },
+    {
+        "intermediate_1": "jing4tou2",
+        "intermediate_2": "jìngtóu",
+        "native_1": "camera shot (in a movie, etc.); scene; camera lens",
+        "primary_1": "镜头",
+        "primary_2": "鏡頭"
+    },
+    {
+        "intermediate_1": "jiu1fen1",
+        "intermediate_2": "jiūfēn",
+        "native_1": "dispute; quarrel",
+        "primary_1": "纠纷",
+        "primary_2": "糾紛"
+    },
+    {
+        "intermediate_1": "jiu1zheng4",
+        "intermediate_2": "jiūzhèng",
+        "native_1": "to correct; to make right",
+        "primary_1": "纠正",
+        "primary_2": "糾正"
+    },
+    {
+        "intermediate_1": "jiu3jing1",
+        "intermediate_2": "jiǔjīng",
+        "native_1": "alcohol; ethanol",
+        "primary_1": "酒精",
+        "primary_2": "酒精"
+    },
+    {
+        "intermediate_1": "jiu4ji4",
+        "intermediate_2": "jiùjì",
+        "native_1": "emergency relief; aid; help out in a disaster",
+        "primary_1": "救济",
+        "primary_2": "救濟"
+    },
+    {
+        "intermediate_1": "jiu4jin4",
+        "intermediate_2": "jiùjìn",
+        "native_1": "nearby; in a close neighborhood",
+        "primary_1": "就近",
+        "primary_2": "就近"
+    },
+    {
+        "intermediate_1": "jiu4ye4",
+        "intermediate_2": "jiùyè",
+        "native_1": "employment; getting a job",
+        "primary_1": "就业",
+        "primary_2": "就業"
+    },
+    {
+        "intermediate_1": "jiu4 zhi2",
+        "intermediate_2": "jiù zhí",
+        "native_1": "take office; assume a post",
+        "primary_1": "就职",
+        "primary_2": "就職"
+    },
+    {
+        "intermediate_1": "ju1liu2",
+        "intermediate_2": "jūliú",
+        "native_1": "detain (a prison); keep (someone) in custody",
+        "primary_1": "拘留",
+        "primary_2": "拘留"
+    },
+    {
+        "intermediate_1": "ju1shu4",
+        "intermediate_2": "jūshù",
+        "native_1": "restrict; constrained; ill at ease; reticent",
+        "primary_1": "拘束",
+        "primary_2": "拘束"
+    },
+    {
+        "intermediate_1": "ju1min2",
+        "intermediate_2": "jūmín",
+        "native_1": "resident; inhabitant",
+        "primary_1": "居民",
+        "primary_2": "居民"
+    },
+    {
+        "intermediate_1": "ju1zhu4",
+        "intermediate_2": "jūzhù",
+        "native_1": "reside; dwell; to live (in a place)",
+        "primary_1": "居住",
+        "primary_2": "居住"
+    },
+    {
+        "intermediate_1": "ju1gong1",
+        "intermediate_2": "jūgōng",
+        "native_1": "to bow",
+        "primary_1": "鞠躬",
+        "primary_2": "鞠躬"
+    },
+    {
+        "intermediate_1": "ju2bu4",
+        "intermediate_2": "júbù",
+        "native_1": "part; local",
+        "primary_1": "局部",
+        "primary_2": "局部"
+    },
+    {
+        "intermediate_1": "ju2mian4",
+        "intermediate_2": "júmiàn",
+        "native_1": "aspect; situation",
+        "primary_1": "局面",
+        "primary_2": "局面"
+    },
+    {
+        "intermediate_1": "ju2shi4",
+        "intermediate_2": "júshì",
+        "native_1": "situation; state (of affairs)",
+        "primary_1": "局势",
+        "primary_2": "局勢"
+    },
+    {
+        "intermediate_1": "ju2xian4",
+        "intermediate_2": "júxiàn",
+        "native_1": "to limit; confine; restrict or confine sth.",
+        "primary_1": "局限",
+        "primary_2": "局限"
+    },
+    {
+        "intermediate_1": "ju3jue2",
+        "intermediate_2": "jǔjué",
+        "native_1": "to chew",
+        "primary_1": "咀嚼",
+        "primary_2": "咀嚼"
+    },
+    {
+        "intermediate_1": "ju3sang4",
+        "intermediate_2": "jǔsàng",
+        "native_1": "dejected; depressed; dispirited",
+        "primary_1": "沮丧",
+        "primary_2": "沮喪"
+    },
+    {
+        "intermediate_1": "ju3dong4",
+        "intermediate_2": "jǔdòng",
+        "native_1": "action; act; (make) a move; movement",
+        "primary_1": "举动",
+        "primary_2": "舉動"
+    },
+    {
+        "intermediate_1": "ju3shi4 zhu3mu4",
+        "intermediate_2": "jǔshì zhǔmù",
+        "native_1": "attract worldwide attention",
+        "primary_1": "举世瞩目",
+        "primary_2": "舉世矚目"
+    },
+    {
+        "intermediate_1": "ju3zu2qing1zhong4",
+        "intermediate_2": "jǔzúqīngzhòng",
+        "native_1": "a foot's move sways the balance; hold the balance of power; play a key role",
+        "primary_1": "举足轻重",
+        "primary_2": "舉足輕重"
+    },
+    {
+        "intermediate_1": "ju4ben3",
+        "intermediate_2": "jùběn",
+        "native_1": "script for a play; opera; movie; etc",
+        "primary_1": "剧本",
+        "primary_2": "劇本"
+    },
+    {
+        "intermediate_1": "ju4lie4",
+        "intermediate_2": "jùliè",
+        "native_1": "acute; violent; severe",
+        "primary_1": "剧烈",
+        "primary_2": "劇烈"
+    },
+    {
+        "intermediate_1": "ju4xi1",
+        "intermediate_2": "jùxī",
+        "native_1": "according to reports; it is reported (that)",
+        "primary_1": "据悉",
+        "primary_2": "據悉"
+    },
+    {
+        "intermediate_1": "ju4 jing1 hui4 shen2",
+        "intermediate_2": "jù jīng huì shén",
+        "native_1": "concentrate one's attention",
+        "primary_1": "聚精会神",
+        "primary_2": "聚精會神"
+    },
+    {
+        "intermediate_1": "juan3",
+        "intermediate_2": "juǎn",
+        "native_1": "to roll (up); to coil; (mw for tapes)",
+        "primary_1": "卷",
+        "primary_2": "卷"
+    },
+    {
+        "intermediate_1": "jue2ce4",
+        "intermediate_2": "juécè",
+        "native_1": "Make policy; make strategic decision",
+        "primary_1": "决策",
+        "primary_2": "決策"
+    },
+    {
+        "intermediate_1": "jue2wu4",
+        "intermediate_2": "juéwù",
+        "native_1": "consciousness; awareness; (Buddhist) enlightenment",
+        "primary_1": "觉悟",
+        "primary_2": "覺悟"
+    },
+    {
+        "intermediate_1": "jue2xing3",
+        "intermediate_2": "juéxǐng",
+        "native_1": "awaken; arousal; realize",
+        "primary_1": "觉醒",
+        "primary_2": "覺醒"
+    },
+    {
+        "intermediate_1": "jue2 wang4",
+        "intermediate_2": "jué wàng",
+        "native_1": "desperation; forlorn; hopeless",
+        "primary_1": "绝望",
+        "primary_2": "絕望"
+    },
+    {
+        "intermediate_1": "jue2jiang4",
+        "intermediate_2": "juéjiàng",
+        "native_1": "stubborn; unbending",
+        "primary_1": "倔强",
+        "primary_2": "倔強"
+    },
+    {
+        "intermediate_1": "jun1dui4",
+        "intermediate_2": "jūnduì",
+        "native_1": "army troops",
+        "primary_1": "军队",
+        "primary_2": "軍隊"
+    },
+    {
+        "intermediate_1": "jun1zi3",
+        "intermediate_2": "jūnzǐ",
+        "native_1": "gentleman; man of noble character",
+        "primary_1": "君子",
+        "primary_2": "君子"
+    },
+    {
+        "intermediate_1": "ka3tong1",
+        "intermediate_2": "kǎtōng",
+        "native_1": "cartoon",
+        "primary_1": "卡通",
+        "primary_2": "卡通"
+    },
+    {
+        "intermediate_1": "kai1cai3",
+        "intermediate_2": "kāicǎi",
+        "native_1": "extract ore or some other natural resource from a mine",
+        "primary_1": "开采",
+        "primary_2": "開采"
+    },
+    {
+        "intermediate_1": "kai1chu2",
+        "intermediate_2": "kāichú",
+        "native_1": "expel; to discharge; to kick out",
+        "primary_1": "开除",
+        "primary_2": "開除"
+    },
+    {
+        "intermediate_1": "kai1kuo4",
+        "intermediate_2": "kāikuò",
+        "native_1": "wide; open (spaces)",
+        "primary_1": "开阔",
+        "primary_2": "開闊"
+    },
+    {
+        "intermediate_1": "kai1lang3",
+        "intermediate_2": "kāilǎng",
+        "native_1": "outgoing and cheerful; optimistic; carefree; spacious and well-lit",
+        "primary_1": "开朗",
+        "primary_2": "開朗"
+    },
+    {
+        "intermediate_1": "kai1ming2",
+        "intermediate_2": "kāimíng",
+        "native_1": "enlightened; open-minded",
+        "primary_1": "开明",
+        "primary_2": "開明"
+    },
+    {
+        "intermediate_1": "kai1pi4",
+        "intermediate_2": "kāipì",
+        "native_1": "open up; to start; to build",
+        "primary_1": "开辟",
+        "primary_2": "開辟"
+    },
+    {
+        "intermediate_1": "kai1tuo4",
+        "intermediate_2": "kāituò",
+        "native_1": "break new ground (for agriculture); development",
+        "primary_1": "开拓",
+        "primary_2": "開拓"
+    },
+    {
+        "intermediate_1": "kai1zhan3",
+        "intermediate_2": "kāizhǎn",
+        "native_1": "begin to develop; to launch",
+        "primary_1": "开展",
+        "primary_2": "開展"
+    },
+    {
+        "intermediate_1": "kai1zhi1",
+        "intermediate_2": "kāizhī",
+        "native_1": "expenditures; pay; expenses",
+        "primary_1": "开支",
+        "primary_2": "開支"
+    },
+    {
+        "intermediate_1": "kan1deng1",
+        "intermediate_2": "kāndēng",
+        "native_1": "publish in a newspaper; carry a story",
+        "primary_1": "刊登",
+        "primary_2": "刊登"
+    },
+    {
+        "intermediate_1": "kan1wu4",
+        "intermediate_2": "kānwù",
+        "native_1": "publication; periodical; journal",
+        "primary_1": "刊物",
+        "primary_2": "刊物"
+    },
+    {
+        "intermediate_1": "kan1tan4",
+        "intermediate_2": "kāntàn",
+        "native_1": "exploration",
+        "primary_1": "勘探",
+        "primary_2": "勘探"
+    },
+    {
+        "intermediate_1": "kan3kan3'er2tan2",
+        "intermediate_2": "kǎnkǎn'értán",
+        "native_1": "speak frankly and in measured tones; argue about leisurely and boldly",
+        "primary_1": "侃侃而谈",
+        "primary_2": "侃侃而談"
+    },
+    {
+        "intermediate_1": "kan3fa2",
+        "intermediate_2": "kǎnfá",
+        "native_1": "cut down; lop; hew (as a tree)",
+        "primary_1": "砍伐",
+        "primary_2": "砍伐"
+    },
+    {
+        "intermediate_1": "kan4dai4",
+        "intermediate_2": "kàndài",
+        "native_1": "look upon; regard",
+        "primary_1": "看待",
+        "primary_2": "看待"
+    },
+    {
+        "intermediate_1": "kang1kai3",
+        "intermediate_2": "kāngkǎi",
+        "native_1": "vehement; fervent; generous",
+        "primary_1": "慷慨",
+        "primary_2": "慷慨"
+    },
+    {
+        "intermediate_1": "kang2",
+        "intermediate_2": "káng",
+        "native_1": "to carry on one's shoulder",
+        "primary_1": "扛",
+        "primary_2": "扛"
+    },
+    {
+        "intermediate_1": "kang4yi4",
+        "intermediate_2": "kàngyì",
+        "native_1": "to protest; protest",
+        "primary_1": "抗议",
+        "primary_2": "抗議"
+    },
+    {
+        "intermediate_1": "kao3cha2",
+        "intermediate_2": "kǎochá",
+        "native_1": "inspect; investigate; analyze",
+        "primary_1": "考察",
+        "primary_2": "考察"
+    },
+    {
+        "intermediate_1": "kao3gu3",
+        "intermediate_2": "kǎogǔ",
+        "native_1": "archaeology",
+        "primary_1": "考古",
+        "primary_2": "考古"
+    },
+    {
+        "intermediate_1": "kao3he2",
+        "intermediate_2": "kǎohé",
+        "native_1": "examine; check up on",
+        "primary_1": "考核",
+        "primary_2": "考核"
+    },
+    {
+        "intermediate_1": "kao3yan4",
+        "intermediate_2": "kǎoyàn",
+        "native_1": "put to the test; trial",
+        "primary_1": "考验",
+        "primary_2": "考驗"
+    },
+    {
+        "intermediate_1": "kao4long3",
+        "intermediate_2": "kàolǒng",
+        "native_1": "draw close; close up; move up",
+        "primary_1": "靠拢",
+        "primary_2": "靠攏"
+    },
+    {
+        "intermediate_1": "ke1mu4",
+        "intermediate_2": "kēmù",
+        "native_1": "(school) subject",
+        "primary_1": "科目",
+        "primary_2": "科目"
+    },
+    {
+        "intermediate_1": "ke1",
+        "intermediate_2": "kē",
+        "native_1": "knock; tap",
+        "primary_1": "磕",
+        "primary_2": "磕"
+    },
+    {
+        "intermediate_1": "ke3guan1",
+        "intermediate_2": "kěguān",
+        "native_1": "considerable; impressive",
+        "primary_1": "可观",
+        "primary_2": "可觀"
+    },
+    {
+        "intermediate_1": "ke3kou3",
+        "intermediate_2": "kěkǒu",
+        "native_1": "tasty; taste good",
+        "primary_1": "可口",
+        "primary_2": "可口"
+    },
+    {
+        "intermediate_1": "ke3wu4",
+        "intermediate_2": "kěwù",
+        "native_1": "hateful; abominable; repulsive",
+        "primary_1": "可恶",
+        "primary_2": "可惡"
+    },
+    {
+        "intermediate_1": "ke3xing2",
+        "intermediate_2": "kěxíng",
+        "native_1": "feasible",
+        "primary_1": "可行",
+        "primary_2": "可行"
+    },
+    {
+        "intermediate_1": "ke3wang4",
+        "intermediate_2": "kěwàng",
+        "native_1": "wishful; to yearn for; desire",
+        "primary_1": "渴望",
+        "primary_2": "渴望"
+    },
+    {
+        "intermediate_1": "ke4zhi4",
+        "intermediate_2": "kèzhì",
+        "native_1": "restrain; take a firm hold on",
+        "primary_1": "克制",
+        "primary_2": "克制"
+    },
+    {
+        "intermediate_1": "ke4bu4rong2huan3",
+        "intermediate_2": "kèbùrónghuǎn",
+        "native_1": "demand immediate action; brook no delay",
+        "primary_1": "刻不容缓",
+        "primary_2": "刻不容緩"
+    },
+    {
+        "intermediate_1": "ke4hu4",
+        "intermediate_2": "kèhù",
+        "native_1": "customer; account; client",
+        "primary_1": "客户",
+        "primary_2": "客戶"
+    },
+    {
+        "intermediate_1": "ke4ti2",
+        "intermediate_2": "kètí",
+        "native_1": "task; problem; issue; question for discussion",
+        "primary_1": "课题",
+        "primary_2": "課題"
+    },
+    {
+        "intermediate_1": "ken3qie4",
+        "intermediate_2": "kěnqiè",
+        "native_1": "earnest; genuine; fair-spoken",
+        "primary_1": "恳切",
+        "primary_2": "懇切"
+    },
+    {
+        "intermediate_1": "ken3",
+        "intermediate_2": "kěn",
+        "native_1": "gnaw; nibble; bite",
+        "primary_1": "啃",
+        "primary_2": "啃"
+    },
+    {
+        "intermediate_1": "keng1",
+        "intermediate_2": "kēng",
+        "native_1": "pit; hole; defraud",
+        "primary_1": "坑",
+        "primary_2": "坑"
+    },
+    {
+        "intermediate_1": "kong1dong4",
+        "intermediate_2": "kōngdòng",
+        "native_1": "empty; hollow; vacuous; devoid of content",
+        "primary_1": "空洞",
+        "primary_2": "空洞"
+    },
+    {
+        "intermediate_1": "kong1qian2jue2hou4",
+        "intermediate_2": "kōngqiánjuéhòu",
+        "native_1": "unprecedented and unrepeatable; never to be reduplicated; the first and the last; unmatched; unique",
+        "primary_1": "空前绝后",
+        "primary_2": "空前絕後"
+    },
+    {
+        "intermediate_1": "kong1xiang3",
+        "intermediate_2": "kōngxiǎng",
+        "native_1": "daydream; fantasy",
+        "primary_1": "空想",
+        "primary_2": "空想"
+    },
+    {
+        "intermediate_1": "kong1xu1",
+        "intermediate_2": "kōngxū",
+        "native_1": "hollow; emptiness; meaningless",
+        "primary_1": "空虚",
+        "primary_2": "空虛"
+    },
+    {
+        "intermediate_1": "kong3",
+        "intermediate_2": "kǒng",
+        "native_1": "hole",
+        "primary_1": "孔",
+        "primary_2": "孔"
+    },
+    {
+        "intermediate_1": "kong3bu4",
+        "intermediate_2": "kǒngbù",
+        "native_1": "afraid; terror",
+        "primary_1": "恐怖",
+        "primary_2": "恐怖"
+    },
+    {
+        "intermediate_1": "kong3he4",
+        "intermediate_2": "kǒnghè",
+        "native_1": "to threaten",
+        "primary_1": "恐吓",
+        "primary_2": "恐嚇"
+    },
+    {
+        "intermediate_1": "kong3ju4",
+        "intermediate_2": "kǒngjù",
+        "native_1": "fear; dread; phobia",
+        "primary_1": "恐惧",
+        "primary_2": "恐懼"
+    },
+    {
+        "intermediate_1": "kong4bai2",
+        "intermediate_2": "kòngbái",
+        "native_1": "blank space; blank",
+        "primary_1": "空白",
+        "primary_2": "空白"
+    },
+    {
+        "intermediate_1": "kong4xi4",
+        "intermediate_2": "kòngxì",
+        "native_1": "crack; gap between two objects",
+        "primary_1": "空隙",
+        "primary_2": "空隙"
+    },
+    {
+        "intermediate_1": "kou3qi4",
+        "intermediate_2": "kǒuqì",
+        "native_1": "tone of voice; manner of speaking",
+        "primary_1": "口气",
+        "primary_2": "口氣"
+    },
+    {
+        "intermediate_1": "kou3qiang1",
+        "intermediate_2": "kǒuqiāng",
+        "native_1": "space inside mouth (oral cavity)",
+        "primary_1": "口腔",
+        "primary_2": "口腔"
+    },
+    {
+        "intermediate_1": "kou3tou2",
+        "intermediate_2": "kǒutóu",
+        "native_1": "oral; verbal",
+        "primary_1": "口头",
+        "primary_2": "口頭"
+    },
+    {
+        "intermediate_1": "kou3yin1",
+        "intermediate_2": "kǒuyīn",
+        "native_1": "accent",
+        "primary_1": "口音",
+        "primary_2": "口音"
+    },
+    {
+        "intermediate_1": "kou4",
+        "intermediate_2": "kòu",
+        "native_1": "to fasten; to button; button; buckle; knot; to arrest; to confiscate; to deduct (money); discount; to knock; put upside down; to smash or spike (a ball); to cover (with a bowl etc); fig. to tag a label on sb",
+        "primary_1": "扣",
+        "primary_2": "扣"
+    },
+    {
+        "intermediate_1": "ku1wei3",
+        "intermediate_2": "kūwěi",
+        "native_1": "wither; withered",
+        "primary_1": "枯萎",
+        "primary_2": "枯萎"
+    },
+    {
+        "intermediate_1": "ku1zao4",
+        "intermediate_2": "kūzào",
+        "native_1": "dry and dull; uninteresting",
+        "primary_1": "枯燥",
+        "primary_2": "枯燥"
+    },
+    {
+        "intermediate_1": "ku1qi4",
+        "intermediate_2": "kūqì",
+        "native_1": "weep; cry; sob",
+        "primary_1": "哭泣",
+        "primary_2": "哭泣"
+    },
+    {
+        "intermediate_1": "ku3jing4an1lai2",
+        "intermediate_2": "kǔjìngānlái",
+        "native_1": "sweetness comes after bitterness; the hard times are over and the good times are just beginning",
+        "primary_1": "苦尽甘来",
+        "primary_2": "苦盡甘來"
+    },
+    {
+        "intermediate_1": "ku3se4",
+        "intermediate_2": "kǔsè",
+        "native_1": "bitter and astringent; pained; agonized; anguished",
+        "primary_1": "苦涩",
+        "primary_2": "苦澀"
+    },
+    {
+        "intermediate_1": "kua4",
+        "intermediate_2": "kuà",
+        "native_1": "carry over one's shoulder or slung on one's side",
+        "primary_1": "挎",
+        "primary_2": "挎"
+    },
+    {
+        "intermediate_1": "kua4",
+        "intermediate_2": "kuà",
+        "native_1": "step across; stride; straddle; to cross",
+        "primary_1": "跨",
+        "primary_2": "跨"
+    },
+    {
+        "intermediate_1": "kuai4huo",
+        "intermediate_2": "kuàihuo",
+        "native_1": "happy; cheerful",
+        "primary_1": "快活",
+        "primary_2": "快活"
+    },
+    {
+        "intermediate_1": "kuan1chang",
+        "intermediate_2": "kuānchang",
+        "native_1": "spacious; commodious",
+        "primary_1": "宽敞",
+        "primary_2": "寬敞"
+    },
+    {
+        "intermediate_1": "kuan1rong2",
+        "intermediate_2": "kuānróng",
+        "native_1": "tolerant; lenient",
+        "primary_1": "宽容",
+        "primary_2": "寬容"
+    },
+    {
+        "intermediate_1": "kuan3dai4",
+        "intermediate_2": "kuǎndài",
+        "native_1": "to entertain (guests)",
+        "primary_1": "款待",
+        "primary_2": "款待"
+    },
+    {
+        "intermediate_1": "kuan3shi4",
+        "intermediate_2": "kuǎnshì",
+        "native_1": "pattern; design; style",
+        "primary_1": "款式",
+        "primary_2": "款式"
+    },
+    {
+        "intermediate_1": "kuang1",
+        "intermediate_2": "kuāng",
+        "native_1": "basket",
+        "primary_1": "筐",
+        "primary_2": "筐"
+    },
+    {
+        "intermediate_1": "kuang4 ke4",
+        "intermediate_2": "kuàng kè",
+        "native_1": "cut school; be truant from school",
+        "primary_1": "旷课",
+        "primary_2": "曠課"
+    },
+    {
+        "intermediate_1": "kuang4qie3",
+        "intermediate_2": "kuàngqiě",
+        "native_1": "moreover; besides; in addition",
+        "primary_1": "况且",
+        "primary_2": "況且"
+    },
+    {
+        "intermediate_1": "kuang4chan3",
+        "intermediate_2": "kuàngchǎn",
+        "native_1": "minerals",
+        "primary_1": "矿产",
+        "primary_2": "礦産"
+    },
+    {
+        "intermediate_1": "kuang4jia4",
+        "intermediate_2": "kuàngjià",
+        "native_1": "frame; framework; skeleton",
+        "primary_1": "框架",
+        "primary_2": "框架"
+    },
+    {
+        "intermediate_1": "kui1dai4",
+        "intermediate_2": "kuīdài",
+        "native_1": "treat sb. unfairly",
+        "primary_1": "亏待",
+        "primary_2": "虧待"
+    },
+    {
+        "intermediate_1": "kui1sun3",
+        "intermediate_2": "kuīsǔn",
+        "native_1": "deficit; (financial) loss",
+        "primary_1": "亏损",
+        "primary_2": "虧損"
+    },
+    {
+        "intermediate_1": "kun3bang3",
+        "intermediate_2": "kǔnbǎng",
+        "native_1": "tie up; bundled",
+        "primary_1": "捆绑",
+        "primary_2": "捆綁"
+    },
+    {
+        "intermediate_1": "kuo4chong1",
+        "intermediate_2": "kuòchōng",
+        "native_1": "expand; extend",
+        "primary_1": "扩充",
+        "primary_2": "擴充"
+    },
+    {
+        "intermediate_1": "kuo4san4",
+        "intermediate_2": "kuòsàn",
+        "native_1": "spread; proliferation",
+        "primary_1": "扩散",
+        "primary_2": "擴散"
+    },
+    {
+        "intermediate_1": "kuo4zhang1",
+        "intermediate_2": "kuòzhāng",
+        "native_1": "expansion; extension",
+        "primary_1": "扩张",
+        "primary_2": "擴張"
+    },
+    {
+        "intermediate_1": "la3ba",
+        "intermediate_2": "lǎba",
+        "native_1": "horn; trumpet; loudspeaker",
+        "primary_1": "喇叭",
+        "primary_2": "喇叭"
+    },
+    {
+        "intermediate_1": "la4zhu2",
+        "intermediate_2": "làzhú",
+        "native_1": "candle",
+        "primary_1": "蜡烛",
+        "primary_2": "蠟燭"
+    },
+    {
+        "intermediate_1": "la",
+        "intermediate_2": "la",
+        "native_1": "sentence-final particle: a contraction of 了 (le) and 啊 (a)",
+        "primary_1": "啦",
+        "primary_2": "啦"
+    },
+    {
+        "intermediate_1": "lai2li4",
+        "intermediate_2": "láilì",
+        "native_1": "history; antecedents; origin",
+        "primary_1": "来历",
+        "primary_2": "來曆"
+    },
+    {
+        "intermediate_1": "lai2yuan2",
+        "intermediate_2": "láiyuán",
+        "native_1": "source; originate",
+        "primary_1": "来源",
+        "primary_2": "來源"
+    },
+    {
+        "intermediate_1": "lan2mu4",
+        "intermediate_2": "lánmù",
+        "native_1": "column (in a newspaper,TV,etc)",
+        "primary_1": "栏目",
+        "primary_2": "欄目"
+    },
+    {
+        "intermediate_1": "lan3duo4",
+        "intermediate_2": "lǎnduò",
+        "native_1": "lazy; idle",
+        "primary_1": "懒惰",
+        "primary_2": "懶惰"
+    },
+    {
+        "intermediate_1": "lang2bei4",
+        "intermediate_2": "lángbèi",
+        "native_1": "in a difficult position or situation; in a tight corner; scoundrel! (derogatory)",
+        "primary_1": "狼狈",
+        "primary_2": "狼狽"
+    },
+    {
+        "intermediate_1": "lang2tun1hu3yan4",
+        "intermediate_2": "lángtūnhǔyàn",
+        "native_1": "wolf down one's food (idiom); gorge oneself",
+        "primary_1": "狼吞虎咽",
+        "primary_2": "狼吞虎咽"
+    },
+    {
+        "intermediate_1": "lao1",
+        "intermediate_2": "lāo",
+        "native_1": "dredge up; fish up",
+        "primary_1": "捞",
+        "primary_2": "撈"
+    },
+    {
+        "intermediate_1": "lao2gu4",
+        "intermediate_2": "láogù",
+        "native_1": "firm; secure; solid",
+        "primary_1": "牢固",
+        "primary_2": "牢固"
+    },
+    {
+        "intermediate_1": "lao2sao1",
+        "intermediate_2": "láosāo",
+        "native_1": "grumble; complaint",
+        "primary_1": "牢骚",
+        "primary_2": "牢騷"
+    },
+    {
+        "intermediate_1": "lao2dao",
+        "intermediate_2": "láodao",
+        "native_1": "be talkative (especially about trivial matters); be garrulous; prattle",
+        "primary_1": "唠叨",
+        "primary_2": "唠叨"
+    },
+    {
+        "intermediate_1": "le4qu4",
+        "intermediate_2": "lèqù",
+        "native_1": "delight; pleasure; joy; fun",
+        "primary_1": "乐趣",
+        "primary_2": "樂趣"
+    },
+    {
+        "intermediate_1": "le4yi4",
+        "intermediate_2": "lèyì",
+        "native_1": "be happy/willing do something; content; satisfied",
+        "primary_1": "乐意",
+        "primary_2": "樂意"
+    },
+    {
+        "intermediate_1": "lei2da2",
+        "intermediate_2": "léidá",
+        "native_1": "radar",
+        "primary_1": "雷达",
+        "primary_2": "雷達"
+    },
+    {
+        "intermediate_1": "lei4si4",
+        "intermediate_2": "lèisì",
+        "native_1": "similar; analogous",
+        "primary_1": "类似",
+        "primary_2": "類似"
+    },
+    {
+        "intermediate_1": "leng3ku4",
+        "intermediate_2": "lěngkù",
+        "native_1": "grim; unfeeling; callous",
+        "primary_1": "冷酷",
+        "primary_2": "冷酷"
+    },
+    {
+        "intermediate_1": "leng3luo4",
+        "intermediate_2": "lěngluò",
+        "native_1": "to treat somebody coldy; to snub; desolate; to give the cold shoulder",
+        "primary_1": "冷落",
+        "primary_2": "冷落"
+    },
+    {
+        "intermediate_1": "leng3que4",
+        "intermediate_2": "lěngquè",
+        "native_1": "cooling; cool off",
+        "primary_1": "冷却",
+        "primary_2": "冷卻"
+    },
+    {
+        "intermediate_1": "leng4",
+        "intermediate_2": "lèng",
+        "native_1": "dumbfounded; stupefied; distracted; (spoken) blunt; rash",
+        "primary_1": "愣",
+        "primary_2": "愣"
+    },
+    {
+        "intermediate_1": "li2ming2",
+        "intermediate_2": "límíng",
+        "native_1": "dawn; daybreak",
+        "primary_1": "黎明",
+        "primary_2": "黎明"
+    },
+    {
+        "intermediate_1": "li3jie2",
+        "intermediate_2": "lǐjié",
+        "native_1": "etiquette; proprieties; festival",
+        "primary_1": "礼节",
+        "primary_2": "禮節"
+    },
+    {
+        "intermediate_1": "li3shang4wang3lai2",
+        "intermediate_2": "lǐshàngwǎnglái",
+        "native_1": "courtesy requires reciprocity",
+        "primary_1": "礼尚往来",
+        "primary_2": "禮尚往來"
+    },
+    {
+        "intermediate_1": "li3cheng2bei1",
+        "intermediate_2": "lǐchéngbēi",
+        "native_1": "milestone",
+        "primary_1": "里程碑",
+        "primary_2": "裏程碑"
+    },
+    {
+        "intermediate_1": "li3cai3",
+        "intermediate_2": "lǐcǎi",
+        "native_1": "heed; pay attention to (usually used in the negative)",
+        "primary_1": "理睬",
+        "primary_2": "理睬"
+    },
+    {
+        "intermediate_1": "li3 suo3 dang1 ran2",
+        "intermediate_2": "lǐ suǒ dāng rán",
+        "native_1": "(idiom) it goes without saying; certainly; of course; be natural and right",
+        "primary_1": "理所当然",
+        "primary_2": "理所當然"
+    },
+    {
+        "intermediate_1": "li3zhi2qi4zhuang4",
+        "intermediate_2": "lǐzhíqìzhuàng",
+        "native_1": "with justice on one's side, one is bold and assured; to have the courage of ones convictions; just and forceful",
+        "primary_1": "理直气壮",
+        "primary_2": "理直氣壯"
+    },
+    {
+        "intermediate_1": "li3zhi4",
+        "intermediate_2": "lǐzhì",
+        "native_1": "reason; intellect; rational",
+        "primary_1": "理智",
+        "primary_2": "理智"
+    },
+    {
+        "intermediate_1": "li4qiu2",
+        "intermediate_2": "lìqiú",
+        "native_1": "make every effort; do one's best",
+        "primary_1": "力求",
+        "primary_2": "力求"
+    },
+    {
+        "intermediate_1": "li4suo3neng2ji2",
+        "intermediate_2": "lìsuǒnéngjí",
+        "native_1": "within one's power; to the best of one's ability",
+        "primary_1": "力所能及",
+        "primary_2": "力所能及"
+    },
+    {
+        "intermediate_1": "li4zheng1",
+        "intermediate_2": "lìzhēng",
+        "native_1": "work hard; do all one can to; strive for/argue strongly",
+        "primary_1": "力争",
+        "primary_2": "力爭"
+    },
+    {
+        "intermediate_1": "li4dai4",
+        "intermediate_2": "lìdài",
+        "native_1": "successive dynasties; past dynasties",
+        "primary_1": "历代",
+        "primary_2": "曆代"
+    },
+    {
+        "intermediate_1": "li4lai2",
+        "intermediate_2": "lìlái",
+        "native_1": "always; throughout (a period of time)",
+        "primary_1": "历来",
+        "primary_2": "曆來"
+    },
+    {
+        "intermediate_1": "li4chang3",
+        "intermediate_2": "lìchǎng",
+        "native_1": "position; standpoint",
+        "primary_1": "立场",
+        "primary_2": "立場"
+    },
+    {
+        "intermediate_1": "li4fang1",
+        "intermediate_2": "lìfāng",
+        "native_1": "cube; (mw cubic units of measure)",
+        "primary_1": "立方",
+        "primary_2": "立方"
+    },
+    {
+        "intermediate_1": "li4jiao1qiao2",
+        "intermediate_2": "lìjiāoqiáo",
+        "native_1": "overpass; one road goes on top of another; cloverleaf intersection",
+        "primary_1": "立交桥",
+        "primary_2": "立交橋"
+    },
+    {
+        "intermediate_1": "li4ti3",
+        "intermediate_2": "lìtǐ",
+        "native_1": "solid; three dimensional",
+        "primary_1": "立体",
+        "primary_2": "立體"
+    },
+    {
+        "intermediate_1": "li4zu2",
+        "intermediate_2": "lìzú",
+        "native_1": "base oneself on; be established; have a footing",
+        "primary_1": "立足",
+        "primary_2": "立足"
+    },
+    {
+        "intermediate_1": "li4hai",
+        "intermediate_2": "lìhai",
+        "native_1": "serious; formidable; devastating; (-hài: advantages and disadvantages)",
+        "primary_1": "利害",
+        "primary_2": "利害"
+    },
+    {
+        "intermediate_1": "li4wai4",
+        "intermediate_2": "lìwài",
+        "native_1": "(make an) exception",
+        "primary_1": "例外",
+        "primary_2": "例外"
+    },
+    {
+        "intermediate_1": "li4",
+        "intermediate_2": "lì",
+        "native_1": "a grain; granule; (mw for grain-like things)",
+        "primary_1": "粒",
+        "primary_2": "粒"
+    },
+    {
+        "intermediate_1": "lian2nian2",
+        "intermediate_2": "liánnián",
+        "native_1": "successive years; over many years; once again this year",
+        "primary_1": "连年",
+        "primary_2": "連年"
+    },
+    {
+        "intermediate_1": "lian2suo3",
+        "intermediate_2": "liánsuǒ",
+        "native_1": "chain (store etc); to interlock",
+        "primary_1": "连锁",
+        "primary_2": "連鎖"
+    },
+    {
+        "intermediate_1": "lian2tong2",
+        "intermediate_2": "liántóng",
+        "native_1": "together with; along with",
+        "primary_1": "连同",
+        "primary_2": "連同"
+    },
+    {
+        "intermediate_1": "lian2huan1",
+        "intermediate_2": "liánhuān",
+        "native_1": "have a get-together",
+        "primary_1": "联欢",
+        "primary_2": "聯歡"
+    },
+    {
+        "intermediate_1": "lian2luo4",
+        "intermediate_2": "liánluò",
+        "native_1": "communication; to contact",
+        "primary_1": "联络",
+        "primary_2": "聯絡"
+    },
+    {
+        "intermediate_1": "lian2meng2",
+        "intermediate_2": "liánméng",
+        "native_1": "alliance; union; coalition",
+        "primary_1": "联盟",
+        "primary_2": "聯盟"
+    },
+    {
+        "intermediate_1": "lian2xiang3",
+        "intermediate_2": "liánxiǎng",
+        "native_1": "to associate (cognitively); to make an associative connection; mental association; word prediction and auto-complete functions of input method editing programs; abbr. for 联想集团 Lenovo Group (PRC computer firm)",
+        "primary_1": "联想",
+        "primary_2": "聯想"
+    },
+    {
+        "intermediate_1": "lian2jie2",
+        "intermediate_2": "liánjié",
+        "native_1": "honest; incorruptible",
+        "primary_1": "廉洁",
+        "primary_2": "廉潔"
+    },
+    {
+        "intermediate_1": "liang2xin1",
+        "intermediate_2": "liángxīn",
+        "native_1": "conscience",
+        "primary_1": "良心",
+        "primary_2": "良心"
+    },
+    {
+        "intermediate_1": "liang4jie3",
+        "intermediate_2": "liàngjiě",
+        "native_1": "understanding; make an allowance for; forgive",
+        "primary_1": "谅解",
+        "primary_2": "諒解"
+    },
+    {
+        "intermediate_1": "liang4",
+        "intermediate_2": "liàng",
+        "native_1": "dry in the air/sun; (colloquial) snub or ignore",
+        "primary_1": "晾",
+        "primary_2": "晾"
+    },
+    {
+        "intermediate_1": "liao2kuo4",
+        "intermediate_2": "liáokuò",
+        "native_1": "vast; extensive",
+        "primary_1": "辽阔",
+        "primary_2": "遼闊"
+    },
+    {
+        "intermediate_1": "lie4ju3",
+        "intermediate_2": "lièjǔ",
+        "native_1": "make a list; enumerate",
+        "primary_1": "列举",
+        "primary_2": "列舉"
+    },
+    {
+        "intermediate_1": "lin2chuang2",
+        "intermediate_2": "línchuáng",
+        "native_1": "clinical",
+        "primary_1": "临床",
+        "primary_2": "臨床"
+    },
+    {
+        "intermediate_1": "lin2",
+        "intermediate_2": "lín",
+        "native_1": "to drain; to drip; drench",
+        "primary_1": "淋",
+        "primary_2": "淋"
+    },
+    {
+        "intermediate_1": "lin4se4",
+        "intermediate_2": "lìnsè",
+        "native_1": "stingy; mean; miserly",
+        "primary_1": "吝啬",
+        "primary_2": "吝啬"
+    },
+    {
+        "intermediate_1": "ling2li4",
+        "intermediate_2": "línglì",
+        "native_1": "clever; witty; intelligent",
+        "primary_1": "伶俐",
+        "primary_2": "伶俐"
+    },
+    {
+        "intermediate_1": "ling2gan3",
+        "intermediate_2": "línggǎn",
+        "native_1": "inspiration; insight; a burst of creativity in scientific or artistic endeavor",
+        "primary_1": "灵感",
+        "primary_2": "靈感"
+    },
+    {
+        "intermediate_1": "ling2hun2",
+        "intermediate_2": "línghún",
+        "native_1": "soul; spirit; conscience",
+        "primary_1": "灵魂",
+        "primary_2": "靈魂"
+    },
+    {
+        "intermediate_1": "ling2min3",
+        "intermediate_2": "língmǐn",
+        "native_1": "sensitive",
+        "primary_1": "灵敏",
+        "primary_2": "靈敏"
+    },
+    {
+        "intermediate_1": "ling2chen2",
+        "intermediate_2": "língchén",
+        "native_1": "early in the morning",
+        "primary_1": "凌晨",
+        "primary_2": "淩晨"
+    },
+    {
+        "intermediate_1": "ling2xing1",
+        "intermediate_2": "língxīng",
+        "native_1": "partial; scattered; fragmentary",
+        "primary_1": "零星",
+        "primary_2": "零星"
+    },
+    {
+        "intermediate_1": "ling3hui4",
+        "intermediate_2": "lǐnghuì",
+        "native_1": "understand; comprehend; grasp",
+        "primary_1": "领会",
+        "primary_2": "領會"
+    },
+    {
+        "intermediate_1": "ling3shi4guan3",
+        "intermediate_2": "lǐngshìguǎn",
+        "native_1": "consulate",
+        "primary_1": "领事馆",
+        "primary_2": "領事館"
+    },
+    {
+        "intermediate_1": "ling3tu3",
+        "intermediate_2": "lǐngtǔ",
+        "native_1": "territory",
+        "primary_1": "领土",
+        "primary_2": "領土"
+    },
+    {
+        "intermediate_1": "ling3wu4",
+        "intermediate_2": "lǐngwù",
+        "native_1": "comprehend; grasp; fathom",
+        "primary_1": "领悟",
+        "primary_2": "領悟"
+    },
+    {
+        "intermediate_1": "ling3xian1",
+        "intermediate_2": "lǐngxiān",
+        "native_1": "leadership; to lead; be in front",
+        "primary_1": "领先",
+        "primary_2": "領先"
+    },
+    {
+        "intermediate_1": "ling3xiu4",
+        "intermediate_2": "lǐngxiù",
+        "native_1": "leader",
+        "primary_1": "领袖",
+        "primary_2": "領袖"
+    },
+    {
+        "intermediate_1": "liu1",
+        "intermediate_2": "liū",
+        "native_1": "slip away; to skate; to glide",
+        "primary_1": "溜",
+        "primary_2": "溜"
+    },
+    {
+        "intermediate_1": "liu2lian4",
+        "intermediate_2": "liúliàn",
+        "native_1": "be reluctant to leave",
+        "primary_1": "留恋",
+        "primary_2": "留戀"
+    },
+    {
+        "intermediate_1": "liun2ian4",
+        "intermediate_2": "liúniàn",
+        "native_1": "to keep as a souvenir",
+        "primary_1": "留念",
+        "primary_2": "留念"
+    },
+    {
+        "intermediate_1": "liu2 shen2",
+        "intermediate_2": "liú shén",
+        "native_1": "(idiom) take care to ...; be careful of ...",
+        "primary_1": "留神",
+        "primary_2": "留神"
+    },
+    {
+        "intermediate_1": "liu2lang4",
+        "intermediate_2": "liúlàng",
+        "native_1": "drift about; wander",
+        "primary_1": "流浪",
+        "primary_2": "流浪"
+    },
+    {
+        "intermediate_1": "liu2lu4",
+        "intermediate_2": "liúlù",
+        "native_1": "express; reveal (one's thoughts or feelings)",
+        "primary_1": "流露",
+        "primary_2": "流露"
+    },
+    {
+        "intermediate_1": "liu2mang2",
+        "intermediate_2": "liúmáng",
+        "native_1": "rogue; hooligan; gangster",
+        "primary_1": "流氓",
+        "primary_2": "流氓"
+    },
+    {
+        "intermediate_1": "liu2tong1",
+        "intermediate_2": "liútōng",
+        "native_1": "circulate; currency",
+        "primary_1": "流通",
+        "primary_2": "流通"
+    },
+    {
+        "intermediate_1": "long2ya3",
+        "intermediate_2": "lóngyǎ",
+        "native_1": "deaf and dumb; deaf-mute",
+        "primary_1": "聋哑",
+        "primary_2": "聾啞"
+    },
+    {
+        "intermediate_1": "long2zhong4",
+        "intermediate_2": "lóngzhòng",
+        "native_1": "grand; prosperous; ceremonious",
+        "primary_1": "隆重",
+        "primary_2": "隆重"
+    },
+    {
+        "intermediate_1": "long3duan4",
+        "intermediate_2": "lǒngduàn",
+        "native_1": "monopoly",
+        "primary_1": "垄断",
+        "primary_2": "壟斷"
+    },
+    {
+        "intermediate_1": "long3zhao4",
+        "intermediate_2": "lǒngzhào",
+        "native_1": "envelop; to shroud; be masked by",
+        "primary_1": "笼罩",
+        "primary_2": "籠罩"
+    },
+    {
+        "intermediate_1": "lou3",
+        "intermediate_2": "lǒu",
+        "native_1": "to hug; to embrace",
+        "primary_1": "搂",
+        "primary_2": "摟"
+    },
+    {
+        "intermediate_1": "lu2zao4",
+        "intermediate_2": "lúzào",
+        "native_1": "kitchen range; cooking range; stovetop range",
+        "primary_1": "炉灶",
+        "primary_2": "爐竈"
+    },
+    {
+        "intermediate_1": "lü3ci4",
+        "intermediate_2": "lǚcì",
+        "native_1": "repeatedly; time and again; frequently",
+        "primary_1": "屡次",
+        "primary_2": "屢次"
+    },
+    {
+        "intermediate_1": "lü3xing2",
+        "intermediate_2": "lǚxíng",
+        "native_1": "fulfill (one's obligations); carry out",
+        "primary_1": "履行",
+        "primary_2": "履行"
+    },
+    {
+        "intermediate_1": "lüe4duo2",
+        "intermediate_2": "lüèduó",
+        "native_1": "to plunder; rob; pillage",
+        "primary_1": "掠夺",
+        "primary_2": "掠奪"
+    },
+    {
+        "intermediate_1": "lun2chuan2",
+        "intermediate_2": "lúnchuán",
+        "native_1": "steamship",
+        "primary_1": "轮船",
+        "primary_2": "輪船"
+    },
+    {
+        "intermediate_1": "lun2kuo4",
+        "intermediate_2": "lúnkuò",
+        "native_1": "outline; silhouette",
+        "primary_1": "轮廓",
+        "primary_2": "輪廓"
+    },
+    {
+        "intermediate_1": "lun2tai1",
+        "intermediate_2": "lúntāi",
+        "native_1": "tire (of a wheel)",
+        "primary_1": "轮胎",
+        "primary_2": "輪胎"
+    },
+    {
+        "intermediate_1": "lun4tan2",
+        "intermediate_2": "lùntán",
+        "native_1": "forum",
+        "primary_1": "论坛",
+        "primary_2": "論壇"
+    },
+    {
+        "intermediate_1": "lun4zheng4",
+        "intermediate_2": "lùnzhèng",
+        "native_1": "prove a point; expound on; argumentation",
+        "primary_1": "论证",
+        "primary_2": "論證"
+    },
+    {
+        "intermediate_1": "luo1suo",
+        "intermediate_2": "luōsuo",
+        "native_1": "long-winded; wordy; troublesome; pesky",
+        "primary_1": "啰唆",
+        "primary_2": "啰唆"
+    },
+    {
+        "intermediate_1": "luo4yi4bu4jue2",
+        "intermediate_2": "luòyìbùjué",
+        "native_1": "endless stream",
+        "primary_1": "络绎不绝",
+        "primary_2": "絡繹不絕"
+    },
+    {
+        "intermediate_1": "luo4cheng2",
+        "intermediate_2": "luòchéng",
+        "native_1": "complete a construction project",
+        "primary_1": "落成",
+        "primary_2": "落成"
+    },
+    {
+        "intermediate_1": "luo4shi2",
+        "intermediate_2": "luòshí",
+        "native_1": "workable; implement",
+        "primary_1": "落实",
+        "primary_2": "落實"
+    },
+    {
+        "intermediate_1": "ma2bi4",
+        "intermediate_2": "mábì",
+        "native_1": "paralysis; palsy; numbness",
+        "primary_1": "麻痹",
+        "primary_2": "麻痹"
+    },
+    {
+        "intermediate_1": "ma2mu4",
+        "intermediate_2": "mámù",
+        "native_1": "numb",
+        "primary_1": "麻木",
+        "primary_2": "麻木"
+    },
+    {
+        "intermediate_1": "ma2zui4",
+        "intermediate_2": "mázuì",
+        "native_1": "anesthesia",
+        "primary_1": "麻醉",
+        "primary_2": "麻醉"
+    },
+    {
+        "intermediate_1": "ma3tou",
+        "intermediate_2": "mǎtou",
+        "native_1": "dock; wharf",
+        "primary_1": "码头",
+        "primary_2": "碼頭"
+    },
+    {
+        "intermediate_1": "ma3yi3",
+        "intermediate_2": "mǎyǐ",
+        "native_1": "ant",
+        "primary_1": "蚂蚁",
+        "primary_2": "螞蟻"
+    },
+    {
+        "intermediate_1": "ma, ma2",
+        "intermediate_2": "ma, má",
+        "native_1": "(used to persuade somebody to do something); (particle indicating obviousness) | (colloqial) what?",
+        "primary_1": "嘛",
+        "primary_2": "嘛"
+    },
+    {
+        "intermediate_1": "mai2fu",
+        "intermediate_2": "máifu",
+        "native_1": "ambush; lie in ambush",
+        "primary_1": "埋伏",
+        "primary_2": "埋伏"
+    },
+    {
+        "intermediate_1": "mai2mo4",
+        "intermediate_2": "máimò",
+        "native_1": "oblivion; bury; neglect",
+        "primary_1": "埋没",
+        "primary_2": "埋沒"
+    },
+    {
+        "intermediate_1": "mai2zang4",
+        "intermediate_2": "máizàng",
+        "native_1": "bury",
+        "primary_1": "埋葬",
+        "primary_2": "埋葬"
+    },
+    {
+        "intermediate_1": "mai4",
+        "intermediate_2": "mài",
+        "native_1": "to step; stride",
+        "primary_1": "迈",
+        "primary_2": "邁"
+    },
+    {
+        "intermediate_1": "mai4bo2",
+        "intermediate_2": "màibó",
+        "native_1": "pulse; throbbing",
+        "primary_1": "脉搏",
+        "primary_2": "脈搏"
+    },
+    {
+        "intermediate_1": "man2yuan4",
+        "intermediate_2": "mányuàn",
+        "native_1": "complain; blame; connotes sb or sth is to blame",
+        "primary_1": "埋怨",
+        "primary_2": "埋怨"
+    },
+    {
+        "intermediate_1": "man4yan2",
+        "intermediate_2": "mànyán",
+        "native_1": "extend; spread; to creep",
+        "primary_1": "蔓延",
+        "primary_2": "蔓延"
+    },
+    {
+        "intermediate_1": "man4chang2",
+        "intermediate_2": "màncháng",
+        "native_1": "very long; endless",
+        "primary_1": "漫长",
+        "primary_2": "漫長"
+    },
+    {
+        "intermediate_1": "man4hua4",
+        "intermediate_2": "mànhuà",
+        "native_1": "comics; manga",
+        "primary_1": "漫画",
+        "primary_2": "漫畫"
+    },
+    {
+        "intermediate_1": "man4xing4",
+        "intermediate_2": "mànxìng",
+        "native_1": "slow and patient; chronic (disease)",
+        "primary_1": "慢性",
+        "primary_2": "慢性"
+    },
+    {
+        "intermediate_1": "mang2lu4",
+        "intermediate_2": "mánglù",
+        "native_1": "be busy; bustling",
+        "primary_1": "忙碌",
+        "primary_2": "忙碌"
+    },
+    {
+        "intermediate_1": "mang2mu4",
+        "intermediate_2": "mángmù",
+        "native_1": "blindness; aimless",
+        "primary_1": "盲目",
+        "primary_2": "盲目"
+    },
+    {
+        "intermediate_1": "mang2mang2",
+        "intermediate_2": "mángmáng",
+        "native_1": "boundless; vast and obscure",
+        "primary_1": "茫茫",
+        "primary_2": "茫茫"
+    },
+    {
+        "intermediate_1": "mang2ran2",
+        "intermediate_2": "mángrán",
+        "native_1": "unseeing; ignorant; have no knowledge of sth.",
+        "primary_1": "茫然",
+        "primary_2": "茫然"
+    },
+    {
+        "intermediate_1": "mao4sheng4",
+        "intermediate_2": "màoshèng",
+        "native_1": "exuberance; luxuriant",
+        "primary_1": "茂盛",
+        "primary_2": "茂盛"
+    },
+    {
+        "intermediate_1": "mao4chong1",
+        "intermediate_2": "màochōng",
+        "native_1": "pretend to be (somebody or something else); pass (somebody or something) off as; impersonate",
+        "primary_1": "冒充",
+        "primary_2": "冒充"
+    },
+    {
+        "intermediate_1": "mao4fan4",
+        "intermediate_2": "màofàn",
+        "native_1": "to offend",
+        "primary_1": "冒犯",
+        "primary_2": "冒犯"
+    },
+    {
+        "intermediate_1": "mei2",
+        "intermediate_2": "méi",
+        "native_1": "(mw for coins, rings, medals)",
+        "primary_1": "枚",
+        "primary_2": "枚"
+    },
+    {
+        "intermediate_1": "mei2jie4",
+        "intermediate_2": "méijiè",
+        "native_1": "media; medium",
+        "primary_1": "媒介",
+        "primary_2": "媒介"
+    },
+    {
+        "intermediate_1": "mei3guan1",
+        "intermediate_2": "měiguān",
+        "native_1": "pleasing to the eye; beautiful; artistic",
+        "primary_1": "美观",
+        "primary_2": "美觀"
+    },
+    {
+        "intermediate_1": "mei3man3",
+        "intermediate_2": "měimǎn",
+        "native_1": "happy; blissful",
+        "primary_1": "美满",
+        "primary_2": "美滿"
+    },
+    {
+        "intermediate_1": "mei3miao4",
+        "intermediate_2": "měimiào",
+        "native_1": "beautiful (when describing a work of art); wonderful; splendid",
+        "primary_1": "美妙",
+        "primary_2": "美妙"
+    },
+    {
+        "intermediate_1": "meng2ya2",
+        "intermediate_2": "méngyá",
+        "native_1": "sprout; bud; germ of a plant",
+        "primary_1": "萌芽",
+        "primary_2": "萌芽"
+    },
+    {
+        "intermediate_1": "meng3lie4",
+        "intermediate_2": "měngliè",
+        "native_1": "fierce; violent",
+        "primary_1": "猛烈",
+        "primary_2": "猛烈"
+    },
+    {
+        "intermediate_1": "mi1",
+        "intermediate_2": "mī",
+        "native_1": "to squint; to take a nap",
+        "primary_1": "眯",
+        "primary_2": "眯"
+    },
+    {
+        "intermediate_1": "mi2bu3",
+        "intermediate_2": "míbǔ",
+        "native_1": "make up for a deficiency; remedy; offset",
+        "primary_1": "弥补",
+        "primary_2": "彌補"
+    },
+    {
+        "intermediate_1": "mi2man4",
+        "intermediate_2": "mímàn",
+        "native_1": "fill the air; permeate; to suffuse",
+        "primary_1": "弥漫",
+        "primary_2": "彌漫"
+    },
+    {
+        "intermediate_1": "mi2huo4",
+        "intermediate_2": "míhuò",
+        "native_1": "to puzzle; confuse; mystify",
+        "primary_1": "迷惑",
+        "primary_2": "迷惑"
+    },
+    {
+        "intermediate_1": "mi2ren2",
+        "intermediate_2": "mírén",
+        "native_1": "charming; enchanting; cute",
+        "primary_1": "迷人",
+        "primary_2": "迷人"
+    },
+    {
+        "intermediate_1": "mi2xin4",
+        "intermediate_2": "míxìn",
+        "native_1": "superstition; be superstitious",
+        "primary_1": "迷信",
+        "primary_2": "迷信"
+    },
+    {
+        "intermediate_1": "mi2yu3",
+        "intermediate_2": "míyǔ",
+        "native_1": "riddle; conundrum",
+        "primary_1": "谜语",
+        "primary_2": "謎語"
+    },
+    {
+        "intermediate_1": "mi4du4",
+        "intermediate_2": "mìdù",
+        "native_1": "density; thickness; consistency",
+        "primary_1": "密度",
+        "primary_2": "密度"
+    },
+    {
+        "intermediate_1": "mi4feng1",
+        "intermediate_2": "mìfēng",
+        "native_1": "seal up; pressurize",
+        "primary_1": "密封",
+        "primary_2": "密封"
+    },
+    {
+        "intermediate_1": "mian2hua",
+        "intermediate_2": "miánhua",
+        "native_1": "cotton",
+        "primary_1": "棉花",
+        "primary_2": "棉花"
+    },
+    {
+        "intermediate_1": "mian3de",
+        "intermediate_2": "miǎnde",
+        "native_1": "so as not to; so as to avoid",
+        "primary_1": "免得",
+        "primary_2": "免得"
+    },
+    {
+        "intermediate_1": "mian3yi4",
+        "intermediate_2": "miǎnyì",
+        "native_1": "immune",
+        "primary_1": "免疫",
+        "primary_2": "免疫"
+    },
+    {
+        "intermediate_1": "mian3li4",
+        "intermediate_2": "miǎnlì",
+        "native_1": "encourage",
+        "primary_1": "勉励",
+        "primary_2": "勉勵"
+    },
+    {
+        "intermediate_1": "mian3qiang3",
+        "intermediate_2": "miǎnqiǎng",
+        "native_1": "reluctantly; grudgingly; force sb. to do sth.",
+        "primary_1": "勉强",
+        "primary_2": "勉強"
+    },
+    {
+        "intermediate_1": "mian4mao4",
+        "intermediate_2": "miànmào",
+        "native_1": "appearance; looks; features",
+        "primary_1": "面貌",
+        "primary_2": "面貌"
+    },
+    {
+        "intermediate_1": "mian4zi",
+        "intermediate_2": "miànzi",
+        "native_1": "honor; reputation; prestige; face",
+        "primary_1": "面子",
+        "primary_2": "面子"
+    },
+    {
+        "intermediate_1": "miao2hui4",
+        "intermediate_2": "miáohuì",
+        "native_1": "describe; portray",
+        "primary_1": "描绘",
+        "primary_2": "描繪"
+    },
+    {
+        "intermediate_1": "miao2zhun3",
+        "intermediate_2": "miáozhǔn",
+        "native_1": "take aim (a weapon at a target)",
+        "primary_1": "瞄准",
+        "primary_2": "瞄准"
+    },
+    {
+        "intermediate_1": "miao3xiao3",
+        "intermediate_2": "miǎoxiǎo",
+        "native_1": "tiny; minute; negligible",
+        "primary_1": "渺小",
+        "primary_2": "渺小"
+    },
+    {
+        "intermediate_1": "miao3shi4",
+        "intermediate_2": "miǎoshì",
+        "native_1": "treat with contempt",
+        "primary_1": "藐视",
+        "primary_2": "藐視"
+    },
+    {
+        "intermediate_1": "mie4wang2",
+        "intermediate_2": "mièwáng",
+        "native_1": "be destroyed; perish; exterminate; become extinct",
+        "primary_1": "灭亡",
+        "primary_2": "滅亡"
+    },
+    {
+        "intermediate_1": "mie4shi4",
+        "intermediate_2": "mièshì",
+        "native_1": "despise; loathe; disparage; scorn",
+        "primary_1": "蔑视",
+        "primary_2": "蔑視"
+    },
+    {
+        "intermediate_1": "min2jian1",
+        "intermediate_2": "mínjiān",
+        "native_1": "among the people; popular; folk",
+        "primary_1": "民间",
+        "primary_2": "民間"
+    },
+    {
+        "intermediate_1": "min2zhu3",
+        "intermediate_2": "mínzhǔ",
+        "native_1": "democracy",
+        "primary_1": "民主",
+        "primary_2": "民主"
+    },
+    {
+        "intermediate_1": "min3jie2",
+        "intermediate_2": "mǐnjié",
+        "native_1": "nimble; agile; shrewd",
+        "primary_1": "敏捷",
+        "primary_2": "敏捷"
+    },
+    {
+        "intermediate_1": "min3rui4",
+        "intermediate_2": "mǐnruì",
+        "native_1": "keen; sharp; acute; brisk",
+        "primary_1": "敏锐",
+        "primary_2": "敏銳"
+    },
+    {
+        "intermediate_1": "ming2ci4",
+        "intermediate_2": "míngcì",
+        "native_1": "position in a ranking of names",
+        "primary_1": "名次",
+        "primary_2": "名次"
+    },
+    {
+        "intermediate_1": "ming2'e2",
+        "intermediate_2": "míng'é",
+        "native_1": "particular number of people; quota",
+        "primary_1": "名额",
+        "primary_2": "名額"
+    },
+    {
+        "intermediate_1": "ming2 fu4 qi2 shi2",
+        "intermediate_2": "míng fù qí shí",
+        "native_1": "not just in name only; but also in reality",
+        "primary_1": "名副其实",
+        "primary_2": "名副其實"
+    },
+    {
+        "intermediate_1": "ming2yu4",
+        "intermediate_2": "míngyù",
+        "native_1": "fame; reputation; honor; honorary",
+        "primary_1": "名誉",
+        "primary_2": "名譽"
+    },
+    {
+        "intermediate_1": "ming2ming2",
+        "intermediate_2": "míngmíng",
+        "native_1": "obviously; plainly; undoubtedly",
+        "primary_1": "明明",
+        "primary_2": "明明"
+    },
+    {
+        "intermediate_1": "ming2zhi4",
+        "intermediate_2": "míngzhì",
+        "native_1": "wise",
+        "primary_1": "明智",
+        "primary_2": "明智"
+    },
+    {
+        "intermediate_1": "ming4ming2",
+        "intermediate_2": "mìngmíng",
+        "native_1": "give a name; to dub; christen; naming",
+        "primary_1": "命名",
+        "primary_2": "命名"
+    },
+    {
+        "intermediate_1": "mo1suo3",
+        "intermediate_2": "mōsuǒ",
+        "native_1": "feel about; grope around; fumble",
+        "primary_1": "摸索",
+        "primary_2": "摸索"
+    },
+    {
+        "intermediate_1": "mo2fan4",
+        "intermediate_2": "mófàn",
+        "native_1": "model; exemplar",
+        "primary_1": "模范",
+        "primary_2": "模範"
+    },
+    {
+        "intermediate_1": "mo2shi4",
+        "intermediate_2": "móshì",
+        "native_1": "model; pattern; method",
+        "primary_1": "模式",
+        "primary_2": "模式"
+    },
+    {
+        "intermediate_1": "mo2xing2",
+        "intermediate_2": "móxíng",
+        "native_1": "model; mould; matrix; pattern",
+        "primary_1": "模型",
+        "primary_2": "模型"
+    },
+    {
+        "intermediate_1": "mo2",
+        "intermediate_2": "mó",
+        "native_1": "membrane; film",
+        "primary_1": "膜",
+        "primary_2": "膜"
+    },
+    {
+        "intermediate_1": "mo2ca1",
+        "intermediate_2": "mócā",
+        "native_1": "friction; clash (between two parties); conflict",
+        "primary_1": "摩擦",
+        "primary_2": "摩擦"
+    },
+    {
+        "intermediate_1": "mo2he2",
+        "intermediate_2": "móhé",
+        "native_1": "adapt gradually to each other; to consult; break in; wear in",
+        "primary_1": "磨合",
+        "primary_2": "磨合"
+    },
+    {
+        "intermediate_1": "mo2gui3",
+        "intermediate_2": "móguǐ",
+        "native_1": "devil; demon; monster",
+        "primary_1": "魔鬼",
+        "primary_2": "魔鬼"
+    },
+    {
+        "intermediate_1": "mo2shu4",
+        "intermediate_2": "móshù",
+        "native_1": "magic",
+        "primary_1": "魔术",
+        "primary_2": "魔術"
+    },
+    {
+        "intermediate_1": "mo3sha1",
+        "intermediate_2": "mǒshā",
+        "native_1": "write off; erase; remove from evidence",
+        "primary_1": "抹杀",
+        "primary_2": "抹殺"
+    },
+    {
+        "intermediate_1": "mo4ming2qi2miao4",
+        "intermediate_2": "mòmíngqímiào",
+        "native_1": "odd; baffling; unaccountable",
+        "primary_1": "莫名其妙",
+        "primary_2": "莫名其妙"
+    },
+    {
+        "intermediate_1": "mo4shui3er",
+        "intermediate_2": "mòshuǐer",
+        "native_1": "ink",
+        "primary_1": "墨水儿",
+        "primary_2": "墨水兒"
+    },
+    {
+        "intermediate_1": "mo4mo4",
+        "intermediate_2": "mòmò",
+        "native_1": "in silence; not speaking",
+        "primary_1": "默默",
+        "primary_2": "默默"
+    },
+    {
+        "intermediate_1": "mou2qiu2",
+        "intermediate_2": "móuqiú",
+        "native_1": "seek; strive for; try to get",
+        "primary_1": "谋求",
+        "primary_2": "謀求"
+    },
+    {
+        "intermediate_1": "mu2yang4",
+        "intermediate_2": "múyàng",
+        "native_1": "appearance; form; approximation",
+        "primary_1": "模样",
+        "primary_2": "模樣"
+    },
+    {
+        "intermediate_1": "mu3yu3",
+        "intermediate_2": "mǔyǔ",
+        "native_1": "native/mother tongue",
+        "primary_1": "母语",
+        "primary_2": "母語"
+    },
+    {
+        "intermediate_1": "mu4du3",
+        "intermediate_2": "mùdǔ",
+        "native_1": "witness; see first hand",
+        "primary_1": "目睹",
+        "primary_2": "目睹"
+    },
+    {
+        "intermediate_1": "mu4guang1",
+        "intermediate_2": "mùguāng",
+        "native_1": "sight; vision; view",
+        "primary_1": "目光",
+        "primary_2": "目光"
+    },
+    {
+        "intermediate_1": "mu4yu4",
+        "intermediate_2": "mùyù",
+        "native_1": "take a bath; revel; immerse",
+        "primary_1": "沐浴",
+        "primary_2": "沐浴"
+    },
+    {
+        "intermediate_1": "na2shou3",
+        "intermediate_2": "náshǒu",
+        "native_1": "good at; adept",
+        "primary_1": "拿手",
+        "primary_2": "拿手"
+    },
+    {
+        "intermediate_1": "na4 men4r",
+        "intermediate_2": "nà mènr",
+        "native_1": "feel puzzled; bewildered",
+        "primary_1": "纳闷儿",
+        "primary_2": "納悶兒"
+    },
+    {
+        "intermediate_1": "nai4yong4",
+        "intermediate_2": "nàiyòng",
+        "native_1": "durable",
+        "primary_1": "耐用",
+        "primary_2": "耐用"
+    },
+    {
+        "intermediate_1": "nan2yuan2bei3zhe2",
+        "intermediate_2": "nányuánběizhé",
+        "native_1": "at odds with; act in a way that defeats one's purpose",
+        "primary_1": "南辕北辙",
+        "primary_2": "南轅北轍"
+    },
+    {
+        "intermediate_1": "nan2de2",
+        "intermediate_2": "nándé",
+        "native_1": "hard to come by; difficult to get; rare",
+        "primary_1": "难得",
+        "primary_2": "難得"
+    },
+    {
+        "intermediate_1": "nan2kan1",
+        "intermediate_2": "nánkān",
+        "native_1": "hard to take; endure; embarrassed",
+        "primary_1": "难堪",
+        "primary_2": "難堪"
+    },
+    {
+        "intermediate_1": "nan2neng2ke3gui4",
+        "intermediate_2": "nánnéngkěguì",
+        "native_1": "estimable; extremely good",
+        "primary_1": "难能可贵",
+        "primary_2": "難能可貴"
+    },
+    {
+        "intermediate_1": "nao3huo3",
+        "intermediate_2": "nǎohuǒ",
+        "native_1": "get angry; irritated; annoy",
+        "primary_1": "恼火",
+        "primary_2": "惱火"
+    },
+    {
+        "intermediate_1": "nei4han2",
+        "intermediate_2": "nèihán",
+        "native_1": "connotation",
+        "primary_1": "内涵",
+        "primary_2": "內涵"
+    },
+    {
+        "intermediate_1": "nei4mu4",
+        "intermediate_2": "nèimù",
+        "native_1": "inside story; non-public information; behind the scenes",
+        "primary_1": "内幕",
+        "primary_2": "內幕"
+    },
+    {
+        "intermediate_1": "nei4zai4",
+        "intermediate_2": "nèizài",
+        "native_1": "intrinsic; innate",
+        "primary_1": "内在",
+        "primary_2": "內在"
+    },
+    {
+        "intermediate_1": "neng2liang4",
+        "intermediate_2": "néngliàng",
+        "native_1": "energy; capabilities",
+        "primary_1": "能量",
+        "primary_2": "能量"
+    },
+    {
+        "intermediate_1": "ni3ding4",
+        "intermediate_2": "nǐdìng",
+        "native_1": "make an initial draft; draw up",
+        "primary_1": "拟定",
+        "primary_2": "擬定"
+    },
+    {
+        "intermediate_1": "ni4xing2",
+        "intermediate_2": "nìxíng",
+        "native_1": "go/drive against the traffic; go in the wrong direction; regress; retrograde",
+        "primary_1": "逆行",
+        "primary_2": "逆行"
+    },
+    {
+        "intermediate_1": "nian2du4",
+        "intermediate_2": "niándù",
+        "native_1": "year (e.g. school year, fiscal year, etc.); annual",
+        "primary_1": "年度",
+        "primary_2": "年度"
+    },
+    {
+        "intermediate_1": "nie1",
+        "intermediate_2": "niē",
+        "native_1": "to pinch (with one's fingers); knead",
+        "primary_1": "捏",
+        "primary_2": "捏"
+    },
+    {
+        "intermediate_1": "ning2gu4",
+        "intermediate_2": "nínggù",
+        "native_1": "curdle; freeze; solidify; congeal",
+        "primary_1": "凝固",
+        "primary_2": "凝固"
+    },
+    {
+        "intermediate_1": "ning2ju4",
+        "intermediate_2": "níngjù",
+        "native_1": "agglomeration; agglomerate; cohesion; coherence",
+        "primary_1": "凝聚",
+        "primary_2": "凝聚"
+    },
+    {
+        "intermediate_1": "ning2shi4",
+        "intermediate_2": "níngshì",
+        "native_1": "gaze; stare",
+        "primary_1": "凝视",
+        "primary_2": "凝視"
+    },
+    {
+        "intermediate_1": "ning2",
+        "intermediate_2": "níng",
+        "native_1": "wring; to pinch",
+        "primary_1": "拧",
+        "primary_2": "擰"
+    },
+    {
+        "intermediate_1": "ning4ken3",
+        "intermediate_2": "nìngkěn",
+        "native_1": "would rather ...; it would be better",
+        "primary_1": "宁肯",
+        "primary_2": "甯肯"
+    },
+    {
+        "intermediate_1": "ning4yuan4",
+        "intermediate_2": "nìngyuàn",
+        "native_1": "would rather; better",
+        "primary_1": "宁愿",
+        "primary_2": "甯願"
+    },
+    {
+        "intermediate_1": "niu3zhuan3",
+        "intermediate_2": "niǔzhuǎn",
+        "native_1": "to reverse; turn around (an undesirable situation)",
+        "primary_1": "扭转",
+        "primary_2": "扭轉"
+    },
+    {
+        "intermediate_1": "niu3kou4r",
+        "intermediate_2": "niǔkòur",
+        "native_1": "button",
+        "primary_1": "纽扣儿",
+        "primary_2": "紐扣兒"
+    },
+    {
+        "intermediate_1": "nong2li4",
+        "intermediate_2": "nónglì",
+        "native_1": "agricultural calendar; lunar calendar",
+        "primary_1": "农历",
+        "primary_2": "農曆"
+    },
+    {
+        "intermediate_1": "nong2hou4",
+        "intermediate_2": "nónghòu",
+        "native_1": "dense; thick (fog, clouds, etc.)",
+        "primary_1": "浓厚",
+        "primary_2": "濃厚"
+    },
+    {
+        "intermediate_1": "nu2li4",
+        "intermediate_2": "núlì",
+        "native_1": "slave",
+        "primary_1": "奴隶",
+        "primary_2": "奴隸"
+    },
+    {
+        "intermediate_1": "nüe4dai4",
+        "intermediate_2": "nüèdài",
+        "native_1": "to abuse; maltreat; tyrannize",
+        "primary_1": "虐待",
+        "primary_2": "虐待"
+    },
+    {
+        "intermediate_1": "nuo2",
+        "intermediate_2": "nuó",
+        "native_1": "shift; move",
+        "primary_1": "挪",
+        "primary_2": "挪"
+    },
+    {
+        "intermediate_1": "o4",
+        "intermediate_2": "ò",
+        "native_1": "oh (indicates understanding)",
+        "primary_1": "哦",
+        "primary_2": "哦"
+    },
+    {
+        "intermediate_1": "ou1da3",
+        "intermediate_2": "ōudǎ",
+        "native_1": "beat up; hit",
+        "primary_1": "殴打",
+        "primary_2": "毆打"
+    },
+    {
+        "intermediate_1": "ou3tu4",
+        "intermediate_2": "ǒutù",
+        "native_1": "to vomit; retch; nausea",
+        "primary_1": "呕吐",
+        "primary_2": "嘔吐"
+    },
+    {
+        "intermediate_1": "ou3xiang4",
+        "intermediate_2": "ǒuxiàng",
+        "native_1": "Idol",
+        "primary_1": "偶像",
+        "primary_2": "偶像"
+    },
+    {
+        "intermediate_1": "pa1",
+        "intermediate_2": "pā",
+        "native_1": "lie on one's stomach",
+        "primary_1": "趴",
+        "primary_2": "趴"
+    },
+    {
+        "intermediate_1": "pai2chi4",
+        "intermediate_2": "páichì",
+        "native_1": "to reject; repulse; exclude",
+        "primary_1": "排斥",
+        "primary_2": "排斥"
+    },
+    {
+        "intermediate_1": "pai2chu2",
+        "intermediate_2": "páichú",
+        "native_1": "eliminate; get rid of; remove",
+        "primary_1": "排除",
+        "primary_2": "排除"
+    },
+    {
+        "intermediate_1": "pai2fang4",
+        "intermediate_2": "páifàng",
+        "native_1": "to discharge; emit",
+        "primary_1": "排放",
+        "primary_2": "排放"
+    },
+    {
+        "intermediate_1": "pai2lian4",
+        "intermediate_2": "páiliàn",
+        "native_1": "to rehearse",
+        "primary_1": "排练",
+        "primary_2": "排練"
+    },
+    {
+        "intermediate_1": "pai2huai2",
+        "intermediate_2": "páihuái",
+        "native_1": "pace back and forth; hesitate; waver",
+        "primary_1": "徘徊",
+        "primary_2": "徘徊"
+    },
+    {
+        "intermediate_1": "pai4bie2",
+        "intermediate_2": "pàibié",
+        "native_1": "denomination; group; school; faction; school of thought; sect",
+        "primary_1": "派别",
+        "primary_2": "派別"
+    },
+    {
+        "intermediate_1": "pai4qian3",
+        "intermediate_2": "pàiqiǎn",
+        "native_1": "send (on a mission); dispatch",
+        "primary_1": "派遣",
+        "primary_2": "派遣"
+    },
+    {
+        "intermediate_1": "pan1deng1",
+        "intermediate_2": "pāndēng",
+        "native_1": "to climb; clamber; to pull oneself up",
+        "primary_1": "攀登",
+        "primary_2": "攀登"
+    },
+    {
+        "intermediate_1": "pan2xuan2",
+        "intermediate_2": "pánxuán",
+        "native_1": "spiral; coil; circle; go around",
+        "primary_1": "盘旋",
+        "primary_2": "盤旋"
+    },
+    {
+        "intermediate_1": "pan4jue2",
+        "intermediate_2": "pànjué",
+        "native_1": "judgment (by a court of law); adjudicate",
+        "primary_1": "判决",
+        "primary_2": "判決"
+    },
+    {
+        "intermediate_1": "pan4",
+        "intermediate_2": "pàn",
+        "native_1": "riverbank; side; boundary",
+        "primary_1": "畔",
+        "primary_2": "畔"
+    },
+    {
+        "intermediate_1": "pang2da4",
+        "intermediate_2": "pángdà",
+        "native_1": "enormous; huge; tremendous",
+        "primary_1": "庞大",
+        "primary_2": "龐大"
+    },
+    {
+        "intermediate_1": "pao1qi4",
+        "intermediate_2": "pāoqì",
+        "native_1": "discard; abandon; dump (sb)",
+        "primary_1": "抛弃",
+        "primary_2": "抛棄"
+    },
+    {
+        "intermediate_1": "pao4mo4",
+        "intermediate_2": "pàomò",
+        "native_1": "foam; (soap bubble); (economic) bubble",
+        "primary_1": "泡沫",
+        "primary_2": "泡沫"
+    },
+    {
+        "intermediate_1": "pei2yu4",
+        "intermediate_2": "péiyù",
+        "native_1": "to train; nurture; to breed",
+        "primary_1": "培育",
+        "primary_2": "培育"
+    },
+    {
+        "intermediate_1": "pei4bei4",
+        "intermediate_2": "pèibèi",
+        "native_1": "provide; outfit with",
+        "primary_1": "配备",
+        "primary_2": "配備"
+    },
+    {
+        "intermediate_1": "pei4'ou3",
+        "intermediate_2": "pèi'ǒu",
+        "native_1": "mate; consort; spouse",
+        "primary_1": "配偶",
+        "primary_2": "配偶"
+    },
+    {
+        "intermediate_1": "pei4 tao4",
+        "intermediate_2": "pèi tào",
+        "native_1": "form a complete set",
+        "primary_1": "配套",
+        "primary_2": "配套"
+    },
+    {
+        "intermediate_1": "pen2di4",
+        "intermediate_2": "péndì",
+        "native_1": "basin",
+        "primary_1": "盆地",
+        "primary_2": "盆地"
+    },
+    {
+        "intermediate_1": "peng1ren4",
+        "intermediate_2": "pēngrèn",
+        "native_1": "cooking; culinary arts",
+        "primary_1": "烹饪",
+        "primary_2": "烹饪"
+    },
+    {
+        "intermediate_1": "peng3",
+        "intermediate_2": "pěng",
+        "native_1": "hold or carry with both hands facing up",
+        "primary_1": "捧",
+        "primary_2": "捧"
+    },
+    {
+        "intermediate_1": "pi1fa1",
+        "intermediate_2": "pīfā",
+        "native_1": "wholesale",
+        "primary_1": "批发",
+        "primary_2": "批發"
+    },
+    {
+        "intermediate_1": "pi1pan4",
+        "intermediate_2": "pīpàn",
+        "native_1": "criticize; critique",
+        "primary_1": "批判",
+        "primary_2": "批判"
+    },
+    {
+        "intermediate_1": "pi1",
+        "intermediate_2": "pī",
+        "native_1": "split in two; to divide",
+        "primary_1": "劈",
+        "primary_2": "劈"
+    },
+    {
+        "intermediate_1": "pi2ge2",
+        "intermediate_2": "pígé",
+        "native_1": "leather",
+        "primary_1": "皮革",
+        "primary_2": "皮革"
+    },
+    {
+        "intermediate_1": "pi2bei4",
+        "intermediate_2": "píbèi",
+        "native_1": "beaten; exhausted; tired",
+        "primary_1": "疲惫",
+        "primary_2": "疲憊"
+    },
+    {
+        "intermediate_1": "pi2juan4",
+        "intermediate_2": "píjuàn",
+        "native_1": "tired; weary",
+        "primary_1": "疲倦",
+        "primary_2": "疲倦"
+    },
+    {
+        "intermediate_1": "pi4gu",
+        "intermediate_2": "pìgu",
+        "native_1": "butt; rear; rump",
+        "primary_1": "屁股",
+        "primary_2": "屁股"
+    },
+    {
+        "intermediate_1": "pi4ru2",
+        "intermediate_2": "pìrú",
+        "native_1": "for example; for instance; such as",
+        "primary_1": "譬如",
+        "primary_2": "譬如"
+    },
+    {
+        "intermediate_1": "pian1cha1",
+        "intermediate_2": "piānchā",
+        "native_1": "bias; deviation",
+        "primary_1": "偏差",
+        "primary_2": "偏差"
+    },
+    {
+        "intermediate_1": "pian1jian4",
+        "intermediate_2": "piānjiàn",
+        "native_1": "prejudice",
+        "primary_1": "偏见",
+        "primary_2": "偏見"
+    },
+    {
+        "intermediate_1": "pian1pi4",
+        "intermediate_2": "piānpì",
+        "native_1": "remote and isolated; far from the city",
+        "primary_1": "偏僻",
+        "primary_2": "偏僻"
+    },
+    {
+        "intermediate_1": "pian1pian1",
+        "intermediate_2": "piānpiān",
+        "native_1": "unexpectedly; contrary to expectations",
+        "primary_1": "偏偏",
+        "primary_2": "偏偏"
+    },
+    {
+        "intermediate_1": "pian4duan4",
+        "intermediate_2": "piànduàn",
+        "native_1": "part; passage; extract; fragment; snatch",
+        "primary_1": "片断",
+        "primary_2": "片斷"
+    },
+    {
+        "intermediate_1": "pian4ke4",
+        "intermediate_2": "piànkè",
+        "native_1": "a short period of time",
+        "primary_1": "片刻",
+        "primary_2": "片刻"
+    },
+    {
+        "intermediate_1": "piao1fu2",
+        "intermediate_2": "piāofú",
+        "native_1": "superficial; float; hover; drift",
+        "primary_1": "漂浮",
+        "primary_2": "漂浮"
+    },
+    {
+        "intermediate_1": "piao1yang2",
+        "intermediate_2": "piāoyáng",
+        "native_1": "wave in the wind; flutter; fly",
+        "primary_1": "飘扬",
+        "primary_2": "飄揚"
+    },
+    {
+        "intermediate_1": "pie3",
+        "intermediate_2": "piě",
+        "native_1": "left-curving stroke (丿); throw; fling",
+        "primary_1": "撇",
+        "primary_2": "撇"
+    },
+    {
+        "intermediate_1": "pin1bo2",
+        "intermediate_2": "pīnbó",
+        "native_1": "struggle; wrestle",
+        "primary_1": "拼搏",
+        "primary_2": "拼搏"
+    },
+    {
+        "intermediate_1": "pin1 ming4",
+        "intermediate_2": "pīn mìng",
+        "native_1": "risk one's life; desperately; with all one's might",
+        "primary_1": "拼命",
+        "primary_2": "拼命"
+    },
+    {
+        "intermediate_1": "pin2fa2",
+        "intermediate_2": "pínfá",
+        "native_1": "lacking; incomplete",
+        "primary_1": "贫乏",
+        "primary_2": "貧乏"
+    },
+    {
+        "intermediate_1": "pin2kun4",
+        "intermediate_2": "pínkùn",
+        "native_1": "poor; impoverished",
+        "primary_1": "贫困",
+        "primary_2": "貧困"
+    },
+    {
+        "intermediate_1": "pin2fan2",
+        "intermediate_2": "pínfán",
+        "native_1": "frequently; often",
+        "primary_1": "频繁",
+        "primary_2": "頻繁"
+    },
+    {
+        "intermediate_1": "pin2lü4",
+        "intermediate_2": "pínlǜ",
+        "native_1": "frequency",
+        "primary_1": "频率",
+        "primary_2": "頻率"
+    },
+    {
+        "intermediate_1": "pin3chang2",
+        "intermediate_2": "pǐncháng",
+        "native_1": "try; taste a small amount; to sample",
+        "primary_1": "品尝",
+        "primary_2": "品嘗"
+    },
+    {
+        "intermediate_1": "pin3de2",
+        "intermediate_2": "pǐndé",
+        "native_1": "moral character; morality; morals",
+        "primary_1": "品德",
+        "primary_2": "品德"
+    },
+    {
+        "intermediate_1": "pin3zhi4",
+        "intermediate_2": "pǐnzhì",
+        "native_1": "quality; character",
+        "primary_1": "品质",
+        "primary_2": "品質"
+    },
+    {
+        "intermediate_1": "pin3zhong3",
+        "intermediate_2": "pǐnzhǒng",
+        "native_1": "breed; variety",
+        "primary_1": "品种",
+        "primary_2": "品種"
+    },
+    {
+        "intermediate_1": "ping2fan2",
+        "intermediate_2": "píngfán",
+        "native_1": "commonplace; ordinary",
+        "primary_1": "平凡",
+        "primary_2": "平凡"
+    },
+    {
+        "intermediate_1": "ping2mian4",
+        "intermediate_2": "píngmiàn",
+        "native_1": "a plane (i.e. flat surface); type; category",
+        "primary_1": "平面",
+        "primary_2": "平面"
+    },
+    {
+        "intermediate_1": "ping2tan3",
+        "intermediate_2": "píngtǎn",
+        "native_1": "flat",
+        "primary_1": "平坦",
+        "primary_2": "平坦"
+    },
+    {
+        "intermediate_1": "ping2xing2",
+        "intermediate_2": "píngxíng",
+        "native_1": "parallel; concurrent",
+        "primary_1": "平行",
+        "primary_2": "平行"
+    },
+    {
+        "intermediate_1": "ping2yong1",
+        "intermediate_2": "píngyōng",
+        "native_1": "mediocre",
+        "primary_1": "平庸",
+        "primary_2": "平庸"
+    },
+    {
+        "intermediate_1": "ping2yuan2",
+        "intermediate_2": "píngyuán",
+        "native_1": "field; plain; flatlands",
+        "primary_1": "平原",
+        "primary_2": "平原"
+    },
+    {
+        "intermediate_1": "ping2gu1",
+        "intermediate_2": "pínggū",
+        "native_1": "evaluate",
+        "primary_1": "评估",
+        "primary_2": "評估"
+    },
+    {
+        "intermediate_1": "ping2lun4",
+        "intermediate_2": "pínglùn",
+        "native_1": "comment on; discuss; remark",
+        "primary_1": "评论",
+        "primary_2": "評論"
+    },
+    {
+        "intermediate_1": "ping2mu4",
+        "intermediate_2": "píngmù",
+        "native_1": "screen (TV, etc.)",
+        "primary_1": "屏幕",
+        "primary_2": "屏幕"
+    },
+    {
+        "intermediate_1": "ping2zhang4",
+        "intermediate_2": "píngzhàng",
+        "native_1": "wall; barrier; protective screen",
+        "primary_1": "屏障",
+        "primary_2": "屏障"
+    },
+    {
+        "intermediate_1": "po1",
+        "intermediate_2": "pō",
+        "native_1": "slope",
+        "primary_1": "坡",
+        "primary_2": "坡"
+    },
+    {
+        "intermediate_1": "po1",
+        "intermediate_2": "pō",
+        "native_1": "to splash; to spill; rude and unreasonable; brutish",
+        "primary_1": "泼",
+        "primary_2": "潑"
+    },
+    {
+        "intermediate_1": "po1",
+        "intermediate_2": "pō",
+        "native_1": "rather; quite; inclined to one side",
+        "primary_1": "颇",
+        "primary_2": "頗"
+    },
+    {
+        "intermediate_1": "po4bu4ji2dai4",
+        "intermediate_2": "pòbùjídài",
+        "native_1": "be too impatient to wait",
+        "primary_1": "迫不及待",
+        "primary_2": "迫不及待"
+    },
+    {
+        "intermediate_1": "po4hai4",
+        "intermediate_2": "pòhài",
+        "native_1": "persecute; persecution",
+        "primary_1": "迫害",
+        "primary_2": "迫害"
+    },
+    {
+        "intermediate_1": "po4li4",
+        "intermediate_2": "pòlì",
+        "native_1": "make an exception",
+        "primary_1": "破例",
+        "primary_2": "破例"
+    },
+    {
+        "intermediate_1": "po4li4",
+        "intermediate_2": "pòlì",
+        "native_1": "daring resolution; boldness; courage",
+        "primary_1": "魄力",
+        "primary_2": "魄力"
+    },
+    {
+        "intermediate_1": "pu1",
+        "intermediate_2": "pū",
+        "native_1": "to assault; rush at; throw oneself on",
+        "primary_1": "扑",
+        "primary_2": "撲"
+    },
+    {
+        "intermediate_1": "pu4, pu1",
+        "intermediate_2": "pù, pū",
+        "native_1": "bed; store | to spread; to lay",
+        "primary_1": "铺",
+        "primary_2": "鋪"
+    },
+    {
+        "intermediate_1": "pu3shi2",
+        "intermediate_2": "pǔshí",
+        "native_1": "plain; sober; down-to-earth",
+        "primary_1": "朴实",
+        "primary_2": "樸實"
+    },
+    {
+        "intermediate_1": "pu3su4",
+        "intermediate_2": "pǔsù",
+        "native_1": "plain; simple; austerity",
+        "primary_1": "朴素",
+        "primary_2": "樸素"
+    },
+    {
+        "intermediate_1": "pu3ji2",
+        "intermediate_2": "pǔjí",
+        "native_1": "widespread; popular; popularize",
+        "primary_1": "普及",
+        "primary_2": "普及"
+    },
+    {
+        "intermediate_1": "pu4bu4",
+        "intermediate_2": "pùbù",
+        "native_1": "waterfall",
+        "primary_1": "瀑布",
+        "primary_2": "瀑布"
+    },
+    {
+        "intermediate_1": "qi1liang2",
+        "intermediate_2": "qīliáng",
+        "native_1": "desolate; feel like no one likes you",
+        "primary_1": "凄凉",
+        "primary_2": "淒涼"
+    },
+    {
+        "intermediate_1": "qi1wang4",
+        "intermediate_2": "qīwàng",
+        "native_1": "hope; expectation",
+        "primary_1": "期望",
+        "primary_2": "期望"
+    },
+    {
+        "intermediate_1": "qi1xian4",
+        "intermediate_2": "qīxiàn",
+        "native_1": "time limit; deadline; allotted time",
+        "primary_1": "期限",
+        "primary_2": "期限"
+    },
+    {
+        "intermediate_1": "qi1fu",
+        "intermediate_2": "qīfu",
+        "native_1": "to bully; intimidate",
+        "primary_1": "欺负",
+        "primary_2": "欺負"
+    },
+    {
+        "intermediate_1": "qi1pian4",
+        "intermediate_2": "qīpiàn",
+        "native_1": "deceive; to cheat; to dupe",
+        "primary_1": "欺骗",
+        "primary_2": "欺騙"
+    },
+    {
+        "intermediate_1": "qi2quan2",
+        "intermediate_2": "qíquán",
+        "native_1": "complete",
+        "primary_1": "齐全",
+        "primary_2": "齊全"
+    },
+    {
+        "intermediate_1": "qi2xin1xie2li4",
+        "intermediate_2": "qíxīnxiélì",
+        "native_1": "make concerted efforts",
+        "primary_1": "齐心协力",
+        "primary_2": "齊心協力"
+    },
+    {
+        "intermediate_1": "qi2miao4",
+        "intermediate_2": "qímiào",
+        "native_1": "wonderful; fantastic",
+        "primary_1": "奇妙",
+        "primary_2": "奇妙"
+    },
+    {
+        "intermediate_1": "qi2shi4",
+        "intermediate_2": "qíshì",
+        "native_1": "discriminate (against someone)",
+        "primary_1": "歧视",
+        "primary_2": "歧視"
+    },
+    {
+        "intermediate_1": "qi2pao2",
+        "intermediate_2": "qípáo",
+        "native_1": "cheongsam; Chinese-style dress",
+        "primary_1": "旗袍",
+        "primary_2": "旗袍"
+    },
+    {
+        "intermediate_1": "qi2zhi4",
+        "intermediate_2": "qízhì",
+        "native_1": "flag; banner",
+        "primary_1": "旗帜",
+        "primary_2": "旗幟"
+    },
+    {
+        "intermediate_1": "qi3gai4",
+        "intermediate_2": "qǐgài",
+        "native_1": "beggar",
+        "primary_1": "乞丐",
+        "primary_2": "乞丐"
+    },
+    {
+        "intermediate_1": "qi3 you3 ci3 li3",
+        "intermediate_2": "qǐ yǒu cǐ lǐ",
+        "native_1": "outrageous; ridiculous; absurd",
+        "primary_1": "岂有此理",
+        "primary_2": "豈有此理"
+    },
+    {
+        "intermediate_1": "qi3tu2",
+        "intermediate_2": "qǐtú",
+        "native_1": "(to ) attempt; try; attempt",
+        "primary_1": "企图",
+        "primary_2": "企圖"
+    },
+    {
+        "intermediate_1": "qi3cheng2",
+        "intermediate_2": "qǐchéng",
+        "native_1": "set out on a journey",
+        "primary_1": "启程",
+        "primary_2": "啓程"
+    },
+    {
+        "intermediate_1": "qi3meng2",
+        "intermediate_2": "qǐméng",
+        "native_1": "enlighten; enlightenment； instruct the young; to initiate",
+        "primary_1": "启蒙",
+        "primary_2": "啓蒙"
+    },
+    {
+        "intermediate_1": "qi3shi4",
+        "intermediate_2": "qǐshì",
+        "native_1": "enlightenment; revelation",
+        "primary_1": "启示",
+        "primary_2": "啓示"
+    },
+    {
+        "intermediate_1": "qi3shi4",
+        "intermediate_2": "qǐshì",
+        "native_1": "announcement; public information (usually posted on a billboard)",
+        "primary_1": "启事",
+        "primary_2": "啓事"
+    },
+    {
+        "intermediate_1": "qi3 cao3",
+        "intermediate_2": "qǐ cǎo",
+        "native_1": "draft (a bill); draw up (plans)",
+        "primary_1": "起草",
+        "primary_2": "起草"
+    },
+    {
+        "intermediate_1": "qi3chu1",
+        "intermediate_2": "qǐchū",
+        "native_1": "at first; originally; in the beginning",
+        "primary_1": "起初",
+        "primary_2": "起初"
+    },
+    {
+        "intermediate_1": "qi3fu2",
+        "intermediate_2": "qǐfú",
+        "native_1": "ups and downs; with a wavy motion",
+        "primary_1": "起伏",
+        "primary_2": "起伏"
+    },
+    {
+        "intermediate_1": "qi3 hong4",
+        "intermediate_2": "qǐ hòng",
+        "native_1": "gather together; cause a commotion",
+        "primary_1": "起哄",
+        "primary_2": "起哄"
+    },
+    {
+        "intermediate_1": "qi3ma3",
+        "intermediate_2": "qǐmǎ",
+        "native_1": "at the minimum; at the very least",
+        "primary_1": "起码",
+        "primary_2": "起碼"
+    },
+    {
+        "intermediate_1": "qi3yuan2",
+        "intermediate_2": "qǐyuán",
+        "native_1": "origin; originate; come from",
+        "primary_1": "起源",
+        "primary_2": "起源"
+    },
+    {
+        "intermediate_1": "qi4gai4",
+        "intermediate_2": "qìgài",
+        "native_1": "mettle; spirit; gumption",
+        "primary_1": "气概",
+        "primary_2": "氣概"
+    },
+    {
+        "intermediate_1": "qi4gong1",
+        "intermediate_2": "qìgōng",
+        "native_1": "Qi Gong, a system of deep breathing exercises",
+        "primary_1": "气功",
+        "primary_2": "氣功"
+    },
+    {
+        "intermediate_1": "qi4po4",
+        "intermediate_2": "qìpò",
+        "native_1": "spirit; daring; nerve; boldness; enterprising outlook",
+        "primary_1": "气魄",
+        "primary_2": "氣魄"
+    },
+    {
+        "intermediate_1": "qi4se4",
+        "intermediate_2": "qìsè",
+        "native_1": "complexion",
+        "primary_1": "气色",
+        "primary_2": "氣色"
+    },
+    {
+        "intermediate_1": "qi4shi4",
+        "intermediate_2": "qìshì",
+        "native_1": "imposing manner; look of great force or imposing manner",
+        "primary_1": "气势",
+        "primary_2": "氣勢"
+    },
+    {
+        "intermediate_1": "qi4wei4",
+        "intermediate_2": "qìwèi",
+        "native_1": "odor; scent",
+        "primary_1": "气味",
+        "primary_2": "氣味"
+    },
+    {
+        "intermediate_1": "qi4xiang4",
+        "intermediate_2": "qìxiàng",
+        "native_1": "meteorology; atmosphere; phenomenon",
+        "primary_1": "气象",
+        "primary_2": "氣象"
+    },
+    {
+        "intermediate_1": "qi4ya1",
+        "intermediate_2": "qìyā",
+        "native_1": "atmospheric pressure; barometric pressure",
+        "primary_1": "气压",
+        "primary_2": "氣壓"
+    },
+    {
+        "intermediate_1": "qi4zhi4",
+        "intermediate_2": "qìzhì",
+        "native_1": "temperament; disposition",
+        "primary_1": "气质",
+        "primary_2": "氣質"
+    },
+    {
+        "intermediate_1": "qi4jin1wei2zhi3",
+        "intermediate_2": "qìjīnwéizhǐ",
+        "native_1": "until now; so far; to date",
+        "primary_1": "迄今为止",
+        "primary_2": "迄今爲止"
+    },
+    {
+        "intermediate_1": "qi4cai2",
+        "intermediate_2": "qìcái",
+        "native_1": "equipment; material",
+        "primary_1": "器材",
+        "primary_2": "器材"
+    },
+    {
+        "intermediate_1": "qi4guan1",
+        "intermediate_2": "qìguān",
+        "native_1": "organ; apparatus",
+        "primary_1": "器官",
+        "primary_2": "器官"
+    },
+    {
+        "intermediate_1": "qia1",
+        "intermediate_2": "qiā",
+        "native_1": "pick (flowers); pinch; clutch",
+        "primary_1": "掐",
+        "primary_2": "掐"
+    },
+    {
+        "intermediate_1": "qia4tan2",
+        "intermediate_2": "qiàtán",
+        "native_1": "discuss; talk over",
+        "primary_1": "洽谈",
+        "primary_2": "洽談"
+    },
+    {
+        "intermediate_1": "qia4dang4",
+        "intermediate_2": "qiàdàng",
+        "native_1": "appropriate; suitable; proper",
+        "primary_1": "恰当",
+        "primary_2": "恰當"
+    },
+    {
+        "intermediate_1": "qia4 dao4 hao3 chu4",
+        "intermediate_2": "qià dào hǎo chù",
+        "native_1": "just right; it's just perfect",
+        "primary_1": "恰到好处",
+        "primary_2": "恰到好處"
+    },
+    {
+        "intermediate_1": "qia4qiao3",
+        "intermediate_2": "qiàqiǎo",
+        "native_1": "happen by chance; coincidence",
+        "primary_1": "恰巧",
+        "primary_2": "恰巧"
+    },
+    {
+        "intermediate_1": "qian1 fang1 bai3 ji4",
+        "intermediate_2": "qiān fāng bǎi jì",
+        "native_1": "by every possible means",
+        "primary_1": "千方百计",
+        "primary_2": "千方百計"
+    },
+    {
+        "intermediate_1": "qian1jiu4",
+        "intermediate_2": "qiānjiù",
+        "native_1": "humor; yield; adapt to; accommodate (something)",
+        "primary_1": "迁就",
+        "primary_2": "遷就"
+    },
+    {
+        "intermediate_1": "qian1xi3",
+        "intermediate_2": "qiānxǐ",
+        "native_1": "migrate; move; change one's residence",
+        "primary_1": "迁徙",
+        "primary_2": "遷徙"
+    },
+    {
+        "intermediate_1": "qian1",
+        "intermediate_2": "qiān",
+        "native_1": "to lead along; to pull (an animal on a tether)",
+        "primary_1": "牵",
+        "primary_2": "牽"
+    },
+    {
+        "intermediate_1": "qian1che3",
+        "intermediate_2": "qiānchě",
+        "native_1": "implicate; involve",
+        "primary_1": "牵扯",
+        "primary_2": "牽扯"
+    },
+    {
+        "intermediate_1": "qian1zhi4",
+        "intermediate_2": "qiānzhì",
+        "native_1": "control; curb; restrict; impede",
+        "primary_1": "牵制",
+        "primary_2": "牽制"
+    },
+    {
+        "intermediate_1": "qian1xun4",
+        "intermediate_2": "qiānxùn",
+        "native_1": "humble; modest; humility",
+        "primary_1": "谦逊",
+        "primary_2": "謙遜"
+    },
+    {
+        "intermediate_1": "qian1shu3",
+        "intermediate_2": "qiānshǔ",
+        "native_1": "sign (an agreement)",
+        "primary_1": "签署",
+        "primary_2": "簽署"
+    },
+    {
+        "intermediate_1": "qian2jing3",
+        "intermediate_2": "qiánjǐng",
+        "native_1": "outlook; future (prospects); foreground",
+        "primary_1": "前景",
+        "primary_2": "前景"
+    },
+    {
+        "intermediate_1": "qian2ti2",
+        "intermediate_2": "qiántí",
+        "native_1": "premise; precondition",
+        "primary_1": "前提",
+        "primary_2": "前提"
+    },
+    {
+        "intermediate_1": "qian2li4",
+        "intermediate_2": "qiánlì",
+        "native_1": "potential; capacity",
+        "primary_1": "潜力",
+        "primary_2": "潛力"
+    },
+    {
+        "intermediate_1": "qian2shui3",
+        "intermediate_2": "qiánshuǐ",
+        "native_1": "go diving",
+        "primary_1": "潜水",
+        "primary_2": "潛水"
+    },
+    {
+        "intermediate_1": "qian2yi2mo4hua4",
+        "intermediate_2": "qiányímòhuà",
+        "native_1": "exert a subtle influence on sb.'s character, thinking, etc.; impercebtibly influence; to influence secretly",
+        "primary_1": "潜移默化",
+        "primary_2": "潛移默化"
+    },
+    {
+        "intermediate_1": "qian3ze2",
+        "intermediate_2": "qiǎnzé",
+        "native_1": "denounce; condemn; criticize",
+        "primary_1": "谴责",
+        "primary_2": "譴責"
+    },
+    {
+        "intermediate_1": "qiang2zhi4",
+        "intermediate_2": "qiángzhì",
+        "native_1": "enforce; control; coerce",
+        "primary_1": "强制",
+        "primary_2": "強制"
+    },
+    {
+        "intermediate_1": "qiang3jie2",
+        "intermediate_2": "qiǎngjié",
+        "native_1": "rob; looting",
+        "primary_1": "抢劫",
+        "primary_2": "搶劫"
+    },
+    {
+        "intermediate_1": "qiang3jiu4",
+        "intermediate_2": "qiǎngjiù",
+        "native_1": "rescue; to save",
+        "primary_1": "抢救",
+        "primary_2": "搶救"
+    },
+    {
+        "intermediate_1": "qiang3po4",
+        "intermediate_2": "qiǎngpò",
+        "native_1": "compel; to force",
+        "primary_1": "强迫",
+        "primary_2": "強迫"
+    },
+    {
+        "intermediate_1": "qiao2liang2",
+        "intermediate_2": "qiáoliáng",
+        "native_1": "bridge",
+        "primary_1": "桥梁",
+        "primary_2": "橋梁"
+    },
+    {
+        "intermediate_1": "qiao4men2",
+        "intermediate_2": "qiàomén",
+        "native_1": "special tricks",
+        "primary_1": "窍门",
+        "primary_2": "竅門"
+    },
+    {
+        "intermediate_1": "qiao4",
+        "intermediate_2": "qiào",
+        "native_1": "stick up; bend upwards",
+        "primary_1": "翘",
+        "primary_2": "翹"
+    },
+    {
+        "intermediate_1": "qie4shi2",
+        "intermediate_2": "qièshí",
+        "native_1": "realistic; feasible; conscientiously",
+        "primary_1": "切实",
+        "primary_2": "切實"
+    },
+    {
+        "intermediate_1": "qie4'er2bu4she3",
+        "intermediate_2": "qiè'érbùshě",
+        "native_1": "keep on chipping away; work with perseverance",
+        "primary_1": "锲而不舍",
+        "primary_2": "锲而不舍"
+    },
+    {
+        "intermediate_1": "qin1pei4",
+        "intermediate_2": "qīnpèi",
+        "native_1": "admire; have great respect for",
+        "primary_1": "钦佩",
+        "primary_2": "欽佩"
+    },
+    {
+        "intermediate_1": "qin1fan4",
+        "intermediate_2": "qīnfàn",
+        "native_1": "encroach on; infringe on; violation",
+        "primary_1": "侵犯",
+        "primary_2": "侵犯"
+    },
+    {
+        "intermediate_1": "qin1lüe4",
+        "intermediate_2": "qīnlüè",
+        "native_1": "invasion; encroachment; invade",
+        "primary_1": "侵略",
+        "primary_2": "侵略"
+    },
+    {
+        "intermediate_1": "qin1mi4",
+        "intermediate_2": "qīnmì",
+        "native_1": "intimate; close; familiarity",
+        "primary_1": "亲密",
+        "primary_2": "親密"
+    },
+    {
+        "intermediate_1": "qin1re4",
+        "intermediate_2": "qīnrè",
+        "native_1": "intimate; affectionate; warm",
+        "primary_1": "亲热",
+        "primary_2": "親熱"
+    },
+    {
+        "intermediate_1": "qin2jian3",
+        "intermediate_2": "qínjiǎn",
+        "native_1": "hardworking and thrifty",
+        "primary_1": "勤俭",
+        "primary_2": "勤儉"
+    },
+    {
+        "intermediate_1": "qin2lao2",
+        "intermediate_2": "qínláo",
+        "native_1": "hardworking; diligent; industrious",
+        "primary_1": "勤劳",
+        "primary_2": "勤勞"
+    },
+    {
+        "intermediate_1": "qing1ting1",
+        "intermediate_2": "qīngtīng",
+        "native_1": "listen attentively; heed (other people's opinions)",
+        "primary_1": "倾听",
+        "primary_2": "傾聽"
+    },
+    {
+        "intermediate_1": "qing1xiang4",
+        "intermediate_2": "qīngxiàng",
+        "native_1": "trend; tendency; inclination",
+        "primary_1": "倾向",
+        "primary_2": "傾向"
+    },
+    {
+        "intermediate_1": "qing1xie2",
+        "intermediate_2": "qīngxié",
+        "native_1": "incline; lean; to slant; to slope; to tilt",
+        "primary_1": "倾斜",
+        "primary_2": "傾斜"
+    },
+    {
+        "intermediate_1": "qing1che4",
+        "intermediate_2": "qīngchè",
+        "native_1": "clear; limpid",
+        "primary_1": "清澈",
+        "primary_2": "清澈"
+    },
+    {
+        "intermediate_1": "qing1chen2",
+        "intermediate_2": "qīngchén",
+        "native_1": "early morning",
+        "primary_1": "清晨",
+        "primary_2": "清晨"
+    },
+    {
+        "intermediate_1": "qing1chu2",
+        "intermediate_2": "qīngchú",
+        "native_1": "eliminate; get rid of",
+        "primary_1": "清除",
+        "primary_2": "清除"
+    },
+    {
+        "intermediate_1": "qing1jie2",
+        "intermediate_2": "qīngjié",
+        "native_1": "clean; unpolluted; purity",
+        "primary_1": "清洁",
+        "primary_2": "清潔"
+    },
+    {
+        "intermediate_1": "qing1li3",
+        "intermediate_2": "qīnglǐ",
+        "native_1": "cleanup; put in order; check up",
+        "primary_1": "清理",
+        "primary_2": "清理"
+    },
+    {
+        "intermediate_1": "qing1xi1",
+        "intermediate_2": "qīngxī",
+        "native_1": "clear; distinct; clarity",
+        "primary_1": "清晰",
+        "primary_2": "清晰"
+    },
+    {
+        "intermediate_1": "qing1xing3",
+        "intermediate_2": "qīngxǐng",
+        "native_1": "clear-headed; sober; regain consciousness",
+        "primary_1": "清醒",
+        "primary_2": "清醒"
+    },
+    {
+        "intermediate_1": "qing1zhen1",
+        "intermediate_2": "qīngzhēn",
+        "native_1": "Muslim",
+        "primary_1": "清真",
+        "primary_2": "清真"
+    },
+    {
+        "intermediate_1": "qing2bao4",
+        "intermediate_2": "qíngbào",
+        "native_1": "intelligence; information-gathering",
+        "primary_1": "情报",
+        "primary_2": "情報"
+    },
+    {
+        "intermediate_1": "qing2jie2",
+        "intermediate_2": "qíngjié",
+        "native_1": "plot; circumstances",
+        "primary_1": "情节",
+        "primary_2": "情節"
+    },
+    {
+        "intermediate_1": "qing2li3",
+        "intermediate_2": "qínglǐ",
+        "native_1": "reason; sense",
+        "primary_1": "情理",
+        "primary_2": "情理"
+    },
+    {
+        "intermediate_1": "qing2xing",
+        "intermediate_2": "qíngxing",
+        "native_1": "circumstances; situation",
+        "primary_1": "情形",
+        "primary_2": "情形"
+    },
+    {
+        "intermediate_1": "qing2lang3",
+        "intermediate_2": "qínglǎng",
+        "native_1": "sunny and cloudless",
+        "primary_1": "晴朗",
+        "primary_2": "晴朗"
+    },
+    {
+        "intermediate_1": "qing3jian3",
+        "intermediate_2": "qǐngjiǎn",
+        "native_1": "invitation card; written invitation",
+        "primary_1": "请柬",
+        "primary_2": "請柬"
+    },
+    {
+        "intermediate_1": "qing3jiao4",
+        "intermediate_2": "qǐngjiào",
+        "native_1": "consult; seek advice",
+        "primary_1": "请教",
+        "primary_2": "請教"
+    },
+    {
+        "intermediate_1": "qing3shi4",
+        "intermediate_2": "qǐngshì",
+        "native_1": "ask for instructions",
+        "primary_1": "请示",
+        "primary_2": "請示"
+    },
+    {
+        "intermediate_1": "qing3tie3",
+        "intermediate_2": "qǐngtiě",
+        "native_1": "invitation card; written invitation",
+        "primary_1": "请帖",
+        "primary_2": "請帖"
+    },
+    {
+        "intermediate_1": "qiu1ling2",
+        "intermediate_2": "qiūlíng",
+        "native_1": "hills",
+        "primary_1": "丘陵",
+        "primary_2": "丘陵"
+    },
+    {
+        "intermediate_1": "qu1fen1",
+        "intermediate_2": "qūfēn",
+        "native_1": "differentiate; find differing aspects; find the difference between",
+        "primary_1": "区分",
+        "primary_2": "區分"
+    },
+    {
+        "intermediate_1": "qu1yu4",
+        "intermediate_2": "qūyù",
+        "native_1": "area; region; district",
+        "primary_1": "区域",
+        "primary_2": "區域"
+    },
+    {
+        "intermediate_1": "qu1zhe2",
+        "intermediate_2": "qūzhé",
+        "native_1": "winding; zigzag; complicated",
+        "primary_1": "曲折",
+        "primary_2": "曲折"
+    },
+    {
+        "intermediate_1": "qu1zhu2",
+        "intermediate_2": "qūzhú",
+        "native_1": "banishment; expel; deport",
+        "primary_1": "驱逐",
+        "primary_2": "驅逐"
+    },
+    {
+        "intermediate_1": "qu1fu2",
+        "intermediate_2": "qūfú",
+        "native_1": "yield; give in; submit",
+        "primary_1": "屈服",
+        "primary_2": "屈服"
+    },
+    {
+        "intermediate_1": "qu2dao4",
+        "intermediate_2": "qúdào",
+        "native_1": "irrigation ditch; medium or channel of communication",
+        "primary_1": "渠道",
+        "primary_2": "渠道"
+    },
+    {
+        "intermediate_1": "qu3zi",
+        "intermediate_2": "qǔzi",
+        "native_1": "folk tune; music; melody",
+        "primary_1": "曲子",
+        "primary_2": "曲子"
+    },
+    {
+        "intermediate_1": "qu3di4",
+        "intermediate_2": "qǔdì",
+        "native_1": "to ban; suppress",
+        "primary_1": "取缔",
+        "primary_2": "取締"
+    },
+    {
+        "intermediate_1": "qu4wei4",
+        "intermediate_2": "qùwèi",
+        "native_1": "fun; interest; delight; taste",
+        "primary_1": "趣味",
+        "primary_2": "趣味"
+    },
+    {
+        "intermediate_1": "quan1tao4",
+        "intermediate_2": "quāntào",
+        "native_1": "trap",
+        "primary_1": "圈套",
+        "primary_2": "圈套"
+    },
+    {
+        "intermediate_1": "quan2heng2",
+        "intermediate_2": "quánhéng",
+        "native_1": "trade-off; weigh pros and cons",
+        "primary_1": "权衡",
+        "primary_2": "權衡"
+    },
+    {
+        "intermediate_1": "quan2wei1",
+        "intermediate_2": "quánwēi",
+        "native_1": "authority; authoritative",
+        "primary_1": "权威",
+        "primary_2": "權威"
+    },
+    {
+        "intermediate_1": "quan2ju2",
+        "intermediate_2": "quánjú",
+        "native_1": "overall situation",
+        "primary_1": "全局",
+        "primary_2": "全局"
+    },
+    {
+        "intermediate_1": "quan2 li4 yi3 fu4",
+        "intermediate_2": "quán lì yǐ fù",
+        "native_1": "do at all costs; make an all-out effort",
+        "primary_1": "全力以赴",
+        "primary_2": "全力以赴"
+    },
+    {
+        "intermediate_1": "quan2tou",
+        "intermediate_2": "quántou",
+        "native_1": "fist",
+        "primary_1": "拳头",
+        "primary_2": "拳頭"
+    },
+    {
+        "intermediate_1": "quan3",
+        "intermediate_2": "quǎn",
+        "native_1": "dog (Kangxi radical 94)",
+        "primary_1": "犬",
+        "primary_2": "犬"
+    },
+    {
+        "intermediate_1": "que1kou3",
+        "intermediate_2": "quēkǒu",
+        "native_1": "gap; breach; shortfall",
+        "primary_1": "缺口",
+        "primary_2": "缺口"
+    },
+    {
+        "intermediate_1": "que1 xi2",
+        "intermediate_2": "quē xí",
+        "native_1": "absence; absent; default",
+        "primary_1": "缺席",
+        "primary_2": "缺席"
+    },
+    {
+        "intermediate_1": "que1xian4",
+        "intermediate_2": "quēxiàn",
+        "native_1": "a defect; a flaw; disfigurement",
+        "primary_1": "缺陷",
+        "primary_2": "缺陷"
+    },
+    {
+        "intermediate_1": "que2",
+        "intermediate_2": "qué",
+        "native_1": "lame",
+        "primary_1": "瘸",
+        "primary_2": "瘸"
+    },
+    {
+        "intermediate_1": "que4bao3",
+        "intermediate_2": "quèbǎo",
+        "native_1": "ensure; guarantee",
+        "primary_1": "确保",
+        "primary_2": "確保"
+    },
+    {
+        "intermediate_1": "que4li4",
+        "intermediate_2": "quèlì",
+        "native_1": "to establish; to institute",
+        "primary_1": "确立",
+        "primary_2": "確立"
+    },
+    {
+        "intermediate_1": "que4qie4",
+        "intermediate_2": "quèqiè",
+        "native_1": "definite; exact; precise",
+        "primary_1": "确切",
+        "primary_2": "確切"
+    },
+    {
+        "intermediate_1": "que4xin4",
+        "intermediate_2": "quèxìn",
+        "native_1": "confident; be certain of; to firmly believe",
+        "primary_1": "确信",
+        "primary_2": "確信"
+    },
+    {
+        "intermediate_1": "qun2zhong4",
+        "intermediate_2": "qúnzhòng",
+        "native_1": "the masses; multitude",
+        "primary_1": "群众",
+        "primary_2": "群衆"
+    },
+    {
+        "intermediate_1": "ran3",
+        "intermediate_2": "rǎn",
+        "native_1": "dye; to catch (a disease)",
+        "primary_1": "染",
+        "primary_2": "染"
+    },
+    {
+        "intermediate_1": "rang3",
+        "intermediate_2": "rǎng",
+        "native_1": "blurt out; shout",
+        "primary_1": "嚷",
+        "primary_2": "嚷"
+    },
+    {
+        "intermediate_1": "rang4 bu4",
+        "intermediate_2": "ràng bù",
+        "native_1": "give in; concede; yield",
+        "primary_1": "让步",
+        "primary_2": "讓步"
+    },
+    {
+        "intermediate_1": "rao2shu4",
+        "intermediate_2": "ráoshù",
+        "native_1": "forgive; pardon; spare",
+        "primary_1": "饶恕",
+        "primary_2": "饒恕"
+    },
+    {
+        "intermediate_1": "rao3luan4",
+        "intermediate_2": "rǎoluàn",
+        "native_1": "disturb; perturb; harass",
+        "primary_1": "扰乱",
+        "primary_2": "擾亂"
+    },
+    {
+        "intermediate_1": "re3huo4",
+        "intermediate_2": "rěhuò",
+        "native_1": "stir up troubles",
+        "primary_1": "惹祸",
+        "primary_2": "惹禍"
+    },
+    {
+        "intermediate_1": "re4 lei4 ying2 kuang4",
+        "intermediate_2": "rè lèi yíng kuàng",
+        "native_1": "(saying) eyes brimming with tears; extremely moved",
+        "primary_1": "热泪盈眶",
+        "primary_2": "熱淚盈眶"
+    },
+    {
+        "intermediate_1": "re4men2",
+        "intermediate_2": "rèmén",
+        "native_1": "in demand; popular; in vogue",
+        "primary_1": "热门",
+        "primary_2": "熱門"
+    },
+    {
+        "intermediate_1": "ren2dao4",
+        "intermediate_2": "réndào",
+        "native_1": "humanitarianism; humane",
+        "primary_1": "人道",
+        "primary_2": "人道"
+    },
+    {
+        "intermediate_1": "reng2e2",
+        "intermediate_2": "réngé",
+        "native_1": "personality; moral integrity; character",
+        "primary_1": "人格",
+        "primary_2": "人格"
+    },
+    {
+        "intermediate_1": "reng2ong1",
+        "intermediate_2": "réngōng",
+        "native_1": "man-made; manpower; manual work",
+        "primary_1": "人工",
+        "primary_2": "人工"
+    },
+    {
+        "intermediate_1": "ren2jia1",
+        "intermediate_2": "rénjiā",
+        "native_1": "other people; others; they; I; family; household",
+        "primary_1": "人家",
+        "primary_2": "人家"
+    },
+    {
+        "intermediate_1": "ren2jian1",
+        "intermediate_2": "rénjiān",
+        "native_1": "man's world; the world",
+        "primary_1": "人间",
+        "primary_2": "人間"
+    },
+    {
+        "intermediate_1": "ren2shi4",
+        "intermediate_2": "rénshì",
+        "native_1": "person; public figure",
+        "primary_1": "人士",
+        "primary_2": "人士"
+    },
+    {
+        "intermediate_1": "ren2wei2",
+        "intermediate_2": "rénwéi",
+        "native_1": "artificial; man-made",
+        "primary_1": "人为",
+        "primary_2": "人爲"
+    },
+    {
+        "intermediate_1": "ren2xing4",
+        "intermediate_2": "rénxìng",
+        "native_1": "human nature; humanity",
+        "primary_1": "人性",
+        "primary_2": "人性"
+    },
+    {
+        "intermediate_1": "ren2zhi4",
+        "intermediate_2": "rénzhì",
+        "native_1": "hostage",
+        "primary_1": "人质",
+        "primary_2": "人質"
+    },
+    {
+        "intermediate_1": "ren2ci2",
+        "intermediate_2": "réncí",
+        "native_1": "benevolent; kindhearted; charitable",
+        "primary_1": "仁慈",
+        "primary_2": "仁慈"
+    },
+    {
+        "intermediate_1": "ren3nai4",
+        "intermediate_2": "rěnnài",
+        "native_1": "show restraint; endure; exercise patience",
+        "primary_1": "忍耐",
+        "primary_2": "忍耐"
+    },
+    {
+        "intermediate_1": "ren3shou4",
+        "intermediate_2": "rěnshòu",
+        "native_1": "to bear; endure; tolerate",
+        "primary_1": "忍受",
+        "primary_2": "忍受"
+    },
+    {
+        "intermediate_1": "ren4ding4",
+        "intermediate_2": "rèndìng",
+        "native_1": "maintain (that sth. is true); firmly believe",
+        "primary_1": "认定",
+        "primary_2": "認定"
+    },
+    {
+        "intermediate_1": "ren4ke3",
+        "intermediate_2": "rènkě",
+        "native_1": "approve; accept; ratify",
+        "primary_1": "认可",
+        "primary_2": "認可"
+    },
+    {
+        "intermediate_1": "ren4ming4",
+        "intermediate_2": "rènmìng",
+        "native_1": "appoint and nominate",
+        "primary_1": "任命",
+        "primary_2": "任命"
+    },
+    {
+        "intermediate_1": "ren4xing4",
+        "intermediate_2": "rènxìng",
+        "native_1": "willful; headstrong",
+        "primary_1": "任性",
+        "primary_2": "任性"
+    },
+    {
+        "intermediate_1": "ren4yi4",
+        "intermediate_2": "rènyì",
+        "native_1": "arbitrarily; at will; at random",
+        "primary_1": "任意",
+        "primary_2": "任意"
+    },
+    {
+        "intermediate_1": "ren4zhong4dao4yuan3",
+        "intermediate_2": "rènzhòngdàoyuǎn",
+        "native_1": "lit. a heavy load and a long road; fig. to bear heavy responsibilities through a long struggle; shoulder heavy responsibilities",
+        "primary_1": "任重道远",
+        "primary_2": "任重道遠"
+    },
+    {
+        "intermediate_1": "reng2jiu4",
+        "intermediate_2": "réngjiù",
+        "native_1": "still (remaining); remain (the same); yet",
+        "primary_1": "仍旧",
+        "primary_2": "仍舊"
+    },
+    {
+        "intermediate_1": "ri4xin1yue4yi4",
+        "intermediate_2": "rìxīnyuèyì",
+        "native_1": "change with each passing day",
+        "primary_1": "日新月异",
+        "primary_2": "日新月異"
+    },
+    {
+        "intermediate_1": "ri4yi4",
+        "intermediate_2": "rìyì",
+        "native_1": "day by day; more and more; increasingly",
+        "primary_1": "日益",
+        "primary_2": "日益"
+    },
+    {
+        "intermediate_1": "rong2xing4",
+        "intermediate_2": "róngxìng",
+        "native_1": "honored",
+        "primary_1": "荣幸",
+        "primary_2": "榮幸"
+    },
+    {
+        "intermediate_1": "rong2yu4",
+        "intermediate_2": "róngyù",
+        "native_1": "honor; glory",
+        "primary_1": "荣誉",
+        "primary_2": "榮譽"
+    },
+    {
+        "intermediate_1": "rong2mao4",
+        "intermediate_2": "róngmào",
+        "native_1": "facial features; looks; appearance",
+        "primary_1": "容貌",
+        "primary_2": "容貌"
+    },
+    {
+        "intermediate_1": "rong2na4",
+        "intermediate_2": "róngnà",
+        "native_1": "contain; accommodate; tolerate (different options)",
+        "primary_1": "容纳",
+        "primary_2": "容納"
+    },
+    {
+        "intermediate_1": "rong2qi4",
+        "intermediate_2": "róngqì",
+        "native_1": "container; receptacle; vessel",
+        "primary_1": "容器",
+        "primary_2": "容器"
+    },
+    {
+        "intermediate_1": "rong2ren3",
+        "intermediate_2": "róngrěn",
+        "native_1": "put up with; tolerate; condone",
+        "primary_1": "容忍",
+        "primary_2": "容忍"
+    },
+    {
+        "intermediate_1": "rong2jie3",
+        "intermediate_2": "róngjiě",
+        "native_1": "dissolve; solution",
+        "primary_1": "溶解",
+        "primary_2": "溶解"
+    },
+    {
+        "intermediate_1": "rong2hua4",
+        "intermediate_2": "rónghuà",
+        "native_1": "melt; thaw; dissolve; blend into",
+        "primary_1": "融化",
+        "primary_2": "融化"
+    },
+    {
+        "intermediate_1": "rong2qia4",
+        "intermediate_2": "róngqià",
+        "native_1": "harmonious; friendly relations",
+        "primary_1": "融洽",
+        "primary_2": "融洽"
+    },
+    {
+        "intermediate_1": "rou2he2",
+        "intermediate_2": "róuhé",
+        "native_1": "gentle; soft; mild",
+        "primary_1": "柔和",
+        "primary_2": "柔和"
+    },
+    {
+        "intermediate_1": "rou2",
+        "intermediate_2": "róu",
+        "native_1": "knead; to massage; to rub",
+        "primary_1": "揉",
+        "primary_2": "揉"
+    },
+    {
+        "intermediate_1": "ru2jia1",
+        "intermediate_2": "rújiā",
+        "native_1": "Confucianism",
+        "primary_1": "儒家",
+        "primary_2": "儒家"
+    },
+    {
+        "intermediate_1": "ruo4gan1",
+        "intermediate_2": "ruògān",
+        "native_1": "a certain number or amount; how many; how much",
+        "primary_1": "若干",
+        "primary_2": "若幹"
+    },
+    {
+        "intermediate_1": "ruo4dian3",
+        "intermediate_2": "ruòdiǎn",
+        "native_1": "weak point; failing",
+        "primary_1": "弱点",
+        "primary_2": "弱點"
+    },
+    {
+        "intermediate_1": "sa1 huang3",
+        "intermediate_2": "sā huǎng",
+        "native_1": "to tell lies",
+        "primary_1": "撒谎",
+        "primary_2": "撒謊"
+    },
+    {
+        "intermediate_1": "san3wen2",
+        "intermediate_2": "sǎnwén",
+        "native_1": "prose; essay",
+        "primary_1": "散文",
+        "primary_2": "散文"
+    },
+    {
+        "intermediate_1": "san4bu4",
+        "intermediate_2": "sànbù",
+        "native_1": "to scatter; disseminate; to spread",
+        "primary_1": "散布",
+        "primary_2": "散布"
+    },
+    {
+        "intermediate_1": "san4fa1",
+        "intermediate_2": "sànfā",
+        "native_1": "distribute; emit",
+        "primary_1": "散发",
+        "primary_2": "散發"
+    },
+    {
+        "intermediate_1": "sang4shi1",
+        "intermediate_2": "sàngshī",
+        "native_1": "to lose; to forfeit",
+        "primary_1": "丧失",
+        "primary_2": "喪失"
+    },
+    {
+        "intermediate_1": "sao1rao3",
+        "intermediate_2": "sāorǎo",
+        "native_1": "harass; disturb; molest; cause a commotion",
+        "primary_1": "骚扰",
+        "primary_2": "騷擾"
+    },
+    {
+        "intermediate_1": "sao3zi",
+        "intermediate_2": "sǎozi",
+        "native_1": "(informal) elder brother's wife; sister-in-law",
+        "primary_1": "嫂子",
+        "primary_2": "嫂子"
+    },
+    {
+        "intermediate_1": "sha1 che1",
+        "intermediate_2": "shā chē",
+        "native_1": "brake (when driving); stop; switch off",
+        "primary_1": "刹车",
+        "primary_2": "刹車"
+    },
+    {
+        "intermediate_1": "sha2",
+        "intermediate_2": "shá",
+        "native_1": "(spoken) what",
+        "primary_1": "啥",
+        "primary_2": "啥"
+    },
+    {
+        "intermediate_1": "shai1xuan3",
+        "intermediate_2": "shāixuǎn",
+        "native_1": "to filter; to sift",
+        "primary_1": "筛选",
+        "primary_2": "篩選"
+    },
+    {
+        "intermediate_1": "shan1mai4",
+        "intermediate_2": "shānmài",
+        "native_1": "mountain range",
+        "primary_1": "山脉",
+        "primary_2": "山脈"
+    },
+    {
+        "intermediate_1": "shan3shuo4",
+        "intermediate_2": "shǎnshuò",
+        "native_1": "to twinkle; to flicker; glimmer",
+        "primary_1": "闪烁",
+        "primary_2": "閃爍"
+    },
+    {
+        "intermediate_1": "shan4chang2",
+        "intermediate_2": "shàncháng",
+        "native_1": "be good at; be expert in",
+        "primary_1": "擅长",
+        "primary_2": "擅長"
+    },
+    {
+        "intermediate_1": "shan4zi4",
+        "intermediate_2": "shànzì",
+        "native_1": "unauthorized",
+        "primary_1": "擅自",
+        "primary_2": "擅自"
+    },
+    {
+        "intermediate_1": "shang1 nao3jin1",
+        "intermediate_2": "shāng nǎojīn",
+        "native_1": "troublesome; bothersome",
+        "primary_1": "伤脑筋",
+        "primary_2": "傷腦筋"
+    },
+    {
+        "intermediate_1": "shang1biao1",
+        "intermediate_2": "shāngbiāo",
+        "native_1": "trademark; logo",
+        "primary_1": "商标",
+        "primary_2": "商標"
+    },
+    {
+        "intermediate_1": "shang4ji2",
+        "intermediate_2": "shàngjí",
+        "native_1": "higher authorities; superiors",
+        "primary_1": "上级",
+        "primary_2": "上級"
+    },
+    {
+        "intermediate_1": "shang4jin4",
+        "intermediate_2": "shàngjìn",
+        "native_1": "make forward progress; do better",
+        "primary_1": "上进",
+        "primary_2": "上進"
+    },
+    {
+        "intermediate_1": "shang4 ren4",
+        "intermediate_2": "shàng rèn",
+        "native_1": "take office",
+        "primary_1": "上任",
+        "primary_2": "上任"
+    },
+    {
+        "intermediate_1": "shang4yin3",
+        "intermediate_2": "shàngyǐn",
+        "native_1": "become addicted; get into a habit",
+        "primary_1": "上瘾",
+        "primary_2": "上瘾"
+    },
+    {
+        "intermediate_1": "shang4you2",
+        "intermediate_2": "shàngyóu",
+        "native_1": "upper reaches (of a river); advanced position",
+        "primary_1": "上游",
+        "primary_2": "上遊"
+    },
+    {
+        "intermediate_1": "shang4qie3",
+        "intermediate_2": "shàngqiě",
+        "native_1": "yet; still; even; also",
+        "primary_1": "尚且",
+        "primary_2": "尚且"
+    },
+    {
+        "intermediate_1": "shao1",
+        "intermediate_2": "shāo",
+        "native_1": "bring or take (along); deliver (a message)",
+        "primary_1": "捎",
+        "primary_2": "捎"
+    },
+    {
+        "intermediate_1": "shao1",
+        "intermediate_2": "shāo",
+        "native_1": "tip of a branch",
+        "primary_1": "梢",
+        "primary_2": "梢"
+    },
+    {
+        "intermediate_1": "shao4",
+        "intermediate_2": "shào",
+        "native_1": "a whistle; sentry post",
+        "primary_1": "哨",
+        "primary_2": "哨"
+    },
+    {
+        "intermediate_1": "she1chi3",
+        "intermediate_2": "shēchǐ",
+        "native_1": "luxury; sumptuous; extravagant",
+        "primary_1": "奢侈",
+        "primary_2": "奢侈"
+    },
+    {
+        "intermediate_1": "she2tou",
+        "intermediate_2": "shétou",
+        "native_1": "tongue",
+        "primary_1": "舌头",
+        "primary_2": "舌頭"
+    },
+    {
+        "intermediate_1": "she4li4",
+        "intermediate_2": "shèlì",
+        "native_1": "set up; establish",
+        "primary_1": "设立",
+        "primary_2": "設立"
+    },
+    {
+        "intermediate_1": "she4xiang3",
+        "intermediate_2": "shèxiǎng",
+        "native_1": "imagine; consider; tentative plan",
+        "primary_1": "设想",
+        "primary_2": "設想"
+    },
+    {
+        "intermediate_1": "she4zhi4",
+        "intermediate_2": "shèzhì",
+        "native_1": "set up; install; to fit",
+        "primary_1": "设置",
+        "primary_2": "設置"
+    },
+    {
+        "intermediate_1": "she4qu1",
+        "intermediate_2": "shèqū",
+        "native_1": "community",
+        "primary_1": "社区",
+        "primary_2": "社區"
+    },
+    {
+        "intermediate_1": "she4ji2",
+        "intermediate_2": "shèjí",
+        "native_1": "involve; relate to; to touch upon (a topic)",
+        "primary_1": "涉及",
+        "primary_2": "涉及"
+    },
+    {
+        "intermediate_1": "she4shi4du4",
+        "intermediate_2": "shèshìdù",
+        "native_1": "degrees Celsius",
+        "primary_1": "摄氏度",
+        "primary_2": "攝氏度"
+    },
+    {
+        "intermediate_1": "shen1bao4",
+        "intermediate_2": "shēnbào",
+        "native_1": "declare; report (to customs or other authority)",
+        "primary_1": "申报",
+        "primary_2": "申報"
+    },
+    {
+        "intermediate_1": "shen1yin2",
+        "intermediate_2": "shēnyín",
+        "native_1": "to moan; to groan",
+        "primary_1": "呻吟",
+        "primary_2": "呻吟"
+    },
+    {
+        "intermediate_1": "shen1shi4",
+        "intermediate_2": "shēnshì",
+        "native_1": "gentleman",
+        "primary_1": "绅士",
+        "primary_2": "紳士"
+    },
+    {
+        "intermediate_1": "shen1'ao4",
+        "intermediate_2": "shēn'ào",
+        "native_1": "profound; deep",
+        "primary_1": "深奥",
+        "primary_2": "深奧"
+    },
+    {
+        "intermediate_1": "shen1chen2",
+        "intermediate_2": "shēnchén",
+        "native_1": "deep; extreme; low pitched (sound); grave; of major importance",
+        "primary_1": "深沉",
+        "primary_2": "深沈"
+    },
+    {
+        "intermediate_1": "shen1qing2hou4yi4",
+        "intermediate_2": "shēnqínghòuyì",
+        "native_1": "profound friendship",
+        "primary_1": "深情厚谊",
+        "primary_2": "深情厚誼"
+    },
+    {
+        "intermediate_1": "shen2jing1",
+        "intermediate_2": "shénjīng",
+        "native_1": "nerve",
+        "primary_1": "神经",
+        "primary_2": "神經"
+    },
+    {
+        "intermediate_1": "shen2qi2",
+        "intermediate_2": "shénqí",
+        "native_1": "miraculous; magical; mystical",
+        "primary_1": "神奇",
+        "primary_2": "神奇"
+    },
+    {
+        "intermediate_1": "shen2qi4",
+        "intermediate_2": "shénqì",
+        "native_1": "expression; manner; spirited",
+        "primary_1": "神气",
+        "primary_2": "神氣"
+    },
+    {
+        "intermediate_1": "shen2sheng4",
+        "intermediate_2": "shénshèng",
+        "native_1": "divine; holy; sacred",
+        "primary_1": "神圣",
+        "primary_2": "神聖"
+    },
+    {
+        "intermediate_1": "shen2tai4",
+        "intermediate_2": "shéntài",
+        "native_1": "appearance; looks; manner; expression",
+        "primary_1": "神态",
+        "primary_2": "神態"
+    },
+    {
+        "intermediate_1": "shen2xian1",
+        "intermediate_2": "shénxiān",
+        "native_1": "fig. lighthearted person; Daoist immortal; supernatural entity; (in modern fiction) fairy, elf, leprechaun, etc.; supernatural being, celestial being, immortal; a person who has the power of clairvoyance or who is free from worldly cares",
+        "primary_1": "神仙",
+        "primary_2": "神仙"
+    },
+    {
+        "intermediate_1": "shen3cha2",
+        "intermediate_2": "shěnchá",
+        "native_1": "examine; investigate; censorship",
+        "primary_1": "审查",
+        "primary_2": "審查"
+    },
+    {
+        "intermediate_1": "shen3li3",
+        "intermediate_2": "shěnlǐ",
+        "native_1": "hear (a case)",
+        "primary_1": "审理",
+        "primary_2": "審理"
+    },
+    {
+        "intermediate_1": "shen3mei3",
+        "intermediate_2": "shěnměi",
+        "native_1": "aesthetic sense; appreciation of the arts",
+        "primary_1": "审美",
+        "primary_2": "審美"
+    },
+    {
+        "intermediate_1": "shen3pan4",
+        "intermediate_2": "shěnpàn",
+        "native_1": "put (someone) to trial; to try somebody",
+        "primary_1": "审判",
+        "primary_2": "審判"
+    },
+    {
+        "intermediate_1": "shen4tou4",
+        "intermediate_2": "shèntòu",
+        "native_1": "infiltrate; permeate",
+        "primary_1": "渗透",
+        "primary_2": "滲透"
+    },
+    {
+        "intermediate_1": "shen4zhong4",
+        "intermediate_2": "shènzhòng",
+        "native_1": "cautious; careful; prudent",
+        "primary_1": "慎重",
+        "primary_2": "慎重"
+    },
+    {
+        "intermediate_1": "sheng1cun2",
+        "intermediate_2": "shēngcún",
+        "native_1": "exist; survive",
+        "primary_1": "生存",
+        "primary_2": "生存"
+    },
+    {
+        "intermediate_1": "sheng1ji1",
+        "intermediate_2": "shēngjī",
+        "native_1": "reprieve from death; life force; vitality",
+        "primary_1": "生机",
+        "primary_2": "生機"
+    },
+    {
+        "intermediate_1": "sheng1li3",
+        "intermediate_2": "shēnglǐ",
+        "native_1": "physiology",
+        "primary_1": "生理",
+        "primary_2": "生理"
+    },
+    {
+        "intermediate_1": "sheng1shu1",
+        "intermediate_2": "shēngshū",
+        "native_1": "unfamiliar; strange; out of practice",
+        "primary_1": "生疏",
+        "primary_2": "生疏"
+    },
+    {
+        "intermediate_1": "sheng1tai4",
+        "intermediate_2": "shēngtài",
+        "native_1": "way of life; ecology",
+        "primary_1": "生态",
+        "primary_2": "生態"
+    },
+    {
+        "intermediate_1": "sheng1wu4",
+        "intermediate_2": "shēngwù",
+        "native_1": "organism; living creature; life form",
+        "primary_1": "生物",
+        "primary_2": "生物"
+    },
+    {
+        "intermediate_1": "sheng1xiao4",
+        "intermediate_2": "shēngxiào",
+        "native_1": "Chinese zodiac",
+        "primary_1": "生肖",
+        "primary_2": "生肖"
+    },
+    {
+        "intermediate_1": "sheng1 xiao4",
+        "intermediate_2": "shēng xiào",
+        "native_1": "take effect; become effective",
+        "primary_1": "生效",
+        "primary_2": "生效"
+    },
+    {
+        "intermediate_1": "sheng1xiu4",
+        "intermediate_2": "shēngxiù",
+        "native_1": "to rust",
+        "primary_1": "生锈",
+        "primary_2": "生鏽"
+    },
+    {
+        "intermediate_1": "sheng1yu4",
+        "intermediate_2": "shēngyù",
+        "native_1": "give birth; to rear; bring up (children)",
+        "primary_1": "生育",
+        "primary_2": "生育"
+    },
+    {
+        "intermediate_1": "sheng1ming2",
+        "intermediate_2": "shēngmíng",
+        "native_1": "statement; declare; proclaim",
+        "primary_1": "声明",
+        "primary_2": "聲明"
+    },
+    {
+        "intermediate_1": "sheng1shi4",
+        "intermediate_2": "shēngshì",
+        "native_1": "momentum; fame and power; prestige",
+        "primary_1": "声势",
+        "primary_2": "聲勢"
+    },
+    {
+        "intermediate_1": "sheng1yu4",
+        "intermediate_2": "shēngyù",
+        "native_1": "reputation; fame",
+        "primary_1": "声誉",
+        "primary_2": "聲譽"
+    },
+    {
+        "intermediate_1": "sheng1chu4",
+        "intermediate_2": "shēngchù",
+        "native_1": "livestock; domesticated animals",
+        "primary_1": "牲畜",
+        "primary_2": "牲畜"
+    },
+    {
+        "intermediate_1": "sheng3hui4",
+        "intermediate_2": "shěnghuì",
+        "native_1": "provincial capital",
+        "primary_1": "省会",
+        "primary_2": "省會"
+    },
+    {
+        "intermediate_1": "sheng4fu4",
+        "intermediate_2": "shèngfù",
+        "native_1": "victory or defeat; the outcome of a battle",
+        "primary_1": "胜负",
+        "primary_2": "勝負"
+    },
+    {
+        "intermediate_1": "sheng4chan3",
+        "intermediate_2": "shèngchǎn",
+        "native_1": "abound in; teem with; superabundant",
+        "primary_1": "盛产",
+        "primary_2": "盛産"
+    },
+    {
+        "intermediate_1": "sheng4kai1",
+        "intermediate_2": "shèngkāi",
+        "native_1": "to bloom; be in full flower",
+        "primary_1": "盛开",
+        "primary_2": "盛開"
+    },
+    {
+        "intermediate_1": "sheng4qing2",
+        "intermediate_2": "shèngqíng",
+        "native_1": "great kindness; boundless hospitality",
+        "primary_1": "盛情",
+        "primary_2": "盛情"
+    },
+    {
+        "intermediate_1": "sheng4xing2",
+        "intermediate_2": "shèngxíng",
+        "native_1": "in fashion; prevalent; prevail",
+        "primary_1": "盛行",
+        "primary_2": "盛行"
+    },
+    {
+        "intermediate_1": "shi1ti3",
+        "intermediate_2": "shītǐ",
+        "native_1": "dead body; corpse; carcass",
+        "primary_1": "尸体",
+        "primary_2": "屍體"
+    },
+    {
+        "intermediate_1": "shi1 shi4",
+        "intermediate_2": "shī shì",
+        "native_1": "be involved in a crash; (have an) accident",
+        "primary_1": "失事",
+        "primary_2": "失事"
+    },
+    {
+        "intermediate_1": "shi1wu4",
+        "intermediate_2": "shīwù",
+        "native_1": "mistake; lapse; miss",
+        "primary_1": "失误",
+        "primary_2": "失誤"
+    },
+    {
+        "intermediate_1": "shi1 zong1",
+        "intermediate_2": "shī zōng",
+        "native_1": "be missing; be unaccounted for",
+        "primary_1": "失踪",
+        "primary_2": "失蹤"
+    },
+    {
+        "intermediate_1": "shi1fan4",
+        "intermediate_2": "shīfàn",
+        "native_1": "teacher-training; pedagogical; normal (school)",
+        "primary_1": "师范",
+        "primary_2": "師範"
+    },
+    {
+        "intermediate_1": "shi1jia1",
+        "intermediate_2": "shījiā",
+        "native_1": "exert (effort or pressure)",
+        "primary_1": "施加",
+        "primary_2": "施加"
+    },
+    {
+        "intermediate_1": "shi1zhan3",
+        "intermediate_2": "shīzhǎn",
+        "native_1": "use fully; put to good use",
+        "primary_1": "施展",
+        "primary_2": "施展"
+    },
+    {
+        "intermediate_1": "shi2zu2",
+        "intermediate_2": "shízú",
+        "native_1": "full of; complete; 100 percent",
+        "primary_1": "十足",
+        "primary_2": "十足"
+    },
+    {
+        "intermediate_1": "shi2you2",
+        "intermediate_2": "shíyóu",
+        "native_1": "oil; petroleum",
+        "primary_1": "石油",
+        "primary_2": "石油"
+    },
+    {
+        "intermediate_1": "shi2chang2",
+        "intermediate_2": "shícháng",
+        "native_1": "time and again; often; frequently",
+        "primary_1": "时常",
+        "primary_2": "時常"
+    },
+    {
+        "intermediate_1": "shi2'er2",
+        "intermediate_2": "shí'ér",
+        "native_1": "occasionally; often, but not at any fixed time",
+        "primary_1": "时而",
+        "primary_2": "時而"
+    },
+    {
+        "intermediate_1": "shi2guang1",
+        "intermediate_2": "shíguāng",
+        "native_1": "time; era; period of time",
+        "primary_1": "时光",
+        "primary_2": "時光"
+    },
+    {
+        "intermediate_1": "shi2ji1",
+        "intermediate_2": "shíjī",
+        "native_1": "opportune time; opportunity",
+        "primary_1": "时机",
+        "primary_2": "時機"
+    },
+    {
+        "intermediate_1": "shi2shi4",
+        "intermediate_2": "shíshì",
+        "native_1": "current events; the present situation",
+        "primary_1": "时事",
+        "primary_2": "時事"
+    },
+    {
+        "intermediate_1": "shi2bie2",
+        "intermediate_2": "shíbié",
+        "native_1": "identify; distinguish; discern",
+        "primary_1": "识别",
+        "primary_2": "識別"
+    },
+    {
+        "intermediate_1": "shi2hui4",
+        "intermediate_2": "shíhuì",
+        "native_1": "substantial material benefit; advantageous (deal)",
+        "primary_1": "实惠",
+        "primary_2": "實惠"
+    },
+    {
+        "intermediate_1": "shi2li4",
+        "intermediate_2": "shílì",
+        "native_1": "strength",
+        "primary_1": "实力",
+        "primary_2": "實力"
+    },
+    {
+        "intermediate_1": "shi2shi1",
+        "intermediate_2": "shíshī",
+        "native_1": "to implement; put into effect; carry out",
+        "primary_1": "实施",
+        "primary_2": "實施"
+    },
+    {
+        "intermediate_1": "shi2 shi4 qiu2 shi4",
+        "intermediate_2": "shí shì qiú shì",
+        "native_1": "be practical and realistic; seek truth from facts",
+        "primary_1": "实事求是",
+        "primary_2": "實事求是"
+    },
+    {
+        "intermediate_1": "shi2xing2",
+        "intermediate_2": "shíxíng",
+        "native_1": "to implement; put into practice; carry out",
+        "primary_1": "实行",
+        "primary_2": "實行"
+    },
+    {
+        "intermediate_1": "shi2zhi4",
+        "intermediate_2": "shízhì",
+        "native_1": "substance; essence; gist",
+        "primary_1": "实质",
+        "primary_2": "實質"
+    },
+    {
+        "intermediate_1": "shi2",
+        "intermediate_2": "shí",
+        "native_1": "pick up; ten (banker's anti-fraud numeral)",
+        "primary_1": "拾",
+        "primary_2": "拾"
+    },
+    {
+        "intermediate_1": "shi3ming4",
+        "intermediate_2": "shǐmìng",
+        "native_1": "a (diplomatic or other) mission",
+        "primary_1": "使命",
+        "primary_2": "使命"
+    },
+    {
+        "intermediate_1": "shi4fan4",
+        "intermediate_2": "shìfàn",
+        "native_1": "demonstrate; lead the way; show how something is done",
+        "primary_1": "示范",
+        "primary_2": "示範"
+    },
+    {
+        "intermediate_1": "shi4wei1",
+        "intermediate_2": "shìwēi",
+        "native_1": "hold a protest demonstration",
+        "primary_1": "示威",
+        "primary_2": "示威"
+    },
+    {
+        "intermediate_1": "shi4yi4",
+        "intermediate_2": "shìyì",
+        "native_1": "to signal; to hint; to gesture; to motion; to indicate (an idea to sb)",
+        "primary_1": "示意",
+        "primary_2": "示意"
+    },
+    {
+        "intermediate_1": "shi4dai4",
+        "intermediate_2": "shìdài",
+        "native_1": "for generations; generation to generation",
+        "primary_1": "世代",
+        "primary_2": "世代"
+    },
+    {
+        "intermediate_1": "shi4bi4",
+        "intermediate_2": "shìbì",
+        "native_1": "is bound to (happen)",
+        "primary_1": "势必",
+        "primary_2": "勢必"
+    },
+    {
+        "intermediate_1": "shi4li",
+        "intermediate_2": "shìli",
+        "native_1": "power; influence",
+        "primary_1": "势力",
+        "primary_2": "勢力"
+    },
+    {
+        "intermediate_1": "shi4gu4",
+        "intermediate_2": "shìgù",
+        "native_1": "accident",
+        "primary_1": "事故",
+        "primary_2": "事故"
+    },
+    {
+        "intermediate_1": "shi4ji4",
+        "intermediate_2": "shìjì",
+        "native_1": "achievement; deed",
+        "primary_1": "事迹",
+        "primary_2": "事迹"
+    },
+    {
+        "intermediate_1": "shi4jian4",
+        "intermediate_2": "shìjiàn",
+        "native_1": "event; happening; incident",
+        "primary_1": "事件",
+        "primary_2": "事件"
+    },
+    {
+        "intermediate_1": "shi4tai4",
+        "intermediate_2": "shìtài",
+        "native_1": "situation; existing state of affairs",
+        "primary_1": "事态",
+        "primary_2": "事態"
+    },
+    {
+        "intermediate_1": "shi4wu4",
+        "intermediate_2": "shìwù",
+        "native_1": "affairs; work",
+        "primary_1": "事务",
+        "primary_2": "事務"
+    },
+    {
+        "intermediate_1": "shi4xiang4",
+        "intermediate_2": "shìxiàng",
+        "native_1": "matter; item",
+        "primary_1": "事项",
+        "primary_2": "事項"
+    },
+    {
+        "intermediate_1": "shi4ye4",
+        "intermediate_2": "shìyè",
+        "native_1": "undertaking; project; cause; enterprise",
+        "primary_1": "事业",
+        "primary_2": "事業"
+    },
+    {
+        "intermediate_1": "shi4tu2",
+        "intermediate_2": "shìtú",
+        "native_1": "to try; to attempt",
+        "primary_1": "试图",
+        "primary_2": "試圖"
+    },
+    {
+        "intermediate_1": "shi4yan4",
+        "intermediate_2": "shìyàn",
+        "native_1": "experiment; test",
+        "primary_1": "试验",
+        "primary_2": "試驗"
+    },
+    {
+        "intermediate_1": "shi4li4",
+        "intermediate_2": "shìlì",
+        "native_1": "vision; eyesight",
+        "primary_1": "视力",
+        "primary_2": "視力"
+    },
+    {
+        "intermediate_1": "shi4pin2",
+        "intermediate_2": "shìpín",
+        "native_1": "video",
+        "primary_1": "视频",
+        "primary_2": "視頻"
+    },
+    {
+        "intermediate_1": "shi4xian4",
+        "intermediate_2": "shìxiàn",
+        "native_1": "line of sight; view line",
+        "primary_1": "视线",
+        "primary_2": "視線"
+    },
+    {
+        "intermediate_1": "shi4ye3",
+        "intermediate_2": "shìyě",
+        "native_1": "field of vision",
+        "primary_1": "视野",
+        "primary_2": "視野"
+    },
+    {
+        "intermediate_1": "shi4fei1",
+        "intermediate_2": "shìfēi",
+        "native_1": "right and wrong; truth and fiction; quarrel",
+        "primary_1": "是非",
+        "primary_2": "是非"
+    },
+    {
+        "intermediate_1": "shi4yi2",
+        "intermediate_2": "shìyí",
+        "native_1": "suitable for; appropriate for",
+        "primary_1": "适宜",
+        "primary_2": "適宜"
+    },
+    {
+        "intermediate_1": "shi4shi4",
+        "intermediate_2": "shìshì",
+        "native_1": "pass away; to die",
+        "primary_1": "逝世",
+        "primary_2": "逝世"
+    },
+    {
+        "intermediate_1": "shi4fang4",
+        "intermediate_2": "shìfàng",
+        "native_1": "release; set free; liberate (a prisoner)",
+        "primary_1": "释放",
+        "primary_2": "釋放"
+    },
+    {
+        "intermediate_1": "shou1cang2",
+        "intermediate_2": "shōucáng",
+        "native_1": "collect; keep",
+        "primary_1": "收藏",
+        "primary_2": "收藏"
+    },
+    {
+        "intermediate_1": "shou1suo1",
+        "intermediate_2": "shōusuō",
+        "native_1": "pull back; shrink",
+        "primary_1": "收缩",
+        "primary_2": "收縮"
+    },
+    {
+        "intermediate_1": "shou1yi4",
+        "intermediate_2": "shōuyì",
+        "native_1": "earnings; profit",
+        "primary_1": "收益",
+        "primary_2": "收益"
+    },
+    {
+        "intermediate_1": "shou1yin1ji1",
+        "intermediate_2": "shōuyīnjī",
+        "native_1": "radio",
+        "primary_1": "收音机",
+        "primary_2": "收音機"
+    },
+    {
+        "intermediate_1": "shou3fa3",
+        "intermediate_2": "shǒufǎ",
+        "native_1": "technique; trick; skill; tact",
+        "primary_1": "手法",
+        "primary_2": "手法"
+    },
+    {
+        "intermediate_1": "shou3shi4",
+        "intermediate_2": "shǒushì",
+        "native_1": "gesture; sign; signal",
+        "primary_1": "手势",
+        "primary_2": "手勢"
+    },
+    {
+        "intermediate_1": "shou3yi4",
+        "intermediate_2": "shǒuyì",
+        "native_1": "craft; workmanship; one's cooking",
+        "primary_1": "手艺",
+        "primary_2": "手藝"
+    },
+    {
+        "intermediate_1": "shou3hu4",
+        "intermediate_2": "shǒuhù",
+        "native_1": "guard; defend; protect",
+        "primary_1": "守护",
+        "primary_2": "守護"
+    },
+    {
+        "intermediate_1": "shou3shi4",
+        "intermediate_2": "shǒushì",
+        "native_1": "jewelry",
+        "primary_1": "首饰",
+        "primary_2": "首飾"
+    },
+    {
+        "intermediate_1": "shou3yao4",
+        "intermediate_2": "shǒuyào",
+        "native_1": "the most important; chief; principal",
+        "primary_1": "首要",
+        "primary_2": "首要"
+    },
+    {
+        "intermediate_1": "shou4zui4",
+        "intermediate_2": "shòuzuì",
+        "native_1": "endure hardships; have a hard time",
+        "primary_1": "受罪",
+        "primary_2": "受罪"
+    },
+    {
+        "intermediate_1": "shou4yu3",
+        "intermediate_2": "shòuyǔ",
+        "native_1": "to award; confer",
+        "primary_1": "授予",
+        "primary_2": "授予"
+    },
+    {
+        "intermediate_1": "shu1fa3",
+        "intermediate_2": "shūfǎ",
+        "native_1": "calligraphy; penmanship",
+        "primary_1": "书法",
+        "primary_2": "書法"
+    },
+    {
+        "intermediate_1": "shu1ji2",
+        "intermediate_2": "shūjí",
+        "native_1": "books; works",
+        "primary_1": "书籍",
+        "primary_2": "書籍"
+    },
+    {
+        "intermediate_1": "shu1ji",
+        "intermediate_2": "shūji",
+        "native_1": "secretary; clerk",
+        "primary_1": "书记",
+        "primary_2": "書記"
+    },
+    {
+        "intermediate_1": "shu1mian4",
+        "intermediate_2": "shūmiàn",
+        "native_1": "in writing; written (guarantee, etc.)",
+        "primary_1": "书面",
+        "primary_2": "書面"
+    },
+    {
+        "intermediate_1": "shu1chang4",
+        "intermediate_2": "shūchàng",
+        "native_1": "happy; entirely free from worry",
+        "primary_1": "舒畅",
+        "primary_2": "舒暢"
+    },
+    {
+        "intermediate_1": "shu1hu",
+        "intermediate_2": "shūhu",
+        "native_1": "neglect; overlook; negligence",
+        "primary_1": "疏忽",
+        "primary_2": "疏忽"
+    },
+    {
+        "intermediate_1": "shu1yuan3",
+        "intermediate_2": "shūyuǎn",
+        "native_1": "drift apart; keep at a distance; not in close touch; estranged",
+        "primary_1": "疏远",
+        "primary_2": "疏遠"
+    },
+    {
+        "intermediate_1": "shu4",
+        "intermediate_2": "shù",
+        "native_1": "to tie; to bind; restrain; (mw for bunches, bundles, bouquets, etc.)",
+        "primary_1": "束",
+        "primary_2": "束"
+    },
+    {
+        "intermediate_1": "shu4fu4",
+        "intermediate_2": "shùfù",
+        "native_1": "to bind; restrict; to tie",
+        "primary_1": "束缚",
+        "primary_2": "束縛"
+    },
+    {
+        "intermediate_1": "shu4li4",
+        "intermediate_2": "shùlì",
+        "native_1": "set up; establish",
+        "primary_1": "树立",
+        "primary_2": "樹立"
+    },
+    {
+        "intermediate_1": "shu4",
+        "intermediate_2": "shù",
+        "native_1": "vertical; to erect; vertical stroke",
+        "primary_1": "竖",
+        "primary_2": "豎"
+    },
+    {
+        "intermediate_1": "shu4'e2",
+        "intermediate_2": "shù'é",
+        "native_1": "amount; sum of money; fixed number",
+        "primary_1": "数额",
+        "primary_2": "數額"
+    },
+    {
+        "intermediate_1": "shua3",
+        "intermediate_2": "shuǎ",
+        "native_1": "play/mess around with; juggle",
+        "primary_1": "耍",
+        "primary_2": "耍"
+    },
+    {
+        "intermediate_1": "shuai1lao3",
+        "intermediate_2": "shuāilǎo",
+        "native_1": "grow old; age; deteriorate",
+        "primary_1": "衰老",
+        "primary_2": "衰老"
+    },
+    {
+        "intermediate_1": "shuai1tui4",
+        "intermediate_2": "shuāituì",
+        "native_1": "decline; fall; drop; falter",
+        "primary_1": "衰退",
+        "primary_2": "衰退"
+    },
+    {
+        "intermediate_1": "shuai4ling3",
+        "intermediate_2": "shuàilǐng",
+        "native_1": "lead; command; head",
+        "primary_1": "率领",
+        "primary_2": "率領"
+    },
+    {
+        "intermediate_1": "shuan4huo3guo1",
+        "intermediate_2": "shuànhuǒguō",
+        "native_1": "to instant-boil (mutton, beef, vegetables, etc.)",
+        "primary_1": "涮火锅",
+        "primary_2": "涮火鍋"
+    },
+    {
+        "intermediate_1": "shuang1bao1tai1",
+        "intermediate_2": "shuāngbāotāi",
+        "native_1": "twins",
+        "primary_1": "双胞胎",
+        "primary_2": "雙胞胎"
+    },
+    {
+        "intermediate_1": "shuang3kuai4",
+        "intermediate_2": "shuǎngkuài",
+        "native_1": "refreshed; rejuvenated; frank",
+        "primary_1": "爽快",
+        "primary_2": "爽快"
+    },
+    {
+        "intermediate_1": "shui3li4",
+        "intermediate_2": "shuǐlì",
+        "native_1": "water conservancy; irrigation works",
+        "primary_1": "水利",
+        "primary_2": "水利"
+    },
+    {
+        "intermediate_1": "shui3long2tou2",
+        "intermediate_2": "shuǐlóngtóu",
+        "native_1": "faucet; tap",
+        "primary_1": "水龙头",
+        "primary_2": "水龍頭"
+    },
+    {
+        "intermediate_1": "shuin3i2",
+        "intermediate_2": "shuǐní",
+        "native_1": "cement",
+        "primary_1": "水泥",
+        "primary_2": "水泥"
+    },
+    {
+        "intermediate_1": "shun4jian1",
+        "intermediate_2": "shùnjiān",
+        "native_1": "in the twinkling of an eye; in an instant; momentary",
+        "primary_1": "瞬间",
+        "primary_2": "瞬間"
+    },
+    {
+        "intermediate_1": "si1fa3",
+        "intermediate_2": "sīfǎ",
+        "native_1": "judicial; (administration of) justice",
+        "primary_1": "司法",
+        "primary_2": "司法"
+    },
+    {
+        "intermediate_1": "si1ling4",
+        "intermediate_2": "sīlìng",
+        "native_1": "commanding officer",
+        "primary_1": "司令",
+        "primary_2": "司令"
+    },
+    {
+        "intermediate_1": "si1zi4",
+        "intermediate_2": "sīzì",
+        "native_1": "private; secretly; without permission",
+        "primary_1": "私自",
+        "primary_2": "私自"
+    },
+    {
+        "intermediate_1": "sin1ian4",
+        "intermediate_2": "sīniàn",
+        "native_1": "think of; long for; to miss",
+        "primary_1": "思念",
+        "primary_2": "思念"
+    },
+    {
+        "intermediate_1": "si1suo3",
+        "intermediate_2": "sīsuǒ",
+        "native_1": "think deeply; ponder",
+        "primary_1": "思索",
+        "primary_2": "思索"
+    },
+    {
+        "intermediate_1": "si1wei2",
+        "intermediate_2": "sīwéi",
+        "native_1": "(line) of thought; thinking",
+        "primary_1": "思维",
+        "primary_2": "思維"
+    },
+    {
+        "intermediate_1": "si1wen",
+        "intermediate_2": "sīwen",
+        "native_1": "refined; educated; cultured; intellectual; men of letters; scholars; literati; polite; gentle",
+        "primary_1": "斯文",
+        "primary_2": "斯文"
+    },
+    {
+        "intermediate_1": "si3wang2",
+        "intermediate_2": "sǐwáng",
+        "native_1": "to die; death; be dead",
+        "primary_1": "死亡",
+        "primary_2": "死亡"
+    },
+    {
+        "intermediate_1": "si4zhi1",
+        "intermediate_2": "sìzhī",
+        "native_1": "arms and legs; the four limbs of the body",
+        "primary_1": "四肢",
+        "primary_2": "四肢"
+    },
+    {
+        "intermediate_1": "si4miao4",
+        "intermediate_2": "sìmiào",
+        "native_1": "temple; monastery",
+        "primary_1": "寺庙",
+        "primary_2": "寺廟"
+    },
+    {
+        "intermediate_1": "si4yang3",
+        "intermediate_2": "sìyǎng",
+        "native_1": "to raise; to rear (domestic animal)",
+        "primary_1": "饲养",
+        "primary_2": "飼養"
+    },
+    {
+        "intermediate_1": "si4wu2ji4dan4",
+        "intermediate_2": "sìwújìdàn",
+        "native_1": "absolutely unrestrained; unbridled; without the slightest scruple",
+        "primary_1": "肆无忌惮",
+        "primary_2": "肆無忌憚"
+    },
+    {
+        "intermediate_1": "song3",
+        "intermediate_2": "sǒng",
+        "native_1": "shrug; towering; shock (alarm)",
+        "primary_1": "耸",
+        "primary_2": "聳"
+    },
+    {
+        "intermediate_1": "sou1",
+        "intermediate_2": "sōu",
+        "native_1": "(mw for boats and ships)",
+        "primary_1": "艘",
+        "primary_2": "艘"
+    },
+    {
+        "intermediate_1": "su1xing3",
+        "intermediate_2": "sūxǐng",
+        "native_1": "wake up; regain consciousness",
+        "primary_1": "苏醒",
+        "primary_2": "蘇醒"
+    },
+    {
+        "intermediate_1": "su2hua4",
+        "intermediate_2": "súhuà",
+        "native_1": "common saying; proverb",
+        "primary_1": "俗话",
+        "primary_2": "俗話"
+    },
+    {
+        "intermediate_1": "su4song4",
+        "intermediate_2": "sùsòng",
+        "native_1": "lawsuit",
+        "primary_1": "诉讼",
+        "primary_2": "訴訟"
+    },
+    {
+        "intermediate_1": "su4shi2",
+        "intermediate_2": "sùshí",
+        "native_1": "vegetables; vegetarian food",
+        "primary_1": "素食",
+        "primary_2": "素食"
+    },
+    {
+        "intermediate_1": "su4zhi4",
+        "intermediate_2": "sùzhì",
+        "native_1": "inner quality; basic essence; character quality",
+        "primary_1": "素质",
+        "primary_2": "素質"
+    },
+    {
+        "intermediate_1": "su4zao4",
+        "intermediate_2": "sùzào",
+        "native_1": "to shape; mould; figure",
+        "primary_1": "塑造",
+        "primary_2": "塑造"
+    },
+    {
+        "intermediate_1": "suan4shu4",
+        "intermediate_2": "suànshù",
+        "native_1": "(do) arithmetic; count",
+        "primary_1": "算数",
+        "primary_2": "算數"
+    },
+    {
+        "intermediate_1": "sui2ji2",
+        "intermediate_2": "suíjí",
+        "native_1": "immediately (after); soon after; immediately",
+        "primary_1": "随即",
+        "primary_2": "隨即"
+    },
+    {
+        "intermediate_1": "sui2yi4",
+        "intermediate_2": "suíyì",
+        "native_1": "as one wishes; according to one's wishes",
+        "primary_1": "随意",
+        "primary_2": "隨意"
+    },
+    {
+        "intermediate_1": "sui4yue4",
+        "intermediate_2": "suìyuè",
+        "native_1": "the years of a person's life",
+        "primary_1": "岁月",
+        "primary_2": "歲月"
+    },
+    {
+        "intermediate_1": "sui4dao4",
+        "intermediate_2": "suìdào",
+        "native_1": "tunnel",
+        "primary_1": "隧道",
+        "primary_2": "隧道"
+    },
+    {
+        "intermediate_1": "sun3huai4",
+        "intermediate_2": "sǔnhuài",
+        "native_1": "to damage; injure",
+        "primary_1": "损坏",
+        "primary_2": "損壞"
+    },
+    {
+        "intermediate_1": "suo3qu3",
+        "intermediate_2": "suǒqǔ",
+        "native_1": "demand; ask for; to exact",
+        "primary_1": "索取",
+        "primary_2": "索取"
+    },
+    {
+        "intermediate_1": "suo3xing4",
+        "intermediate_2": "suǒxìng",
+        "native_1": "you might as well (do it); simply; just; frankly; bluntly; directly",
+        "primary_1": "索性",
+        "primary_2": "索性"
+    },
+    {
+        "intermediate_1": "ta1",
+        "intermediate_2": "tā",
+        "native_1": "collapse; fall down; crumple",
+        "primary_1": "塌",
+        "primary_2": "塌"
+    },
+    {
+        "intermediate_1": "ta1shi",
+        "intermediate_2": "tāshi",
+        "native_1": "practical; down-to-earth; realistic; feel at ease; steadfast",
+        "primary_1": "踏实",
+        "primary_2": "踏實"
+    },
+    {
+        "intermediate_1": "ta3",
+        "intermediate_2": "tǎ",
+        "native_1": "pagoda; tower",
+        "primary_1": "塔",
+        "primary_2": "塔"
+    },
+    {
+        "intermediate_1": "tai2feng1",
+        "intermediate_2": "táifēng",
+        "native_1": "typhoon",
+        "primary_1": "台风",
+        "primary_2": "台風"
+    },
+    {
+        "intermediate_1": "tai4kong1",
+        "intermediate_2": "tàikōng",
+        "native_1": "outer space",
+        "primary_1": "太空",
+        "primary_2": "太空"
+    },
+    {
+        "intermediate_1": "tai4dou3",
+        "intermediate_2": "tàidǒu",
+        "native_1": "leading scholar of his time; magnate",
+        "primary_1": "泰斗",
+        "primary_2": "泰鬥"
+    },
+    {
+        "intermediate_1": "tan1lan2",
+        "intermediate_2": "tānlán",
+        "native_1": "greedy; avaricious",
+        "primary_1": "贪婪",
+        "primary_2": "貪婪"
+    },
+    {
+        "intermediate_1": "tan1wu1",
+        "intermediate_2": "tānwū",
+        "native_1": "(political, moral) corruption; embezzle",
+        "primary_1": "贪污",
+        "primary_2": "貪汙"
+    },
+    {
+        "intermediate_1": "tan1",
+        "intermediate_2": "tān",
+        "native_1": "to spread out; vendor's stand; booth; fry; (mw for puddles)",
+        "primary_1": "摊",
+        "primary_2": "攤"
+    },
+    {
+        "intermediate_1": "tan1huan4",
+        "intermediate_2": "tānhuàn",
+        "native_1": "paralysis",
+        "primary_1": "瘫痪",
+        "primary_2": "癱瘓"
+    },
+    {
+        "intermediate_1": "tan2xing4",
+        "intermediate_2": "tánxìng",
+        "native_1": "flexibility; elasticity",
+        "primary_1": "弹性",
+        "primary_2": "彈性"
+    },
+    {
+        "intermediate_1": "tan3bai2",
+        "intermediate_2": "tǎnbái",
+        "native_1": "honest; forthcoming; to confess",
+        "primary_1": "坦白",
+        "primary_2": "坦白"
+    },
+    {
+        "intermediate_1": "tan4 qi4",
+        "intermediate_2": "tàn qì",
+        "native_1": "to sigh",
+        "primary_1": "叹气",
+        "primary_2": "歎氣"
+    },
+    {
+        "intermediate_1": "tan4ce4",
+        "intermediate_2": "tàncè",
+        "native_1": "probe; take readings; detect; explore",
+        "primary_1": "探测",
+        "primary_2": "探測"
+    },
+    {
+        "intermediate_1": "tan4suo3",
+        "intermediate_2": "tànsuǒ",
+        "native_1": "explore; quest",
+        "primary_1": "探索",
+        "primary_2": "探索"
+    },
+    {
+        "intermediate_1": "tan4tao3",
+        "intermediate_2": "tàntǎo",
+        "native_1": "inquire into; explore",
+        "primary_1": "探讨",
+        "primary_2": "探討"
+    },
+    {
+        "intermediate_1": "tan4wang4",
+        "intermediate_2": "tànwàng",
+        "native_1": "pay a visit; look around",
+        "primary_1": "探望",
+        "primary_2": "探望"
+    },
+    {
+        "intermediate_1": "tang3ruo4",
+        "intermediate_2": "tǎngruò",
+        "native_1": "provided that; supposing that; if; in case",
+        "primary_1": "倘若",
+        "primary_2": "倘若"
+    },
+    {
+        "intermediate_1": "tao1",
+        "intermediate_2": "tāo",
+        "native_1": "fish out (from pocket)",
+        "primary_1": "掏",
+        "primary_2": "掏"
+    },
+    {
+        "intermediate_1": "tao1tao1 bu4 jue2",
+        "intermediate_2": "tāotāo bù jué",
+        "native_1": "(saying) talking non-stop; gushing; torrential",
+        "primary_1": "滔滔不绝",
+        "primary_2": "滔滔不絕"
+    },
+    {
+        "intermediate_1": "tao2ci2",
+        "intermediate_2": "táocí",
+        "native_1": "ceramics; pottery and porcelain",
+        "primary_1": "陶瓷",
+        "primary_2": "陶瓷"
+    },
+    {
+        "intermediate_1": "tao2zui4",
+        "intermediate_2": "táozuì",
+        "native_1": "be intoxicated (with power, success, etc.)",
+        "primary_1": "陶醉",
+        "primary_2": "陶醉"
+    },
+    {
+        "intermediate_1": "tao2tai4",
+        "intermediate_2": "táotài",
+        "native_1": "eliminate (in a competition); natural selection; die/phase out",
+        "primary_1": "淘汰",
+        "primary_2": "淘汰"
+    },
+    {
+        "intermediate_1": "tao3hao3",
+        "intermediate_2": "tǎohǎo",
+        "native_1": "to flatter",
+        "primary_1": "讨好",
+        "primary_2": "討好"
+    },
+    {
+        "intermediate_1": "te4chang2",
+        "intermediate_2": "tècháng",
+        "native_1": "strong point; specialty",
+        "primary_1": "特长",
+        "primary_2": "特長"
+    },
+    {
+        "intermediate_1": "te4ding4",
+        "intermediate_2": "tèdìng",
+        "native_1": "special; specific; designated",
+        "primary_1": "特定",
+        "primary_2": "特定"
+    },
+    {
+        "intermediate_1": "te4yi4",
+        "intermediate_2": "tèyì",
+        "native_1": "specially for; with the special intention of",
+        "primary_1": "特意",
+        "primary_2": "特意"
+    },
+    {
+        "intermediate_1": "ti2ba2",
+        "intermediate_2": "tíbá",
+        "native_1": "promote to a higher job; elevate",
+        "primary_1": "提拔",
+        "primary_2": "提拔"
+    },
+    {
+        "intermediate_1": "ti2lian4",
+        "intermediate_2": "tíliàn",
+        "native_1": "extract (ore, minerals, etc.); refine; purify",
+        "primary_1": "提炼",
+        "primary_2": "提煉"
+    },
+    {
+        "intermediate_1": "ti2shi4",
+        "intermediate_2": "tíshì",
+        "native_1": "to prompt; to present; to point out; to draw attention to sth; hint; brief; cue",
+        "primary_1": "提示",
+        "primary_2": "提示"
+    },
+    {
+        "intermediate_1": "ti2yi4",
+        "intermediate_2": "tíyì",
+        "native_1": "propose; suggest",
+        "primary_1": "提议",
+        "primary_2": "提議"
+    },
+    {
+        "intermediate_1": "ti2cai2",
+        "intermediate_2": "tícái",
+        "native_1": "subject matter",
+        "primary_1": "题材",
+        "primary_2": "題材"
+    },
+    {
+        "intermediate_1": "ti3cai2",
+        "intermediate_2": "tǐcái",
+        "native_1": "types or forms of literature",
+        "primary_1": "体裁",
+        "primary_2": "體裁"
+    },
+    {
+        "intermediate_1": "ti3ji1",
+        "intermediate_2": "tǐjī",
+        "native_1": "volume; bulk",
+        "primary_1": "体积",
+        "primary_2": "體積"
+    },
+    {
+        "intermediate_1": "ti3liang4",
+        "intermediate_2": "tǐliàng",
+        "native_1": "empathize; express sympathy; allow (for something)",
+        "primary_1": "体谅",
+        "primary_2": "體諒"
+    },
+    {
+        "intermediate_1": "ti3mian4",
+        "intermediate_2": "tǐmiàn",
+        "native_1": "dignity; honorable; face",
+        "primary_1": "体面",
+        "primary_2": "體面"
+    },
+    {
+        "intermediate_1": "ti3xi4",
+        "intermediate_2": "tǐxì",
+        "native_1": "system; setup",
+        "primary_1": "体系",
+        "primary_2": "體系"
+    },
+    {
+        "intermediate_1": "tian1cai2",
+        "intermediate_2": "tiāncái",
+        "native_1": "talent; gift; a genius; talented",
+        "primary_1": "天才",
+        "primary_2": "天才"
+    },
+    {
+        "intermediate_1": "tian1fu4",
+        "intermediate_2": "tiānfù",
+        "native_1": "natural talent",
+        "primary_1": "天赋",
+        "primary_2": "天賦"
+    },
+    {
+        "intermediate_1": "tian1lun2zhi1le4",
+        "intermediate_2": "tiānlúnzhīlè",
+        "native_1": "family happiness",
+        "primary_1": "天伦之乐",
+        "primary_2": "天倫之樂"
+    },
+    {
+        "intermediate_1": "tian1ran2qi4",
+        "intermediate_2": "tiānránqì",
+        "native_1": "natural gas",
+        "primary_1": "天然气",
+        "primary_2": "天然氣"
+    },
+    {
+        "intermediate_1": "tian1sheng1",
+        "intermediate_2": "tiānshēng",
+        "native_1": "innate; inherent; natural",
+        "primary_1": "天生",
+        "primary_2": "天生"
+    },
+    {
+        "intermediate_1": "tian1tang2",
+        "intermediate_2": "tiāntáng",
+        "native_1": "paradise; heaven",
+        "primary_1": "天堂",
+        "primary_2": "天堂"
+    },
+    {
+        "intermediate_1": "tian1wen2",
+        "intermediate_2": "tiānwén",
+        "native_1": "astronomy",
+        "primary_1": "天文",
+        "primary_2": "天文"
+    },
+    {
+        "intermediate_1": "tian2jing4",
+        "intermediate_2": "tiánjìng",
+        "native_1": "track and field",
+        "primary_1": "田径",
+        "primary_2": "田徑"
+    },
+    {
+        "intermediate_1": "tian2ye3",
+        "intermediate_2": "tiányě",
+        "native_1": "field; open country",
+        "primary_1": "田野",
+        "primary_2": "田野"
+    },
+    {
+        "intermediate_1": "tian3",
+        "intermediate_2": "tiǎn",
+        "native_1": "to lick",
+        "primary_1": "舔",
+        "primary_2": "舔"
+    },
+    {
+        "intermediate_1": "tiao1ti",
+        "intermediate_2": "tiāoti",
+        "native_1": "picky; fastidious",
+        "primary_1": "挑剔",
+        "primary_2": "挑剔"
+    },
+    {
+        "intermediate_1": "tiao2kuan3",
+        "intermediate_2": "tiáokuǎn",
+        "native_1": "clause (of contract or law)",
+        "primary_1": "条款",
+        "primary_2": "條款"
+    },
+    {
+        "intermediate_1": "tiao2li3",
+        "intermediate_2": "tiáolǐ",
+        "native_1": "consecutive; arrangement; orderliness",
+        "primary_1": "条理",
+        "primary_2": "條理"
+    },
+    {
+        "intermediate_1": "tiao2yue1",
+        "intermediate_2": "tiáoyuē",
+        "native_1": "treaty; pact",
+        "primary_1": "条约",
+        "primary_2": "條約"
+    },
+    {
+        "intermediate_1": "tiao2he2",
+        "intermediate_2": "tiáohé",
+        "native_1": "harmonious; harmony",
+        "primary_1": "调和",
+        "primary_2": "調和"
+    },
+    {
+        "intermediate_1": "tiao2ji4",
+        "intermediate_2": "tiáojì",
+        "native_1": "make an adjustment",
+        "primary_1": "调剂",
+        "primary_2": "調劑"
+    },
+    {
+        "intermediate_1": "tiao2jie2",
+        "intermediate_2": "tiáojié",
+        "native_1": "adjust; regulate; reconcile",
+        "primary_1": "调节",
+        "primary_2": "調節"
+    },
+    {
+        "intermediate_1": "tiao2jie3",
+        "intermediate_2": "tiáojiě",
+        "native_1": "mediation; bring together to an agreement",
+        "primary_1": "调解",
+        "primary_2": "調解"
+    },
+    {
+        "intermediate_1": "tiao2liao4",
+        "intermediate_2": "tiáoliào",
+        "native_1": "seasoning; flavoring",
+        "primary_1": "调料",
+        "primary_2": "調料"
+    },
+    {
+        "intermediate_1": "tiao3bo1",
+        "intermediate_2": "tiǎobō",
+        "native_1": "incite disharmony; provoke; stir up tension in others",
+        "primary_1": "挑拨",
+        "primary_2": "挑撥"
+    },
+    {
+        "intermediate_1": "tiao3xin4",
+        "intermediate_2": "tiǎoxìn",
+        "native_1": "provoke; defiance",
+        "primary_1": "挑衅",
+        "primary_2": "挑釁"
+    },
+    {
+        "intermediate_1": "tiao4yue4",
+        "intermediate_2": "tiàoyuè",
+        "native_1": "jump; leap; bound; skip",
+        "primary_1": "跳跃",
+        "primary_2": "跳躍"
+    },
+    {
+        "intermediate_1": "ting2zi",
+        "intermediate_2": "tíngzi",
+        "native_1": "pavilion; kiosk",
+        "primary_1": "亭子",
+        "primary_2": "亭子"
+    },
+    {
+        "intermediate_1": "ting2bo2",
+        "intermediate_2": "tíngbó",
+        "native_1": "anchor; mooring (of a ship)",
+        "primary_1": "停泊",
+        "primary_2": "停泊"
+    },
+    {
+        "intermediate_1": "ting2dun4",
+        "intermediate_2": "tíngdùn",
+        "native_1": "pause; halt",
+        "primary_1": "停顿",
+        "primary_2": "停頓"
+    },
+    {
+        "intermediate_1": "ting2zhi4",
+        "intermediate_2": "tíngzhì",
+        "native_1": "stagnation; be at a standstill; bogged down",
+        "primary_1": "停滞",
+        "primary_2": "停滯"
+    },
+    {
+        "intermediate_1": "ting3ba2",
+        "intermediate_2": "tǐngbá",
+        "native_1": "tall and straight",
+        "primary_1": "挺拔",
+        "primary_2": "挺拔"
+    },
+    {
+        "intermediate_1": "tong1huo4 peng2zhang4",
+        "intermediate_2": "tōnghuò péngzhàng",
+        "native_1": "inflation",
+        "primary_1": "通货膨胀",
+        "primary_2": "通貨膨脹"
+    },
+    {
+        "intermediate_1": "tong1ji1",
+        "intermediate_2": "tōngjī",
+        "native_1": "order the arrest of a criminal",
+        "primary_1": "通缉",
+        "primary_2": "通緝"
+    },
+    {
+        "intermediate_1": "tong1su2",
+        "intermediate_2": "tōngsú",
+        "native_1": "popular; common; everyday; average; vulgar",
+        "primary_1": "通俗",
+        "primary_2": "通俗"
+    },
+    {
+        "intermediate_1": "tong1xun4",
+        "intermediate_2": "tōngxùn",
+        "native_1": "communication; correspondence; news dispatch",
+        "primary_1": "通讯",
+        "primary_2": "通訊"
+    },
+    {
+        "intermediate_1": "tong1yong4",
+        "intermediate_2": "tōngyòng",
+        "native_1": "in common use; interchangeable; General Motors",
+        "primary_1": "通用",
+        "primary_2": "通用"
+    },
+    {
+        "intermediate_1": "tong2bao1",
+        "intermediate_2": "tóngbāo",
+        "native_1": "compatriot; fellow countryman",
+        "primary_1": "同胞",
+        "primary_2": "同胞"
+    },
+    {
+        "intermediate_1": "tong2zhi4",
+        "intermediate_2": "tóngzhì",
+        "native_1": "comrade; gay (slang)",
+        "primary_1": "同志",
+        "primary_2": "同志"
+    },
+    {
+        "intermediate_1": "tong2",
+        "intermediate_2": "tóng",
+        "native_1": "copper",
+        "primary_1": "铜",
+        "primary_2": "銅"
+    },
+    {
+        "intermediate_1": "tong2hua4",
+        "intermediate_2": "tónghuà",
+        "native_1": "fairy tale",
+        "primary_1": "童话",
+        "primary_2": "童話"
+    },
+    {
+        "intermediate_1": "tong3chou2jiang1u4",
+        "intermediate_2": "tǒngchóujiāngù",
+        "native_1": "take every aspects into consideration through plan and preparation",
+        "primary_1": "统筹兼顾",
+        "primary_2": "統籌兼顧"
+    },
+    {
+        "intermediate_1": "tong3ji4",
+        "intermediate_2": "tǒngjì",
+        "native_1": "statistics; to tally; to add up",
+        "primary_1": "统计",
+        "primary_2": "統計"
+    },
+    {
+        "intermediate_1": "tong3tong3",
+        "intermediate_2": "tǒngtǒng",
+        "native_1": "totally; completely",
+        "primary_1": "统统",
+        "primary_2": "統統"
+    },
+    {
+        "intermediate_1": "tong3zhi4",
+        "intermediate_2": "tǒngzhì",
+        "native_1": "to rule (a country); govern; governance",
+        "primary_1": "统治",
+        "primary_2": "統治"
+    },
+    {
+        "intermediate_1": "tou2ji1",
+        "intermediate_2": "tóujī",
+        "native_1": "speculate (on financial markets); congenial; opportunistic",
+        "primary_1": "投机",
+        "primary_2": "投機"
+    },
+    {
+        "intermediate_1": "tou2piao4",
+        "intermediate_2": "tóupiào",
+        "native_1": "vote; poll",
+        "primary_1": "投票",
+        "primary_2": "投票"
+    },
+    {
+        "intermediate_1": "tou2su4",
+        "intermediate_2": "tóusù",
+        "native_1": "make a complaint; appeal to a court",
+        "primary_1": "投诉",
+        "primary_2": "投訴"
+    },
+    {
+        "intermediate_1": "tou2xiang2",
+        "intermediate_2": "tóuxiáng",
+        "native_1": "to surrender",
+        "primary_1": "投降",
+        "primary_2": "投降"
+    },
+    {
+        "intermediate_1": "tou2zhi4",
+        "intermediate_2": "tóuzhì",
+        "native_1": "throw something a long distance; hurl",
+        "primary_1": "投掷",
+        "primary_2": "投擲"
+    },
+    {
+        "intermediate_1": "tou4lu4",
+        "intermediate_2": "tòulù",
+        "native_1": "divulge; to reveal; leak out",
+        "primary_1": "透露",
+        "primary_2": "透露"
+    },
+    {
+        "intermediate_1": "tu1",
+        "intermediate_2": "tū",
+        "native_1": "bald; blunt",
+        "primary_1": "秃",
+        "primary_2": "禿"
+    },
+    {
+        "intermediate_1": "tu1po4",
+        "intermediate_2": "tūpò",
+        "native_1": "break through; breakthrough",
+        "primary_1": "突破",
+        "primary_2": "突破"
+    },
+    {
+        "intermediate_1": "tu2'an4",
+        "intermediate_2": "tú'àn",
+        "native_1": "design; pattern",
+        "primary_1": "图案",
+        "primary_2": "圖案"
+    },
+    {
+        "intermediate_1": "tu2di4",
+        "intermediate_2": "túdì",
+        "native_1": "disciple",
+        "primary_1": "徒弟",
+        "primary_2": "徒弟"
+    },
+    {
+        "intermediate_1": "tu2jing4",
+        "intermediate_2": "tújìng",
+        "native_1": "way; channel",
+        "primary_1": "途径",
+        "primary_2": "途徑"
+    },
+    {
+        "intermediate_1": "tu2mo3",
+        "intermediate_2": "túmǒ",
+        "native_1": "scribble; smear; doodle",
+        "primary_1": "涂抹",
+        "primary_2": "塗抹"
+    },
+    {
+        "intermediate_1": "tu3rang3",
+        "intermediate_2": "tǔrǎng",
+        "native_1": "soil; earth",
+        "primary_1": "土壤",
+        "primary_2": "土壤"
+    },
+    {
+        "intermediate_1": "tuan2jie2",
+        "intermediate_2": "tuánjié",
+        "native_1": "unite; hold a rally; join forces",
+        "primary_1": "团结",
+        "primary_2": "團結"
+    },
+    {
+        "intermediate_1": "tuan2ti3",
+        "intermediate_2": "tuántǐ",
+        "native_1": "group; organization; team",
+        "primary_1": "团体",
+        "primary_2": "團體"
+    },
+    {
+        "intermediate_1": "tuan2yuan2",
+        "intermediate_2": "tuányuán",
+        "native_1": "have a reunion; reunite as a family",
+        "primary_1": "团圆",
+        "primary_2": "團圓"
+    },
+    {
+        "intermediate_1": "tui1ce4",
+        "intermediate_2": "tuīcè",
+        "native_1": "speculate; conjecture; surmise",
+        "primary_1": "推测",
+        "primary_2": "推測"
+    },
+    {
+        "intermediate_1": "tui1fan1",
+        "intermediate_2": "tuīfān",
+        "native_1": "overthrow; topple",
+        "primary_1": "推翻",
+        "primary_2": "推翻"
+    },
+    {
+        "intermediate_1": "tui1li3",
+        "intermediate_2": "tuīlǐ",
+        "native_1": "reasoning; speculative; inference",
+        "primary_1": "推理",
+        "primary_2": "推理"
+    },
+    {
+        "intermediate_1": "tui1lun4",
+        "intermediate_2": "tuīlùn",
+        "native_1": "infer; a deduction; a corollary",
+        "primary_1": "推论",
+        "primary_2": "推論"
+    },
+    {
+        "intermediate_1": "tui1xiao1",
+        "intermediate_2": "tuīxiāo",
+        "native_1": "to market; sell",
+        "primary_1": "推销",
+        "primary_2": "推銷"
+    },
+    {
+        "intermediate_1": "tun1tun1tu3tu3",
+        "intermediate_2": "tūntūntǔtǔ",
+        "native_1": "hum and haw (idiom); mumble as if hiding something; speak and break off, then start again; to hold something back",
+        "primary_1": "吞吞吐吐",
+        "primary_2": "吞吞吐吐"
+    },
+    {
+        "intermediate_1": "tuo1yun4",
+        "intermediate_2": "tuōyùn",
+        "native_1": "check in (baggage); consign for shipment",
+        "primary_1": "托运",
+        "primary_2": "托運"
+    },
+    {
+        "intermediate_1": "tuo1yan2",
+        "intermediate_2": "tuōyán",
+        "native_1": "prolong; protraction; delay; stall; procrastinate",
+        "primary_1": "拖延",
+        "primary_2": "拖延"
+    },
+    {
+        "intermediate_1": "tuo1li2",
+        "intermediate_2": "tuōlí",
+        "native_1": "to separate oneself from; to break away from; be divorced from; diastasis (medicine); abscission; abjunction (botany)",
+        "primary_1": "脱离",
+        "primary_2": "脫離"
+    },
+    {
+        "intermediate_1": "tuo3dang",
+        "intermediate_2": "tuǒdang",
+        "native_1": "appropriate; proper; pertinence",
+        "primary_1": "妥当",
+        "primary_2": "妥當"
+    },
+    {
+        "intermediate_1": "tuo3shan4",
+        "intermediate_2": "tuǒshàn",
+        "native_1": "appropriate; proper; well-arranged",
+        "primary_1": "妥善",
+        "primary_2": "妥善"
+    },
+    {
+        "intermediate_1": "tuo3xie2",
+        "intermediate_2": "tuǒxié",
+        "native_1": "to compromise; reach terms",
+        "primary_1": "妥协",
+        "primary_2": "妥協"
+    },
+    {
+        "intermediate_1": "tuo3yuan2",
+        "intermediate_2": "tuǒyuán",
+        "native_1": "ellipse; oval",
+        "primary_1": "椭圆",
+        "primary_2": "橢圓"
+    },
+    {
+        "intermediate_1": "tuo4qi4",
+        "intermediate_2": "tuòqì",
+        "native_1": "cast aside; spurn",
+        "primary_1": "唾弃",
+        "primary_2": "唾棄"
+    },
+    {
+        "intermediate_1": "wa1jue2",
+        "intermediate_2": "wājué",
+        "native_1": "excavate; dig; unearth",
+        "primary_1": "挖掘",
+        "primary_2": "挖掘"
+    },
+    {
+        "intermediate_1": "wa",
+        "intermediate_2": "wa",
+        "native_1": "wow; (sound of crying or surprise)",
+        "primary_1": "哇",
+        "primary_2": "哇"
+    },
+    {
+        "intermediate_1": "wa2wa",
+        "intermediate_2": "wáwa",
+        "native_1": "baby; child; doll",
+        "primary_1": "娃娃",
+        "primary_2": "娃娃"
+    },
+    {
+        "intermediate_1": "wa3jie3",
+        "intermediate_2": "wǎjiě",
+        "native_1": "collapse; disintegrate; crumble",
+        "primary_1": "瓦解",
+        "primary_2": "瓦解"
+    },
+    {
+        "intermediate_1": "wai1qu1",
+        "intermediate_2": "wāiqū",
+        "native_1": "to distort; to misrepresent; to twist; crooked; askew; aslant",
+        "primary_1": "歪曲",
+        "primary_2": "歪曲"
+    },
+    {
+        "intermediate_1": "wai4biao3",
+        "intermediate_2": "wàibiǎo",
+        "native_1": "outward appearance; external; outside",
+        "primary_1": "外表",
+        "primary_2": "外表"
+    },
+    {
+        "intermediate_1": "wai4hang2",
+        "intermediate_2": "wàiháng",
+        "native_1": "layman; amateur; nonprofessional",
+        "primary_1": "外行",
+        "primary_2": "外行"
+    },
+    {
+        "intermediate_1": "wai4jie4",
+        "intermediate_2": "wàijiè",
+        "native_1": "the outside world; external",
+        "primary_1": "外界",
+        "primary_2": "外界"
+    },
+    {
+        "intermediate_1": "wai4xiang4",
+        "intermediate_2": "wàixiàng",
+        "native_1": "extroverted; export-oriented (economy)",
+        "primary_1": "外向",
+        "primary_2": "外向"
+    },
+    {
+        "intermediate_1": "wan2",
+        "intermediate_2": "wán",
+        "native_1": "pill; pellet",
+        "primary_1": "丸",
+        "primary_2": "丸"
+    },
+    {
+        "intermediate_1": "wan2bei4",
+        "intermediate_2": "wánbèi",
+        "native_1": "complete; perfect",
+        "primary_1": "完备",
+        "primary_2": "完備"
+    },
+    {
+        "intermediate_1": "wan2bi4",
+        "intermediate_2": "wánbì",
+        "native_1": "finish; end; complete",
+        "primary_1": "完毕",
+        "primary_2": "完畢"
+    },
+    {
+        "intermediate_1": "wan2nong4",
+        "intermediate_2": "wánnòng",
+        "native_1": "resort to; play with; engage in",
+        "primary_1": "玩弄",
+        "primary_2": "玩弄"
+    },
+    {
+        "intermediate_1": "wan2yi4r",
+        "intermediate_2": "wányìr",
+        "native_1": "thing; toy; gadget",
+        "primary_1": "玩意儿",
+        "primary_2": "玩意兒"
+    },
+    {
+        "intermediate_1": "wang2u4",
+        "intermediate_2": "wángù",
+        "native_1": "stubborn; obstinate",
+        "primary_1": "顽固",
+        "primary_2": "頑固"
+    },
+    {
+        "intermediate_1": "wan2qiang2",
+        "intermediate_2": "wánqiáng",
+        "native_1": "tenacious; hard to defeat",
+        "primary_1": "顽强",
+        "primary_2": "頑強"
+    },
+    {
+        "intermediate_1": "wan3hui2",
+        "intermediate_2": "wǎnhuí",
+        "native_1": "reverse or salvage (a situation); redeem; retrieve",
+        "primary_1": "挽回",
+        "primary_2": "挽回"
+    },
+    {
+        "intermediate_1": "wan3jiu4",
+        "intermediate_2": "wǎnjiù",
+        "native_1": "to rescue; retrieve; to remedy",
+        "primary_1": "挽救",
+        "primary_2": "挽救"
+    },
+    {
+        "intermediate_1": "wan3xi1",
+        "intermediate_2": "wǎnxī",
+        "native_1": "feel sorry for a person; sympathize; to regret",
+        "primary_1": "惋惜",
+        "primary_2": "惋惜"
+    },
+    {
+        "intermediate_1": "wan4fen1",
+        "intermediate_2": "wànfēn",
+        "native_1": "very much; extremely",
+        "primary_1": "万分",
+        "primary_2": "萬分"
+    },
+    {
+        "intermediate_1": "wang3chang2",
+        "intermediate_2": "wǎngcháng",
+        "native_1": "habitually in the past; as one used to do; as it used to be",
+        "primary_1": "往常",
+        "primary_2": "往常"
+    },
+    {
+        "intermediate_1": "wang3shi4",
+        "intermediate_2": "wǎngshì",
+        "native_1": "the past events; former happenings",
+        "primary_1": "往事",
+        "primary_2": "往事"
+    },
+    {
+        "intermediate_1": "wang4xiang3",
+        "intermediate_2": "wàngxiǎng",
+        "native_1": "vainly hope; wishful thinking; delusion",
+        "primary_1": "妄想",
+        "primary_2": "妄想"
+    },
+    {
+        "intermediate_1": "wei1ji1",
+        "intermediate_2": "wēijī",
+        "native_1": "crisis",
+        "primary_1": "危机",
+        "primary_2": "危機"
+    },
+    {
+        "intermediate_1": "wei1feng1",
+        "intermediate_2": "wēifēng",
+        "native_1": "awe-inspiring authority; power and prestige; impressive force",
+        "primary_1": "威风",
+        "primary_2": "威風"
+    },
+    {
+        "intermediate_1": "wei1li4",
+        "intermediate_2": "wēilì",
+        "native_1": "might; power that invokes fear",
+        "primary_1": "威力",
+        "primary_2": "威力"
+    },
+    {
+        "intermediate_1": "wei1wang4",
+        "intermediate_2": "wēiwàng",
+        "native_1": "prestige",
+        "primary_1": "威望",
+        "primary_2": "威望"
+    },
+    {
+        "intermediate_1": "wei1xin4",
+        "intermediate_2": "wēixìn",
+        "native_1": "prestige; reputation; veneration; authority; trust",
+        "primary_1": "威信",
+        "primary_2": "威信"
+    },
+    {
+        "intermediate_1": "wei1 bu4 zu2 dao4",
+        "intermediate_2": "wēi bù zú dào",
+        "native_1": "negligible; insignificant; not worth mentioning",
+        "primary_1": "微不足道",
+        "primary_2": "微不足道"
+    },
+    {
+        "intermediate_1": "wei1guan1",
+        "intermediate_2": "wēiguān",
+        "native_1": "microscopic; sub atomic",
+        "primary_1": "微观",
+        "primary_2": "微觀"
+    },
+    {
+        "intermediate_1": "wei2nan2",
+        "intermediate_2": "wéinán",
+        "native_1": "make things difficult for someone; embarrassed",
+        "primary_1": "为难",
+        "primary_2": "爲難"
+    },
+    {
+        "intermediate_1": "wei2qi1",
+        "intermediate_2": "wéiqī",
+        "native_1": "be scheduled for; last for (a certain duration)",
+        "primary_1": "为期",
+        "primary_2": "爲期"
+    },
+    {
+        "intermediate_1": "wei2bei4",
+        "intermediate_2": "wéibèi",
+        "native_1": "violate; go against",
+        "primary_1": "违背",
+        "primary_2": "違背"
+    },
+    {
+        "intermediate_1": "wei2du2",
+        "intermediate_2": "wéidú",
+        "native_1": "only; just (i.e. it is only that ...); alone",
+        "primary_1": "唯独",
+        "primary_2": "唯獨"
+    },
+    {
+        "intermediate_1": "wei2chi2",
+        "intermediate_2": "wéichí",
+        "native_1": "maintain; preserve",
+        "primary_1": "维持",
+        "primary_2": "維持"
+    },
+    {
+        "intermediate_1": "wei2hu4",
+        "intermediate_2": "wéihù",
+        "native_1": "defend; to safeguard; defense; maintain",
+        "primary_1": "维护",
+        "primary_2": "維護"
+    },
+    {
+        "intermediate_1": "wei2sheng1su4",
+        "intermediate_2": "wéishēngsù",
+        "native_1": "vitamin",
+        "primary_1": "维生素",
+        "primary_2": "維生素"
+    },
+    {
+        "intermediate_1": "wei3zao4",
+        "intermediate_2": "wěizào",
+        "native_1": "forge; to fake; to counterfeit",
+        "primary_1": "伪造",
+        "primary_2": "僞造"
+    },
+    {
+        "intermediate_1": "wei3tuo1",
+        "intermediate_2": "wěituō",
+        "native_1": "to entrust; to trust; to ensign; to commission",
+        "primary_1": "委托",
+        "primary_2": "委托"
+    },
+    {
+        "intermediate_1": "wei3yuan2",
+        "intermediate_2": "wěiyuán",
+        "native_1": "committee member; committee; council",
+        "primary_1": "委员",
+        "primary_2": "委員"
+    },
+    {
+        "intermediate_1": "wei4xing1",
+        "intermediate_2": "wèixīng",
+        "native_1": "satellite",
+        "primary_1": "卫星",
+        "primary_2": "衛星"
+    },
+    {
+        "intermediate_1": "wei4mian3",
+        "intermediate_2": "wèimiǎn",
+        "native_1": "(of something that one finds has gone too far); rather a bit too",
+        "primary_1": "未免",
+        "primary_2": "未免"
+    },
+    {
+        "intermediate_1": "wei4ju4",
+        "intermediate_2": "wèijù",
+        "native_1": "to fear; foreboding",
+        "primary_1": "畏惧",
+        "primary_2": "畏懼"
+    },
+    {
+        "intermediate_1": "wei4, wei2",
+        "intermediate_2": "wèi, wéi",
+        "native_1": "hey; to feed | hello (on the phone)",
+        "primary_1": "喂",
+        "primary_2": "喂"
+    },
+    {
+        "intermediate_1": "wei4lan2",
+        "intermediate_2": "wèilán",
+        "native_1": "azure; sky blue",
+        "primary_1": "蔚蓝",
+        "primary_2": "蔚藍"
+    },
+    {
+        "intermediate_1": "wei4wen4",
+        "intermediate_2": "wèiwèn",
+        "native_1": "to express sympathy; consolation; extend regards to; salute",
+        "primary_1": "慰问",
+        "primary_2": "慰問"
+    },
+    {
+        "intermediate_1": "wen1dai4",
+        "intermediate_2": "wēndài",
+        "native_1": "temperate zone",
+        "primary_1": "温带",
+        "primary_2": "溫帶"
+    },
+    {
+        "intermediate_1": "wen1he2",
+        "intermediate_2": "wēnhé",
+        "native_1": "moderate; warm; (-huo: lukewarm)",
+        "primary_1": "温和",
+        "primary_2": "溫和"
+    },
+    {
+        "intermediate_1": "wen2ping2",
+        "intermediate_2": "wénpíng",
+        "native_1": "diploma",
+        "primary_1": "文凭",
+        "primary_2": "文憑"
+    },
+    {
+        "intermediate_1": "wen2wu4",
+        "intermediate_2": "wénwù",
+        "native_1": "cultural relic; historical relic",
+        "primary_1": "文物",
+        "primary_2": "文物"
+    },
+    {
+        "intermediate_1": "wen2xian4",
+        "intermediate_2": "wénxiàn",
+        "native_1": "document; literature",
+        "primary_1": "文献",
+        "primary_2": "文獻"
+    },
+    {
+        "intermediate_1": "wen2ya3",
+        "intermediate_2": "wényǎ",
+        "native_1": "elegant; refined",
+        "primary_1": "文雅",
+        "primary_2": "文雅"
+    },
+    {
+        "intermediate_1": "wen2yi4",
+        "intermediate_2": "wényì",
+        "native_1": "literature and art",
+        "primary_1": "文艺",
+        "primary_2": "文藝"
+    },
+    {
+        "intermediate_1": "wen4shi4",
+        "intermediate_2": "wènshì",
+        "native_1": "be published; to come out",
+        "primary_1": "问世",
+        "primary_2": "問世"
+    },
+    {
+        "intermediate_1": "wo1",
+        "intermediate_2": "wō",
+        "native_1": "nest; den",
+        "primary_1": "窝",
+        "primary_2": "窩"
+    },
+    {
+        "intermediate_1": "wu1hei1",
+        "intermediate_2": "wūhēi",
+        "native_1": "jet-black; pitch-black",
+        "primary_1": "乌黑",
+        "primary_2": "烏黑"
+    },
+    {
+        "intermediate_1": "wu1mie4",
+        "intermediate_2": "wūmiè",
+        "native_1": "to slander",
+        "primary_1": "污蔑",
+        "primary_2": "汙蔑"
+    },
+    {
+        "intermediate_1": "wu1xian4",
+        "intermediate_2": "wūxiàn",
+        "native_1": "entrap; to frame; plant false evidence against sb.",
+        "primary_1": "诬陷",
+        "primary_2": "誣陷"
+    },
+    {
+        "intermediate_1": "wu2bi3",
+        "intermediate_2": "wúbǐ",
+        "native_1": "matchless; incomparable",
+        "primary_1": "无比",
+        "primary_2": "無比"
+    },
+    {
+        "intermediate_1": "wu2chang2",
+        "intermediate_2": "wúcháng",
+        "native_1": "free; no charge; at no cost",
+        "primary_1": "无偿",
+        "primary_2": "無償"
+    },
+    {
+        "intermediate_1": "wu2chi3",
+        "intermediate_2": "wúchǐ",
+        "native_1": "without any sense of shame; shameless; audaciousness",
+        "primary_1": "无耻",
+        "primary_2": "無恥"
+    },
+    {
+        "intermediate_1": "wu2dong4yu2zhong1",
+        "intermediate_2": "wúdòngyúzhōng",
+        "native_1": "aloof; indifferent; unconcerned; untouched",
+        "primary_1": "无动于衷",
+        "primary_2": "無動于衷"
+    },
+    {
+        "intermediate_1": "wu2fei1",
+        "intermediate_2": "wúfēi",
+        "native_1": "nothing but; only",
+        "primary_1": "无非",
+        "primary_2": "無非"
+    },
+    {
+        "intermediate_1": "wu2gu1",
+        "intermediate_2": "wúgū",
+        "native_1": "innocent",
+        "primary_1": "无辜",
+        "primary_2": "無辜"
+    },
+    {
+        "intermediate_1": "wu2jing1da3cai3",
+        "intermediate_2": "wújīngdǎcǎi",
+        "native_1": "listless; be dispirited; in low spirits",
+        "primary_1": "无精打采",
+        "primary_2": "無精打采"
+    },
+    {
+        "intermediate_1": "wu2lai4",
+        "intermediate_2": "wúlài",
+        "native_1": "hoodlum; rascal; rogue; rascally; scoundrelly",
+        "primary_1": "无赖",
+        "primary_2": "無賴"
+    },
+    {
+        "intermediate_1": "wu2li3qun3ao4",
+        "intermediate_2": "wúlǐqǔnào",
+        "native_1": "to make trouble without reason (idiom); wilfully make trouble; to be deliberately provocative; deliberately awkward; pointless provocation",
+        "primary_1": "无理取闹",
+        "primary_2": "無理取鬧"
+    },
+    {
+        "intermediate_1": "wu2 neng2 wei2 li4",
+        "intermediate_2": "wú néng wéi lì",
+        "native_1": "incapable of action; powerless; impotent",
+        "primary_1": "无能为力",
+        "primary_2": "無能爲力"
+    },
+    {
+        "intermediate_1": "wu2qiong2wu2jin4",
+        "intermediate_2": "wúqióngwújìn",
+        "native_1": "vast and limitless; endless span of time; no vestige of a beginning, no prospect of an end",
+        "primary_1": "无穷无尽",
+        "primary_2": "無窮無盡"
+    },
+    {
+        "intermediate_1": "wu2 wei1 bu2 zhi4",
+        "intermediate_2": "wú wēi bú zhì",
+        "native_1": "in every possible way; meticulously",
+        "primary_1": "无微不至",
+        "primary_2": "無微不至"
+    },
+    {
+        "intermediate_1": "wu2you1wu2lü4",
+        "intermediate_2": "wúyōuwúlǜ",
+        "native_1": "carefree and without worries",
+        "primary_1": "无忧无虑",
+        "primary_2": "無憂無慮"
+    },
+    {
+        "intermediate_1": "wu2zhi1",
+        "intermediate_2": "wúzhī",
+        "native_1": "ignorance",
+        "primary_1": "无知",
+        "primary_2": "無知"
+    },
+    {
+        "intermediate_1": "wu3qi4",
+        "intermediate_2": "wǔqì",
+        "native_1": "weapon; arms",
+        "primary_1": "武器",
+        "primary_2": "武器"
+    },
+    {
+        "intermediate_1": "wu3xia2",
+        "intermediate_2": "wǔxiá",
+        "native_1": "knight-errant; a genre of swordplay martial arts movies and books",
+        "primary_1": "武侠",
+        "primary_2": "武俠"
+    },
+    {
+        "intermediate_1": "wu3zhuang1",
+        "intermediate_2": "wǔzhuāng",
+        "native_1": "arms; equipment; to arm",
+        "primary_1": "武装",
+        "primary_2": "武裝"
+    },
+    {
+        "intermediate_1": "wu3ru3",
+        "intermediate_2": "wǔrǔ",
+        "native_1": "to insult; humiliate",
+        "primary_1": "侮辱",
+        "primary_2": "侮辱"
+    },
+    {
+        "intermediate_1": "wu3dao3",
+        "intermediate_2": "wǔdǎo",
+        "native_1": "a dance",
+        "primary_1": "舞蹈",
+        "primary_2": "舞蹈"
+    },
+    {
+        "intermediate_1": "wu4bi4",
+        "intermediate_2": "wùbì",
+        "native_1": "must; need to; be sure to",
+        "primary_1": "务必",
+        "primary_2": "務必"
+    },
+    {
+        "intermediate_1": "wu4mei3jia4lian2",
+        "intermediate_2": "wùměijiàlián",
+        "native_1": "attractive goods at inexpensive prices",
+        "primary_1": "物美价廉",
+        "primary_2": "物美價廉"
+    },
+    {
+        "intermediate_1": "wu4ye4",
+        "intermediate_2": "wùyè",
+        "native_1": "property management",
+        "primary_1": "物业",
+        "primary_2": "物業"
+    },
+    {
+        "intermediate_1": "wu4zi1",
+        "intermediate_2": "wùzī",
+        "native_1": "goods and materials; commodity",
+        "primary_1": "物资",
+        "primary_2": "物資"
+    },
+    {
+        "intermediate_1": "wu4cha1",
+        "intermediate_2": "wùchā",
+        "native_1": "difference; error; inaccuracy",
+        "primary_1": "误差",
+        "primary_2": "誤差"
+    },
+    {
+        "intermediate_1": "wu4jie3",
+        "intermediate_2": "wùjiě",
+        "native_1": "misunderstand; misread",
+        "primary_1": "误解",
+        "primary_2": "誤解"
+    },
+    {
+        "intermediate_1": "xi1yang2",
+        "intermediate_2": "xīyáng",
+        "native_1": "setting sun",
+        "primary_1": "夕阳",
+        "primary_2": "夕陽"
+    },
+    {
+        "intermediate_1": "xi1ri4",
+        "intermediate_2": "xīrì",
+        "native_1": "formerly; in olden days",
+        "primary_1": "昔日",
+        "primary_2": "昔日"
+    },
+    {
+        "intermediate_1": "xi1sheng1",
+        "intermediate_2": "xīshēng",
+        "native_1": "sacrifice (one's life, etc.)",
+        "primary_1": "牺牲",
+        "primary_2": "犧牲"
+    },
+    {
+        "intermediate_1": "xi1",
+        "intermediate_2": "xī",
+        "native_1": "creek",
+        "primary_1": "溪",
+        "primary_2": "溪"
+    },
+    {
+        "intermediate_1": "xi1mie4",
+        "intermediate_2": "xīmiè",
+        "native_1": "extinguish; go out (of fire); die out; extinction",
+        "primary_1": "熄灭",
+        "primary_2": "熄滅"
+    },
+    {
+        "intermediate_1": "xi1gai4",
+        "intermediate_2": "xīgài",
+        "native_1": "knee",
+        "primary_1": "膝盖",
+        "primary_2": "膝蓋"
+    },
+    {
+        "intermediate_1": "xi2su2",
+        "intermediate_2": "xísú",
+        "native_1": "custom; tradition; (local) convention",
+        "primary_1": "习俗",
+        "primary_2": "習俗"
+    },
+    {
+        "intermediate_1": "xi2ji1",
+        "intermediate_2": "xíjī",
+        "native_1": "surprise attack; to raid",
+        "primary_1": "袭击",
+        "primary_2": "襲擊"
+    },
+    {
+        "intermediate_1": "xi2fu4",
+        "intermediate_2": "xífù",
+        "native_1": "daughter-in-law; son's wife",
+        "primary_1": "媳妇",
+        "primary_2": "媳婦"
+    },
+    {
+        "intermediate_1": "xi3wen2le4jian4",
+        "intermediate_2": "xǐwénlèjiàn",
+        "native_1": "a delight to see (idiom); an attractive spectacle",
+        "primary_1": "喜闻乐见",
+        "primary_2": "喜聞樂見"
+    },
+    {
+        "intermediate_1": "xi3yue4",
+        "intermediate_2": "xǐyuè",
+        "native_1": "happy; joyous",
+        "primary_1": "喜悦",
+        "primary_2": "喜悅"
+    },
+    {
+        "intermediate_1": "xi4lie4",
+        "intermediate_2": "xìliè",
+        "native_1": "series",
+        "primary_1": "系列",
+        "primary_2": "系列"
+    },
+    {
+        "intermediate_1": "xi4bao1",
+        "intermediate_2": "xìbāo",
+        "native_1": "cell (biology)",
+        "primary_1": "细胞",
+        "primary_2": "細胞"
+    },
+    {
+        "intermediate_1": "xi4jun1",
+        "intermediate_2": "xìjūn",
+        "native_1": "bacteria; virus; germ",
+        "primary_1": "细菌",
+        "primary_2": "細菌"
+    },
+    {
+        "intermediate_1": "xi4zhi4",
+        "intermediate_2": "xìzhì",
+        "native_1": "delicate; meticulous",
+        "primary_1": "细致",
+        "primary_2": "細致"
+    },
+    {
+        "intermediate_1": "xia2gu3",
+        "intermediate_2": "xiágǔ",
+        "native_1": "canyon; ravine; gorge",
+        "primary_1": "峡谷",
+        "primary_2": "峽谷"
+    },
+    {
+        "intermediate_1": "xia2'ai4",
+        "intermediate_2": "xiá'ài",
+        "native_1": "narrow; tight; narrow (minded); lacking in experience",
+        "primary_1": "狭隘",
+        "primary_2": "狹隘"
+    },
+    {
+        "intermediate_1": "xia2zhai3",
+        "intermediate_2": "xiázhǎi",
+        "native_1": "narrow",
+        "primary_1": "狭窄",
+        "primary_2": "狹窄"
+    },
+    {
+        "intermediate_1": "xia2",
+        "intermediate_2": "xiá",
+        "native_1": "red clouds",
+        "primary_1": "霞",
+        "primary_2": "霞"
+    },
+    {
+        "intermediate_1": "xia4shu3",
+        "intermediate_2": "xiàshǔ",
+        "native_1": "subordinate; underling",
+        "primary_1": "下属",
+        "primary_2": "下屬"
+    },
+    {
+        "intermediate_1": "xian1jin4",
+        "intermediate_2": "xiānjìn",
+        "native_1": "advanced (technology); to advance",
+        "primary_1": "先进",
+        "primary_2": "先進"
+    },
+    {
+        "intermediate_1": "xian1qian2",
+        "intermediate_2": "xiānqián",
+        "native_1": "before; previously",
+        "primary_1": "先前",
+        "primary_2": "先前"
+    },
+    {
+        "intermediate_1": "xian1wei2",
+        "intermediate_2": "xiānwéi",
+        "native_1": "fiber",
+        "primary_1": "纤维",
+        "primary_2": "纖維"
+    },
+    {
+        "intermediate_1": "xian1qi3",
+        "intermediate_2": "xiānqǐ",
+        "native_1": "lift; raise in height",
+        "primary_1": "掀起",
+        "primary_2": "掀起"
+    },
+    {
+        "intermediate_1": "xian1ming2",
+        "intermediate_2": "xiānmíng",
+        "native_1": "bright; clear-cut; distinct",
+        "primary_1": "鲜明",
+        "primary_2": "鮮明"
+    },
+    {
+        "intermediate_1": "xian2hua4",
+        "intermediate_2": "xiánhuà",
+        "native_1": "gossip; digression",
+        "primary_1": "闲话",
+        "primary_2": "閑話"
+    },
+    {
+        "intermediate_1": "xian2hui4",
+        "intermediate_2": "xiánhuì",
+        "native_1": "virtuous and dutiful (of women)",
+        "primary_1": "贤惠",
+        "primary_2": "賢惠"
+    },
+    {
+        "intermediate_1": "xian2",
+        "intermediate_2": "xián",
+        "native_1": "bow string; string of musical instruments",
+        "primary_1": "弦",
+        "primary_2": "弦"
+    },
+    {
+        "intermediate_1": "xian2jie1",
+        "intermediate_2": "xiánjiē",
+        "native_1": "to join together; to combine",
+        "primary_1": "衔接",
+        "primary_2": "銜接"
+    },
+    {
+        "intermediate_1": "xian2",
+        "intermediate_2": "xián",
+        "native_1": "to dislike; suspicion; grudge",
+        "primary_1": "嫌",
+        "primary_2": "嫌"
+    },
+    {
+        "intermediate_1": "xian2yi2",
+        "intermediate_2": "xiányí",
+        "native_1": "suspicion; (be) suspected (of)",
+        "primary_1": "嫌疑",
+        "primary_2": "嫌疑"
+    },
+    {
+        "intermediate_1": "xian3zhu4",
+        "intermediate_2": "xiǎnzhù",
+        "native_1": "notable; marked; outstanding; remarkable",
+        "primary_1": "显著",
+        "primary_2": "顯著"
+    },
+    {
+        "intermediate_1": "xian4chang3",
+        "intermediate_2": "xiànchǎng",
+        "native_1": "scene (of event or incident); on the spot",
+        "primary_1": "现场",
+        "primary_2": "現場"
+    },
+    {
+        "intermediate_1": "xian4cheng2",
+        "intermediate_2": "xiànchéng",
+        "native_1": "ready-made; off-the-shelf",
+        "primary_1": "现成",
+        "primary_2": "現成"
+    },
+    {
+        "intermediate_1": "xian4zhuang4",
+        "intermediate_2": "xiànzhuàng",
+        "native_1": "current situation; status quo",
+        "primary_1": "现状",
+        "primary_2": "現狀"
+    },
+    {
+        "intermediate_1": "xian4suo3",
+        "intermediate_2": "xiànsuǒ",
+        "native_1": "trail; clues; hints; thread (of a story)",
+        "primary_1": "线索",
+        "primary_2": "線索"
+    },
+    {
+        "intermediate_1": "xian4fa3",
+        "intermediate_2": "xiànfǎ",
+        "native_1": "constitution; charter",
+        "primary_1": "宪法",
+        "primary_2": "憲法"
+    },
+    {
+        "intermediate_1": "xian4hai4",
+        "intermediate_2": "xiànhài",
+        "native_1": "cast blame on; to frame",
+        "primary_1": "陷害",
+        "primary_2": "陷害"
+    },
+    {
+        "intermediate_1": "xian4jing3",
+        "intermediate_2": "xiànjǐng",
+        "native_1": "trap; snare",
+        "primary_1": "陷阱",
+        "primary_2": "陷阱"
+    },
+    {
+        "intermediate_1": "xian4ru4",
+        "intermediate_2": "xiànrù",
+        "native_1": "sink into; get caught up in; land in (a predicament)",
+        "primary_1": "陷入",
+        "primary_2": "陷入"
+    },
+    {
+        "intermediate_1": "xian4r",
+        "intermediate_2": "xiànr",
+        "native_1": "stuffing; filling",
+        "primary_1": "馅儿",
+        "primary_2": "餡兒"
+    },
+    {
+        "intermediate_1": "xiang1zhen4",
+        "intermediate_2": "xiāngzhèn",
+        "native_1": "village and town",
+        "primary_1": "乡镇",
+        "primary_2": "鄉鎮"
+    },
+    {
+        "intermediate_1": "xiang1cha4",
+        "intermediate_2": "xiāngchà",
+        "native_1": "differ; difference",
+        "primary_1": "相差",
+        "primary_2": "相差"
+    },
+    {
+        "intermediate_1": "xiang1deng3",
+        "intermediate_2": "xiāngděng",
+        "native_1": "be equal to; equally; equivalent",
+        "primary_1": "相等",
+        "primary_2": "相等"
+    },
+    {
+        "intermediate_1": "xiang1fu3xiang1cheng2",
+        "intermediate_2": "xiāngfǔxiāngchéng",
+        "native_1": "supplement and complement each other",
+        "primary_1": "相辅相成",
+        "primary_2": "相輔相成"
+    },
+    {
+        "intermediate_1": "xiang1ying4",
+        "intermediate_2": "xiāngyìng",
+        "native_1": "correspond; relevant",
+        "primary_1": "相应",
+        "primary_2": "相應"
+    },
+    {
+        "intermediate_1": "xiang1qian4",
+        "intermediate_2": "xiāngqiàn",
+        "native_1": "inlay",
+        "primary_1": "镶嵌",
+        "primary_2": "鑲嵌"
+    },
+    {
+        "intermediate_1": "xiang3liang4",
+        "intermediate_2": "xiǎngliàng",
+        "native_1": "loud and clear; resounding",
+        "primary_1": "响亮",
+        "primary_2": "響亮"
+    },
+    {
+        "intermediate_1": "xiang3ying4",
+        "intermediate_2": "xiǎngyìng",
+        "native_1": "respond to; answer",
+        "primary_1": "响应",
+        "primary_2": "響應"
+    },
+    {
+        "intermediate_1": "xiang3 fang1 she4 fa3",
+        "intermediate_2": "xiǎng fāng shè fǎ",
+        "native_1": "(saying) think of or try every possible method; by all means possible",
+        "primary_1": "想方设法",
+        "primary_2": "想方設法"
+    },
+    {
+        "intermediate_1": "xiang4dao3",
+        "intermediate_2": "xiàngdǎo",
+        "native_1": "guide",
+        "primary_1": "向导",
+        "primary_2": "向導"
+    },
+    {
+        "intermediate_1": "xiang4lai2",
+        "intermediate_2": "xiànglái",
+        "native_1": "always; all along",
+        "primary_1": "向来",
+        "primary_2": "向來"
+    },
+    {
+        "intermediate_1": "xiang4wang3",
+        "intermediate_2": "xiàngwǎng",
+        "native_1": "yearn for; look forward to",
+        "primary_1": "向往",
+        "primary_2": "向往"
+    },
+    {
+        "intermediate_1": "xiang4",
+        "intermediate_2": "xiàng",
+        "native_1": "lane; alley",
+        "primary_1": "巷",
+        "primary_2": "巷"
+    },
+    {
+        "intermediate_1": "xiang4sheng",
+        "intermediate_2": "xiàngsheng",
+        "native_1": "comic dialogue; crosstalk",
+        "primary_1": "相声",
+        "primary_2": "相聲"
+    },
+    {
+        "intermediate_1": "xue1",
+        "intermediate_2": "xuē",
+        "native_1": "to pare/peel with a knife; to cut; to chop",
+        "primary_1": "削",
+        "primary_2": "削"
+    },
+    {
+        "intermediate_1": "xiao1chu2",
+        "intermediate_2": "xiāochú",
+        "native_1": "eliminate; remove; clear up (abstract things）",
+        "primary_1": "消除",
+        "primary_2": "消除"
+    },
+    {
+        "intermediate_1": "xiao1 du2",
+        "intermediate_2": "xiāo dú",
+        "native_1": "disinfect; sterilize",
+        "primary_1": "消毒",
+        "primary_2": "消毒"
+    },
+    {
+        "intermediate_1": "xiao1fang2",
+        "intermediate_2": "xiāofáng",
+        "native_1": "fire-fighting; fire prevention and control",
+        "primary_1": "消防",
+        "primary_2": "消防"
+    },
+    {
+        "intermediate_1": "xiao1hao4",
+        "intermediate_2": "xiāohào",
+        "native_1": "use up; consume",
+        "primary_1": "消耗",
+        "primary_2": "消耗"
+    },
+    {
+        "intermediate_1": "xiao1mie4",
+        "intermediate_2": "xiāomiè",
+        "native_1": "eliminate; perish; wipe out",
+        "primary_1": "消灭",
+        "primary_2": "消滅"
+    },
+    {
+        "intermediate_1": "xiao1hui3",
+        "intermediate_2": "xiāohuǐ",
+        "native_1": "destroy (by melting or burning)",
+        "primary_1": "销毁",
+        "primary_2": "銷毀"
+    },
+    {
+        "intermediate_1": "xiao1sa3",
+        "intermediate_2": "xiāosǎ",
+        "native_1": "free and easy",
+        "primary_1": "潇洒",
+        "primary_2": "潇灑"
+    },
+    {
+        "intermediate_1": "xiao3xin1 yi4yi4",
+        "intermediate_2": "xiǎoxīn yìyì",
+        "native_1": "carefully; cautiously; with great care",
+        "primary_1": "小心翼翼",
+        "primary_2": "小心翼翼"
+    },
+    {
+        "intermediate_1": "xiao4xiang4",
+        "intermediate_2": "xiàoxiàng",
+        "native_1": "portrait",
+        "primary_1": "肖像",
+        "primary_2": "肖像"
+    },
+    {
+        "intermediate_1": "xiao4yi4",
+        "intermediate_2": "xiàoyì",
+        "native_1": "benefit；results",
+        "primary_1": "效益",
+        "primary_2": "效益"
+    },
+    {
+        "intermediate_1": "xie2hui4",
+        "intermediate_2": "xiéhuì",
+        "native_1": "an association; a society",
+        "primary_1": "协会",
+        "primary_2": "協會"
+    },
+    {
+        "intermediate_1": "xie2shang1",
+        "intermediate_2": "xiéshāng",
+        "native_1": "consult with; talk things over",
+        "primary_1": "协商",
+        "primary_2": "協商"
+    },
+    {
+        "intermediate_1": "xie2tiao2",
+        "intermediate_2": "xiétiáo",
+        "native_1": "coordinate; harmonize",
+        "primary_1": "协调",
+        "primary_2": "協調"
+    },
+    {
+        "intermediate_1": "xie2yi4",
+        "intermediate_2": "xiéyì",
+        "native_1": "agreement; pact; protocol",
+        "primary_1": "协议",
+        "primary_2": "協議"
+    },
+    {
+        "intermediate_1": "xie2zhu4",
+        "intermediate_2": "xiézhù",
+        "native_1": "assist; to help",
+        "primary_1": "协助",
+        "primary_2": "協助"
+    },
+    {
+        "intermediate_1": "xie2dai4",
+        "intermediate_2": "xiédài",
+        "native_1": "take with; portable",
+        "primary_1": "携带",
+        "primary_2": "攜帶"
+    },
+    {
+        "intermediate_1": "xie4lou4",
+        "intermediate_2": "xièlòu",
+        "native_1": "leak (information); divulge",
+        "primary_1": "泄露",
+        "primary_2": "泄露"
+    },
+    {
+        "intermediate_1": "xie4qi4",
+        "intermediate_2": "xièqì",
+        "native_1": "despair; feel like giving up/disappointing; pathetic",
+        "primary_1": "泄气",
+        "primary_2": "泄氣"
+    },
+    {
+        "intermediate_1": "xie4",
+        "intermediate_2": "xiè",
+        "native_1": "crumbs; filings; worth while",
+        "primary_1": "屑",
+        "primary_2": "屑"
+    },
+    {
+        "intermediate_1": "xie4jue2",
+        "intermediate_2": "xièjué",
+        "native_1": "politely refuse",
+        "primary_1": "谢绝",
+        "primary_2": "謝絕"
+    },
+    {
+        "intermediate_1": "xin1de2",
+        "intermediate_2": "xīndé",
+        "native_1": "knowledge gained",
+        "primary_1": "心得",
+        "primary_2": "心得"
+    },
+    {
+        "intermediate_1": "xing1an1qing2yuan4",
+        "intermediate_2": "xīngānqíngyuàn",
+        "native_1": "totally willing; perfectly happy to",
+        "primary_1": "心甘情愿",
+        "primary_2": "心甘情願"
+    },
+    {
+        "intermediate_1": "xin1ling2",
+        "intermediate_2": "xīnlíng",
+        "native_1": "heart; soul; smart; quick-witted",
+        "primary_1": "心灵",
+        "primary_2": "心靈"
+    },
+    {
+        "intermediate_1": "xin1tai4",
+        "intermediate_2": "xīntài",
+        "native_1": "pyschology; mentality; spirit",
+        "primary_1": "心态",
+        "primary_2": "心態"
+    },
+    {
+        "intermediate_1": "xin1teng2",
+        "intermediate_2": "xīnténg",
+        "native_1": "love dearly; the pain of love",
+        "primary_1": "心疼",
+        "primary_2": "心疼"
+    },
+    {
+        "intermediate_1": "xin1xue4",
+        "intermediate_2": "xīnxuè",
+        "native_1": "heart and blood; painstaking effort; meticulous care",
+        "primary_1": "心血",
+        "primary_2": "心血"
+    },
+    {
+        "intermediate_1": "xin1yan3r",
+        "intermediate_2": "xīnyǎnr",
+        "native_1": "one's thoughts; mind; intention; willingness to accept new ideas",
+        "primary_1": "心眼儿",
+        "primary_2": "心眼兒"
+    },
+    {
+        "intermediate_1": "xin1qin2",
+        "intermediate_2": "xīnqín",
+        "native_1": "hardworking; diligent; industrious",
+        "primary_1": "辛勤",
+        "primary_2": "辛勤"
+    },
+    {
+        "intermediate_1": "xin1wei4",
+        "intermediate_2": "xīnwèi",
+        "native_1": "be gratified; satisfied",
+        "primary_1": "欣慰",
+        "primary_2": "欣慰"
+    },
+    {
+        "intermediate_1": "xin1xin1 xiang4 rong2",
+        "intermediate_2": "xīnxīn xiàng róng",
+        "native_1": "flourishing; thriving; prosperous",
+        "primary_1": "欣欣向荣",
+        "primary_2": "欣欣向榮"
+    },
+    {
+        "intermediate_1": "xin1 chen2 dai4xie4",
+        "intermediate_2": "xīn chén dàixiè",
+        "native_1": "metabolism (bio); (saying) the new replaces the old",
+        "primary_1": "新陈代谢",
+        "primary_2": "新陳代謝"
+    },
+    {
+        "intermediate_1": "xin1lang2",
+        "intermediate_2": "xīnláng",
+        "native_1": "bridegroom; groom",
+        "primary_1": "新郎",
+        "primary_2": "新郎"
+    },
+    {
+        "intermediate_1": "xin1niang2",
+        "intermediate_2": "xīnniáng",
+        "native_1": "bride",
+        "primary_1": "新娘",
+        "primary_2": "新娘"
+    },
+    {
+        "intermediate_1": "xin1ying3",
+        "intermediate_2": "xīnyǐng",
+        "native_1": "new and original; novel",
+        "primary_1": "新颖",
+        "primary_2": "新穎"
+    },
+    {
+        "intermediate_1": "xin1shui3",
+        "intermediate_2": "xīnshuǐ",
+        "native_1": "salary; wage; pay; stipend",
+        "primary_1": "薪水",
+        "primary_2": "薪水"
+    },
+    {
+        "intermediate_1": "xin4lai4",
+        "intermediate_2": "xìnlài",
+        "native_1": "trust; have confidence in; confide",
+        "primary_1": "信赖",
+        "primary_2": "信賴"
+    },
+    {
+        "intermediate_1": "xin4nian4",
+        "intermediate_2": "xìnniàn",
+        "native_1": "faith; belief; conviction",
+        "primary_1": "信念",
+        "primary_2": "信念"
+    },
+    {
+        "intermediate_1": "xin4yang3",
+        "intermediate_2": "xìnyǎng",
+        "native_1": "firm belief; faith; believe in (a religion)",
+        "primary_1": "信仰",
+        "primary_2": "信仰"
+    },
+    {
+        "intermediate_1": "xin4yu4",
+        "intermediate_2": "xìnyù",
+        "native_1": "reputation; prestige; trust",
+        "primary_1": "信誉",
+        "primary_2": "信譽"
+    },
+    {
+        "intermediate_1": "xing1long2",
+        "intermediate_2": "xīnglóng",
+        "native_1": "prosperous; flourishing",
+        "primary_1": "兴隆",
+        "primary_2": "興隆"
+    },
+    {
+        "intermediate_1": "xing1wang4",
+        "intermediate_2": "xīngwàng",
+        "native_1": "prosperous; thriving; to prosper",
+        "primary_1": "兴旺",
+        "primary_2": "興旺"
+    },
+    {
+        "intermediate_1": "xing1",
+        "intermediate_2": "xīng",
+        "native_1": "fishy (smell)",
+        "primary_1": "腥",
+        "primary_2": "腥"
+    },
+    {
+        "intermediate_1": "xing2shi4",
+        "intermediate_2": "xíngshì",
+        "native_1": "criminal; penal",
+        "primary_1": "刑事",
+        "primary_2": "刑事"
+    },
+    {
+        "intermediate_1": "xing2zheng4",
+        "intermediate_2": "xíngzhèng",
+        "native_1": "administration; administrative",
+        "primary_1": "行政",
+        "primary_2": "行政"
+    },
+    {
+        "intermediate_1": "xing2tai4",
+        "intermediate_2": "xíngtài",
+        "native_1": "shape; form; pattern",
+        "primary_1": "形态",
+        "primary_2": "形態"
+    },
+    {
+        "intermediate_1": "xing4 gao1 cai3 lie4",
+        "intermediate_2": "xìng gāo cǎi liè",
+        "native_1": "in high spirits",
+        "primary_1": "兴高采烈",
+        "primary_2": "興高采烈"
+    },
+    {
+        "intermediate_1": "xing4zhi4bo2bo2",
+        "intermediate_2": "xìngzhìbóbó",
+        "native_1": "in high spirits",
+        "primary_1": "兴致勃勃",
+        "primary_2": "興致勃勃"
+    },
+    {
+        "intermediate_1": "xing4gan3",
+        "intermediate_2": "xìnggǎn",
+        "native_1": "sex appeal; sexy; sexuality",
+        "primary_1": "性感",
+        "primary_2": "性感"
+    },
+    {
+        "intermediate_1": "xing4ming4",
+        "intermediate_2": "xìngmìng",
+        "native_1": "life",
+        "primary_1": "性命",
+        "primary_2": "性命"
+    },
+    {
+        "intermediate_1": "xing4neng2",
+        "intermediate_2": "xìngnéng",
+        "native_1": "function; performance",
+        "primary_1": "性能",
+        "primary_2": "性能"
+    },
+    {
+        "intermediate_1": "xiong1'e4",
+        "intermediate_2": "xiōng'è",
+        "native_1": "fierce; ferocious; menacing",
+        "primary_1": "凶恶",
+        "primary_2": "凶惡"
+    },
+    {
+        "intermediate_1": "xiong1shou3",
+        "intermediate_2": "xiōngshǒu",
+        "native_1": "murderer; assassin; assailant",
+        "primary_1": "凶手",
+        "primary_2": "凶手"
+    },
+    {
+        "intermediate_1": "xiong1yong3",
+        "intermediate_2": "xiōngyǒng",
+        "native_1": "(used in reference to an ocean, river, lake etc.) violently surge up; turbulent",
+        "primary_1": "汹涌",
+        "primary_2": "洶湧"
+    },
+    {
+        "intermediate_1": "xiong1huai2",
+        "intermediate_2": "xiōnghuái",
+        "native_1": "think about; heart; one's bosom (the seat of emotions); breast; broad-minded and open",
+        "primary_1": "胸怀",
+        "primary_2": "胸懷"
+    },
+    {
+        "intermediate_1": "xiong1tang2",
+        "intermediate_2": "xiōngtáng",
+        "native_1": "chest",
+        "primary_1": "胸膛",
+        "primary_2": "胸膛"
+    },
+    {
+        "intermediate_1": "xiong2hou4",
+        "intermediate_2": "xiónghòu",
+        "native_1": "abundant; strong and solid; rich",
+        "primary_1": "雄厚",
+        "primary_2": "雄厚"
+    },
+    {
+        "intermediate_1": "xiong2wei3",
+        "intermediate_2": "xióngwěi",
+        "native_1": "grand; majestic",
+        "primary_1": "雄伟",
+        "primary_2": "雄偉"
+    },
+    {
+        "intermediate_1": "xiu1fu4",
+        "intermediate_2": "xiūfù",
+        "native_1": "restoration; repair",
+        "primary_1": "修复",
+        "primary_2": "修複"
+    },
+    {
+        "intermediate_1": "xiu1jian4",
+        "intermediate_2": "xiūjiàn",
+        "native_1": "to build; to construct; renovate",
+        "primary_1": "修建",
+        "primary_2": "修建"
+    },
+    {
+        "intermediate_1": "xiu1yang3",
+        "intermediate_2": "xiūyǎng",
+        "native_1": "accomplishment; self-cultivation",
+        "primary_1": "修养",
+        "primary_2": "修養"
+    },
+    {
+        "intermediate_1": "xiu1chi3",
+        "intermediate_2": "xiūchǐ",
+        "native_1": "(a feeling of) shame",
+        "primary_1": "羞耻",
+        "primary_2": "羞恥"
+    },
+    {
+        "intermediate_1": "xiu4",
+        "intermediate_2": "xiù",
+        "native_1": "embroider; embroidery",
+        "primary_1": "绣",
+        "primary_2": "繡"
+    },
+    {
+        "intermediate_1": "xiu4jue2",
+        "intermediate_2": "xiùjué",
+        "native_1": "sense of smell; scent",
+        "primary_1": "嗅觉",
+        "primary_2": "嗅覺"
+    },
+    {
+        "intermediate_1": "xu1zhi1",
+        "intermediate_2": "xūzhī",
+        "native_1": "prerequisites; knowledge requirement",
+        "primary_1": "须知",
+        "primary_2": "須知"
+    },
+    {
+        "intermediate_1": "xu1jia3",
+        "intermediate_2": "xūjiǎ",
+        "native_1": "false; phony; pretense; deceit",
+        "primary_1": "虚假",
+        "primary_2": "虛假"
+    },
+    {
+        "intermediate_1": "xu1rong2",
+        "intermediate_2": "xūróng",
+        "native_1": "vanity",
+        "primary_1": "虚荣",
+        "primary_2": "虛榮"
+    },
+    {
+        "intermediate_1": "xu1wei3",
+        "intermediate_2": "xūwěi",
+        "native_1": "false; hypocritical; artificial; sham",
+        "primary_1": "虚伪",
+        "primary_2": "虛僞"
+    },
+    {
+        "intermediate_1": "xu1qiu2",
+        "intermediate_2": "xūqiú",
+        "native_1": "requirement; demand (economics)",
+        "primary_1": "需求",
+        "primary_2": "需求"
+    },
+    {
+        "intermediate_1": "xu3ke3",
+        "intermediate_2": "xǔkě",
+        "native_1": "allow; permit; permission",
+        "primary_1": "许可",
+        "primary_2": "許可"
+    },
+    {
+        "intermediate_1": "xu4yan2",
+        "intermediate_2": "xùyán",
+        "native_1": "preface of a book, used to explain the book's objective",
+        "primary_1": "序言",
+        "primary_2": "序言"
+    },
+    {
+        "intermediate_1": "xu4mu4",
+        "intermediate_2": "xùmù",
+        "native_1": "raise animals",
+        "primary_1": "畜牧",
+        "primary_2": "畜牧"
+    },
+    {
+        "intermediate_1": "xu4jiu3",
+        "intermediate_2": "xùjiǔ",
+        "native_1": "heavy drinking; drink to excess; binge drink",
+        "primary_1": "酗酒",
+        "primary_2": "酗酒"
+    },
+    {
+        "intermediate_1": "xuan1 shi4",
+        "intermediate_2": "xuān shì",
+        "native_1": "swear an oath (of office); make a vow",
+        "primary_1": "宣誓",
+        "primary_2": "宣誓"
+    },
+    {
+        "intermediate_1": "xuan1yang2",
+        "intermediate_2": "xuānyáng",
+        "native_1": "publicize; make public or well known",
+        "primary_1": "宣扬",
+        "primary_2": "宣揚"
+    },
+    {
+        "intermediate_1": "xuan1hua2",
+        "intermediate_2": "xuānhuá",
+        "native_1": "cause a scene",
+        "primary_1": "喧哗",
+        "primary_2": "喧嘩"
+    },
+    {
+        "intermediate_1": "xuang2ua4",
+        "intermediate_2": "xuánguà",
+        "native_1": "suspend; hang; suspension (cable car)",
+        "primary_1": "悬挂",
+        "primary_2": "懸挂"
+    },
+    {
+        "intermediate_1": "xuan2nian4",
+        "intermediate_2": "xuánniàn",
+        "native_1": "reader's involvement; suspense in a movie, place etc",
+        "primary_1": "悬念",
+        "primary_2": "懸念"
+    },
+    {
+        "intermediate_1": "xuan2shu1",
+        "intermediate_2": "xuánshū",
+        "native_1": "a wide gap; big contrast; large disparity; a mismatch",
+        "primary_1": "悬殊",
+        "primary_2": "懸殊"
+    },
+    {
+        "intermediate_1": "xuan2ya2qiao4bi4",
+        "intermediate_2": "xuányáqiàobì",
+        "native_1": "cliffside",
+        "primary_1": "悬崖峭壁",
+        "primary_2": "懸崖峭壁"
+    },
+    {
+        "intermediate_1": "xuan2lü4",
+        "intermediate_2": "xuánlǜ",
+        "native_1": "melody; tune; rhythm",
+        "primary_1": "旋律",
+        "primary_2": "旋律"
+    },
+    {
+        "intermediate_1": "xuan2zhuan3",
+        "intermediate_2": "xuánzhuǎn",
+        "native_1": "to whirl; to spin; rotate",
+        "primary_1": "旋转",
+        "primary_2": "旋轉"
+    },
+    {
+        "intermediate_1": "xuan3ba2",
+        "intermediate_2": "xuǎnbá",
+        "native_1": "select the best; choose",
+        "primary_1": "选拔",
+        "primary_2": "選拔"
+    },
+    {
+        "intermediate_1": "xuan3ju3",
+        "intermediate_2": "xuǎnjǔ",
+        "native_1": "elect; election",
+        "primary_1": "选举",
+        "primary_2": "選舉"
+    },
+    {
+        "intermediate_1": "xuan3shou3",
+        "intermediate_2": "xuǎnshǒu",
+        "native_1": "athlete; contestant; player",
+        "primary_1": "选手",
+        "primary_2": "選手"
+    },
+    {
+        "intermediate_1": "xuan4yao4",
+        "intermediate_2": "xuànyào",
+        "native_1": "to show off; flaunt",
+        "primary_1": "炫耀",
+        "primary_2": "炫耀"
+    },
+    {
+        "intermediate_1": "xue1ruo4",
+        "intermediate_2": "xuēruò",
+        "native_1": "weaken; to cripple",
+        "primary_1": "削弱",
+        "primary_2": "削弱"
+    },
+    {
+        "intermediate_1": "xue2shuo1",
+        "intermediate_2": "xuéshuō",
+        "native_1": "theory; doctrine",
+        "primary_1": "学说",
+        "primary_2": "學說"
+    },
+    {
+        "intermediate_1": "xue2wei4",
+        "intermediate_2": "xuéwèi",
+        "native_1": "academic degree; educational level",
+        "primary_1": "学位",
+        "primary_2": "學位"
+    },
+    {
+        "intermediate_1": "xue3shang4jia1shuang1",
+        "intermediate_2": "xuěshàngjiāshuāng",
+        "native_1": "(literally) add frost to snow; one disaster after another; insult added to injury",
+        "primary_1": "雪上加霜",
+        "primary_2": "雪上加霜"
+    },
+    {
+        "intermediate_1": "xue4ya1",
+        "intermediate_2": "xuèyā",
+        "native_1": "blood pressure",
+        "primary_1": "血压",
+        "primary_2": "血壓"
+    },
+    {
+        "intermediate_1": "xun1tao2",
+        "intermediate_2": "xūntáo",
+        "native_1": "to influence (positively)",
+        "primary_1": "熏陶",
+        "primary_2": "熏陶"
+    },
+    {
+        "intermediate_1": "xun2mi4",
+        "intermediate_2": "xúnmì",
+        "native_1": "to seek; to look for",
+        "primary_1": "寻觅",
+        "primary_2": "尋覓"
+    },
+    {
+        "intermediate_1": "xun2luo2",
+        "intermediate_2": "xúnluó",
+        "native_1": "to patrol (police, army or navy)",
+        "primary_1": "巡逻",
+        "primary_2": "巡邏"
+    },
+    {
+        "intermediate_1": "xun2huan2",
+        "intermediate_2": "xúnhuán",
+        "native_1": "circular cycle; loop; circulate",
+        "primary_1": "循环",
+        "primary_2": "循環"
+    },
+    {
+        "intermediate_1": "xun2 xu4 jian4 jin4",
+        "intermediate_2": "xún xù jiàn jìn",
+        "native_1": "make steady progress incrementally; step by step program",
+        "primary_1": "循序渐进",
+        "primary_2": "循序漸進"
+    },
+    {
+        "intermediate_1": "ya1po4",
+        "intermediate_2": "yāpò",
+        "native_1": "oppress",
+        "primary_1": "压迫",
+        "primary_2": "壓迫"
+    },
+    {
+        "intermediate_1": "ya1sui4qian2",
+        "intermediate_2": "yāsuìqián",
+        "native_1": "gifts of money given to children during the Spring Festival",
+        "primary_1": "压岁钱",
+        "primary_2": "壓歲錢"
+    },
+    {
+        "intermediate_1": "ya1suo1",
+        "intermediate_2": "yāsuō",
+        "native_1": "to compress",
+        "primary_1": "压缩",
+        "primary_2": "壓縮"
+    },
+    {
+        "intermediate_1": "ya1yi4",
+        "intermediate_2": "yāyì",
+        "native_1": "constrain or repress one's emotions; inhibition; repressive",
+        "primary_1": "压抑",
+        "primary_2": "壓抑"
+    },
+    {
+        "intermediate_1": "ya1zha4",
+        "intermediate_2": "yāzhà",
+        "native_1": "to press; to squeeze; to extract juice, oil, etc. by squeezing",
+        "primary_1": "压榨",
+        "primary_2": "壓榨"
+    },
+    {
+        "intermediate_1": "ya1zhi4",
+        "intermediate_2": "yāzhì",
+        "native_1": "suppress; inhibit; stifle",
+        "primary_1": "压制",
+        "primary_2": "壓制"
+    },
+    {
+        "intermediate_1": "ya1que4wu2sheng1",
+        "intermediate_2": "yāquèwúshēng",
+        "native_1": "not even a crow or sparrow can be heard (idiom); silence reigns",
+        "primary_1": "鸦雀无声",
+        "primary_2": "鴉雀無聲"
+    },
+    {
+        "intermediate_1": "ya4jun1",
+        "intermediate_2": "yàjūn",
+        "native_1": "second place; runner-up",
+        "primary_1": "亚军",
+        "primary_2": "亞軍"
+    },
+    {
+        "intermediate_1": "yan1hua1bao4zhu2",
+        "intermediate_2": "yānhuābàozhú",
+        "native_1": "fireworks and crackers",
+        "primary_1": "烟花爆竹",
+        "primary_2": "煙花爆竹"
+    },
+    {
+        "intermediate_1": "yan1mo4",
+        "intermediate_2": "yānmò",
+        "native_1": "submerge; drown; to flood",
+        "primary_1": "淹没",
+        "primary_2": "淹沒"
+    },
+    {
+        "intermediate_1": "yan2 qi1",
+        "intermediate_2": "yán qī",
+        "native_1": "delay; extend; postpone",
+        "primary_1": "延期",
+        "primary_2": "延期"
+    },
+    {
+        "intermediate_1": "yan2shen1",
+        "intermediate_2": "yánshēn",
+        "native_1": "extend; spread; stretch",
+        "primary_1": "延伸",
+        "primary_2": "延伸"
+    },
+    {
+        "intermediate_1": "yan2xu4",
+        "intermediate_2": "yánxù",
+        "native_1": "continue; last longer",
+        "primary_1": "延续",
+        "primary_2": "延續"
+    },
+    {
+        "intermediate_1": "yan2han2",
+        "intermediate_2": "yánhán",
+        "native_1": "bitter cold; severe winter",
+        "primary_1": "严寒",
+        "primary_2": "嚴寒"
+    },
+    {
+        "intermediate_1": "yan2jin4",
+        "intermediate_2": "yánjìn",
+        "native_1": "strictly prohibit; forbid",
+        "primary_1": "严禁",
+        "primary_2": "嚴禁"
+    },
+    {
+        "intermediate_1": "yan2jun4",
+        "intermediate_2": "yánjùn",
+        "native_1": "grim; severe; rigorous; harsh",
+        "primary_1": "严峻",
+        "primary_2": "嚴峻"
+    },
+    {
+        "intermediate_1": "yan2li4",
+        "intermediate_2": "yánlì",
+        "native_1": "strict; severe",
+        "primary_1": "严厉",
+        "primary_2": "嚴厲"
+    },
+    {
+        "intermediate_1": "yan2mi4",
+        "intermediate_2": "yánmì",
+        "native_1": "strict; closely-knit; tight",
+        "primary_1": "严密",
+        "primary_2": "嚴密"
+    },
+    {
+        "intermediate_1": "yan2lun4",
+        "intermediate_2": "yánlùn",
+        "native_1": "expression of (political) opinion; speech",
+        "primary_1": "言论",
+        "primary_2": "言論"
+    },
+    {
+        "intermediate_1": "yan2shi2",
+        "intermediate_2": "yánshí",
+        "native_1": "rock; stone",
+        "primary_1": "岩石",
+        "primary_2": "岩石"
+    },
+    {
+        "intermediate_1": "yan2re4",
+        "intermediate_2": "yánrè",
+        "native_1": "blistering hot; sizzling hot (weather)",
+        "primary_1": "炎热",
+        "primary_2": "炎熱"
+    },
+    {
+        "intermediate_1": "yan2hai3",
+        "intermediate_2": "yánhǎi",
+        "native_1": "coastal",
+        "primary_1": "沿海",
+        "primary_2": "沿海"
+    },
+    {
+        "intermediate_1": "yang3ai4",
+        "intermediate_2": "yǎngài",
+        "native_1": "conceal; cover up; hide behind",
+        "primary_1": "掩盖",
+        "primary_2": "掩蓋"
+    },
+    {
+        "intermediate_1": "yan3hu4",
+        "intermediate_2": "yǎnhù",
+        "native_1": "cover; shield; screen",
+        "primary_1": "掩护",
+        "primary_2": "掩護"
+    },
+    {
+        "intermediate_1": "yan3shi4",
+        "intermediate_2": "yǎnshì",
+        "native_1": "conceal a fault; gloss over",
+        "primary_1": "掩饰",
+        "primary_2": "掩飾"
+    },
+    {
+        "intermediate_1": "yang3uang1",
+        "intermediate_2": "yǎnguāng",
+        "native_1": "vision",
+        "primary_1": "眼光",
+        "primary_2": "眼光"
+    },
+    {
+        "intermediate_1": "yan3se4",
+        "intermediate_2": "yǎnsè",
+        "native_1": "a wink; signal with one's eyes",
+        "primary_1": "眼色",
+        "primary_2": "眼色"
+    },
+    {
+        "intermediate_1": "yan3shen2",
+        "intermediate_2": "yǎnshén",
+        "native_1": "expression or emotion showing in one's eyes",
+        "primary_1": "眼神",
+        "primary_2": "眼神"
+    },
+    {
+        "intermediate_1": "yan3bian4",
+        "intermediate_2": "yǎnbiàn",
+        "native_1": "develop; evolve",
+        "primary_1": "演变",
+        "primary_2": "演變"
+    },
+    {
+        "intermediate_1": "yan3xi2",
+        "intermediate_2": "yǎnxí",
+        "native_1": "rehearse; practice; put on a play",
+        "primary_1": "演习",
+        "primary_2": "演習"
+    },
+    {
+        "intermediate_1": "yan3yi4",
+        "intermediate_2": "yǎnyì",
+        "native_1": "deduction; to deduce; to infer",
+        "primary_1": "演绎",
+        "primary_2": "演繹"
+    },
+    {
+        "intermediate_1": "yan3zou4",
+        "intermediate_2": "yǎnzòu",
+        "native_1": "give an instrumental performance",
+        "primary_1": "演奏",
+        "primary_2": "演奏"
+    },
+    {
+        "intermediate_1": "yan4wu4",
+        "intermediate_2": "yànwù",
+        "native_1": "loathe; to hate; detest",
+        "primary_1": "厌恶",
+        "primary_2": "厭惡"
+    },
+    {
+        "intermediate_1": "yan4shou1",
+        "intermediate_2": "yànshōu",
+        "native_1": "inspect and then accept (i.e. received goods",
+        "primary_1": "验收",
+        "primary_2": "驗收"
+    },
+    {
+        "intermediate_1": "yan4zheng4",
+        "intermediate_2": "yànzhèng",
+        "native_1": "inspect and verify",
+        "primary_1": "验证",
+        "primary_2": "驗證"
+    },
+    {
+        "intermediate_1": "yang3qi4",
+        "intermediate_2": "yǎngqì",
+        "native_1": "oxygen",
+        "primary_1": "氧气",
+        "primary_2": "氧氣"
+    },
+    {
+        "intermediate_1": "yang4pin3",
+        "intermediate_2": "yàngpǐn",
+        "native_1": "sample; specimen",
+        "primary_1": "样品",
+        "primary_2": "樣品"
+    },
+    {
+        "intermediate_1": "yao2yan2",
+        "intermediate_2": "yáoyán",
+        "native_1": "rumor",
+        "primary_1": "谣言",
+        "primary_2": "謠言"
+    },
+    {
+        "intermediate_1": "yao2bai3",
+        "intermediate_2": "yáobǎi",
+        "native_1": "to waver; to wag; to sway",
+        "primary_1": "摇摆",
+        "primary_2": "搖擺"
+    },
+    {
+        "intermediate_1": "yao2gun3",
+        "intermediate_2": "yáogǔn",
+        "native_1": "rock and roll",
+        "primary_1": "摇滚",
+        "primary_2": "搖滾"
+    },
+    {
+        "intermediate_1": "yao2kong4",
+        "intermediate_2": "yáokòng",
+        "native_1": "remote control",
+        "primary_1": "遥控",
+        "primary_2": "遙控"
+    },
+    {
+        "intermediate_1": "yao2yuan3",
+        "intermediate_2": "yáoyuǎn",
+        "native_1": "distant; remote",
+        "primary_1": "遥远",
+        "primary_2": "遙遠"
+    },
+    {
+        "intermediate_1": "yao4dian3",
+        "intermediate_2": "yàodiǎn",
+        "native_1": "main point; essential",
+        "primary_1": "要点",
+        "primary_2": "要點"
+    },
+    {
+        "intermediate_1": "yao4ming4",
+        "intermediate_2": "yàomìng",
+        "native_1": "cause somebody's death; very; extremely; frighteningly; annoyance",
+        "primary_1": "要命",
+        "primary_2": "要命"
+    },
+    {
+        "intermediate_1": "yao4su4",
+        "intermediate_2": "yàosù",
+        "native_1": "essential factor; key constituent",
+        "primary_1": "要素",
+        "primary_2": "要素"
+    },
+    {
+        "intermediate_1": "yao4yan3",
+        "intermediate_2": "yàoyǎn",
+        "native_1": "dazzle; to shine",
+        "primary_1": "耀眼",
+        "primary_2": "耀眼"
+    },
+    {
+        "intermediate_1": "ye3man2",
+        "intermediate_2": "yěmán",
+        "native_1": "barbarous; uncivilized; cruel; wild",
+        "primary_1": "野蛮",
+        "primary_2": "野蠻"
+    },
+    {
+        "intermediate_1": "ye3xin1",
+        "intermediate_2": "yěxīn",
+        "native_1": "ambition; wild schemes or ambitions; careerism",
+        "primary_1": "野心",
+        "primary_2": "野心"
+    },
+    {
+        "intermediate_1": "ye4ti3",
+        "intermediate_2": "yètǐ",
+        "native_1": "liquid",
+        "primary_1": "液体",
+        "primary_2": "液體"
+    },
+    {
+        "intermediate_1": "yi2du4",
+        "intermediate_2": "yídù",
+        "native_1": "for a time; at one time; one time; once",
+        "primary_1": "一度",
+        "primary_2": "一度"
+    },
+    {
+        "intermediate_1": "yi4fan1feng1shun4",
+        "intermediate_2": "yìfānfēngshùn",
+        "native_1": "(saying) smooth sailing",
+        "primary_1": "一帆风顺",
+        "primary_2": "一帆風順"
+    },
+    {
+        "intermediate_1": "yi2guan4",
+        "intermediate_2": "yíguàn",
+        "native_1": "consistent; constant; from start to finish; then as now",
+        "primary_1": "一贯",
+        "primary_2": "一貫"
+    },
+    {
+        "intermediate_1": "yi4ju3liang3de2",
+        "intermediate_2": "yìjǔliǎngdé",
+        "native_1": "kill two birds with one stone; (literally) attain two objectives with a single move",
+        "primary_1": "一举两得",
+        "primary_2": "一舉兩得"
+    },
+    {
+        "intermediate_1": "yi1liu2",
+        "intermediate_2": "yīliú",
+        "native_1": "top-grade",
+        "primary_1": "一流",
+        "primary_2": "一流"
+    },
+    {
+        "intermediate_1": "yi2mu4liao3ran2",
+        "intermediate_2": "yímùliǎorán",
+        "native_1": "obvious at a glance",
+        "primary_1": "一目了然",
+        "primary_2": "一目了然"
+    },
+    {
+        "intermediate_1": "yi4ru2ji4wang3",
+        "intermediate_2": "yìrújìwǎng",
+        "native_1": "just as in the past (idiom); as before; continuing as always",
+        "primary_1": "一如既往",
+        "primary_2": "一如既往"
+    },
+    {
+        "intermediate_1": "yi4si1bu4gou3",
+        "intermediate_2": "yìsībùgǒu",
+        "native_1": "(literally) not one thread loose; strictly according to the rules; meticulous",
+        "primary_1": "一丝不苟",
+        "primary_2": "一絲不苟"
+    },
+    {
+        "intermediate_1": "yi2xiang4",
+        "intermediate_2": "yíxiàng",
+        "native_1": "all along; the whole time; constantly; always",
+        "primary_1": "一向",
+        "primary_2": "一向"
+    },
+    {
+        "intermediate_1": "yi1shang",
+        "intermediate_2": "yīshang",
+        "native_1": "clothes",
+        "primary_1": "衣裳",
+        "primary_2": "衣裳"
+    },
+    {
+        "intermediate_1": "yi1jiu4",
+        "intermediate_2": "yījiù",
+        "native_1": "as before; still",
+        "primary_1": "依旧",
+        "primary_2": "依舊"
+    },
+    {
+        "intermediate_1": "yi1ju4",
+        "intermediate_2": "yījù",
+        "native_1": "according to; basis; foundation",
+        "primary_1": "依据",
+        "primary_2": "依據"
+    },
+    {
+        "intermediate_1": "yi1kao4",
+        "intermediate_2": "yīkào",
+        "native_1": "rely on; depend on",
+        "primary_1": "依靠",
+        "primary_2": "依靠"
+    },
+    {
+        "intermediate_1": "yi1lai4",
+        "intermediate_2": "yīlài",
+        "native_1": "depend on; be dependent on",
+        "primary_1": "依赖",
+        "primary_2": "依賴"
+    },
+    {
+        "intermediate_1": "yi1tuo1",
+        "intermediate_2": "yītuō",
+        "native_1": "rely on; depend on",
+        "primary_1": "依托",
+        "primary_2": "依托"
+    },
+    {
+        "intermediate_1": "yi2qi4",
+        "intermediate_2": "yíqì",
+        "native_1": "apparatus; (scientific) instrument",
+        "primary_1": "仪器",
+        "primary_2": "儀器"
+    },
+    {
+        "intermediate_1": "yi2shi4",
+        "intermediate_2": "yíshì",
+        "native_1": "ceremony",
+        "primary_1": "仪式",
+        "primary_2": "儀式"
+    },
+    {
+        "intermediate_1": "yi2chan3",
+        "intermediate_2": "yíchǎn",
+        "native_1": "heritage; legacy",
+        "primary_1": "遗产",
+        "primary_2": "遺産"
+    },
+    {
+        "intermediate_1": "yi2chuan2",
+        "intermediate_2": "yíchuán",
+        "native_1": "inherit; hereditary",
+        "primary_1": "遗传",
+        "primary_2": "遺傳"
+    },
+    {
+        "intermediate_1": "yi2liu2",
+        "intermediate_2": "yíliú",
+        "native_1": "legacy; left over; hand down",
+        "primary_1": "遗留",
+        "primary_2": "遺留"
+    },
+    {
+        "intermediate_1": "yi2shi1",
+        "intermediate_2": "yíshī",
+        "native_1": "lose; lose due to carelessness",
+        "primary_1": "遗失",
+        "primary_2": "遺失"
+    },
+    {
+        "intermediate_1": "yi2huo4",
+        "intermediate_2": "yíhuò",
+        "native_1": "(a sense of) uncertainty; to feel unsure about something; uncertainty",
+        "primary_1": "疑惑",
+        "primary_2": "疑惑"
+    },
+    {
+        "intermediate_1": "yi3bian4",
+        "intermediate_2": "yǐbiàn",
+        "native_1": "so that; in order to",
+        "primary_1": "以便",
+        "primary_2": "以便"
+    },
+    {
+        "intermediate_1": "yi3mian3",
+        "intermediate_2": "yǐmiǎn",
+        "native_1": "so as not to; in order to avoid; lest",
+        "primary_1": "以免",
+        "primary_2": "以免"
+    },
+    {
+        "intermediate_1": "yi3wang3",
+        "intermediate_2": "yǐwǎng",
+        "native_1": "in the past; formerly",
+        "primary_1": "以往",
+        "primary_2": "以往"
+    },
+    {
+        "intermediate_1": "yi3zhi4",
+        "intermediate_2": "yǐzhì",
+        "native_1": "down to; up to; to such an extent as to...",
+        "primary_1": "以至",
+        "primary_2": "以至"
+    },
+    {
+        "intermediate_1": "yi3zhi4",
+        "intermediate_2": "yǐzhì",
+        "native_1": "so that; as a result",
+        "primary_1": "以致",
+        "primary_2": "以致"
+    },
+    {
+        "intermediate_1": "yi4",
+        "intermediate_2": "yì",
+        "native_1": "also",
+        "primary_1": "亦",
+        "primary_2": "亦"
+    },
+    {
+        "intermediate_1": "yi4chang2",
+        "intermediate_2": "yìcháng",
+        "native_1": "exceptional; abnormal",
+        "primary_1": "异常",
+        "primary_2": "異常"
+    },
+    {
+        "intermediate_1": "yi4liao4",
+        "intermediate_2": "yìliào",
+        "native_1": "expectation; to anticipate; to think ahead",
+        "primary_1": "意料",
+        "primary_2": "意料"
+    },
+    {
+        "intermediate_1": "yi4shi",
+        "intermediate_2": "yìshi",
+        "native_1": "realize; consciousness; awareness; sense",
+        "primary_1": "意识",
+        "primary_2": "意識"
+    },
+    {
+        "intermediate_1": "yi4tu2",
+        "intermediate_2": "yìtú",
+        "native_1": "intent; intention; intend",
+        "primary_1": "意图",
+        "primary_2": "意圖"
+    },
+    {
+        "intermediate_1": "yi4wei4zhe",
+        "intermediate_2": "yìwèizhe",
+        "native_1": "signify; to mean; imply",
+        "primary_1": "意味着",
+        "primary_2": "意味著"
+    },
+    {
+        "intermediate_1": "yi4xiang4",
+        "intermediate_2": "yìxiàng",
+        "native_1": "will; intent; disposition",
+        "primary_1": "意向",
+        "primary_2": "意向"
+    },
+    {
+        "intermediate_1": "yi4zhi4",
+        "intermediate_2": "yìzhì",
+        "native_1": "will; willpower; determination",
+        "primary_1": "意志",
+        "primary_2": "意志"
+    },
+    {
+        "intermediate_1": "yi4li4",
+        "intermediate_2": "yìlì",
+        "native_1": "willpower; perseverance; will; stamina; tenacity",
+        "primary_1": "毅力",
+        "primary_2": "毅力"
+    },
+    {
+        "intermediate_1": "yi4ran2",
+        "intermediate_2": "yìrán",
+        "native_1": "without hesitation; resolutely; firmly",
+        "primary_1": "毅然",
+        "primary_2": "毅然"
+    },
+    {
+        "intermediate_1": "yi4",
+        "intermediate_2": "yì",
+        "native_1": "wings; fins on fish; shelter",
+        "primary_1": "翼",
+        "primary_2": "翼"
+    },
+    {
+        "intermediate_1": "yin1mou2",
+        "intermediate_2": "yīnmóu",
+        "native_1": "a plot; a conspiracy",
+        "primary_1": "阴谋",
+        "primary_2": "陰謀"
+    },
+    {
+        "intermediate_1": "yin1xiang3",
+        "intermediate_2": "yīnxiǎng",
+        "native_1": "(Electronic) speakers; acoustics; sound field (i.e., in a room or theater)",
+        "primary_1": "音响",
+        "primary_2": "音響"
+    },
+    {
+        "intermediate_1": "yin3dao3",
+        "intermediate_2": "yǐndǎo",
+        "native_1": "to guide; to conduct; introduction",
+        "primary_1": "引导",
+        "primary_2": "引導"
+    },
+    {
+        "intermediate_1": "yin3qing2",
+        "intermediate_2": "yǐnqíng",
+        "native_1": "engine",
+        "primary_1": "引擎",
+        "primary_2": "引擎"
+    },
+    {
+        "intermediate_1": "yin3yong4",
+        "intermediate_2": "yǐnyòng",
+        "native_1": "quote; cite",
+        "primary_1": "引用",
+        "primary_2": "引用"
+    },
+    {
+        "intermediate_1": "yin3shi2",
+        "intermediate_2": "yǐnshí",
+        "native_1": "food and drink; diet",
+        "primary_1": "饮食",
+        "primary_2": "飲食"
+    },
+    {
+        "intermediate_1": "yin3bi4",
+        "intermediate_2": "yǐnbì",
+        "native_1": "conceal; hide; covert; under cover; Take cover!",
+        "primary_1": "隐蔽",
+        "primary_2": "隱蔽"
+    },
+    {
+        "intermediate_1": "yin3huan4",
+        "intermediate_2": "yǐnhuàn",
+        "native_1": "hidden danger",
+        "primary_1": "隐患",
+        "primary_2": "隱患"
+    },
+    {
+        "intermediate_1": "yin3man2",
+        "intermediate_2": "yǐnmán",
+        "native_1": "conceal; hide; (a taboo subject); cover up the truth",
+        "primary_1": "隐瞒",
+        "primary_2": "隱瞞"
+    },
+    {
+        "intermediate_1": "yin3si1",
+        "intermediate_2": "yǐnsī",
+        "native_1": "privacy; personal secret",
+        "primary_1": "隐私",
+        "primary_2": "隱私"
+    },
+    {
+        "intermediate_1": "yin3yue1",
+        "intermediate_2": "yǐnyuē",
+        "native_1": "vague; faint; indistinct",
+        "primary_1": "隐约",
+        "primary_2": "隱約"
+    },
+    {
+        "intermediate_1": "ying1ming2",
+        "intermediate_2": "yīngmíng",
+        "native_1": "wise; brilliant",
+        "primary_1": "英明",
+        "primary_2": "英明"
+    },
+    {
+        "intermediate_1": "ying1yong3",
+        "intermediate_2": "yīngyǒng",
+        "native_1": "bravery; heroic; valiant; gallant",
+        "primary_1": "英勇",
+        "primary_2": "英勇"
+    },
+    {
+        "intermediate_1": "ying1'er2",
+        "intermediate_2": "yīng'ér",
+        "native_1": "baby infant",
+        "primary_1": "婴儿",
+        "primary_2": "嬰兒"
+    },
+    {
+        "intermediate_1": "ying2 mian4",
+        "intermediate_2": "yíng miàn",
+        "native_1": "face to face; headlong; in one's face",
+        "primary_1": "迎面",
+        "primary_2": "迎面"
+    },
+    {
+        "intermediate_1": "ying2li4",
+        "intermediate_2": "yínglì",
+        "native_1": "profit; gain",
+        "primary_1": "盈利",
+        "primary_2": "盈利"
+    },
+    {
+        "intermediate_1": "ying4chou",
+        "intermediate_2": "yìngchou",
+        "native_1": "socialize with; a social engagement",
+        "primary_1": "应酬",
+        "primary_2": "應酬"
+    },
+    {
+        "intermediate_1": "ying4yao1",
+        "intermediate_2": "yìngyāo",
+        "native_1": "at sb.'s invitation",
+        "primary_1": "应邀",
+        "primary_2": "應邀"
+    },
+    {
+        "intermediate_1": "yong1hu4",
+        "intermediate_2": "yōnghù",
+        "native_1": "to support; endorse",
+        "primary_1": "拥护",
+        "primary_2": "擁護"
+    },
+    {
+        "intermediate_1": "yong1you3",
+        "intermediate_2": "yōngyǒu",
+        "native_1": "have; possess",
+        "primary_1": "拥有",
+        "primary_2": "擁有"
+    },
+    {
+        "intermediate_1": "yong1su2",
+        "intermediate_2": "yōngsú",
+        "native_1": "filthy; vulgar; debased",
+        "primary_1": "庸俗",
+        "primary_2": "庸俗"
+    },
+    {
+        "intermediate_1": "yong3heng2",
+        "intermediate_2": "yǒnghéng",
+        "native_1": "eternal; everlasting",
+        "primary_1": "永恒",
+        "primary_2": "永恒"
+    },
+    {
+        "intermediate_1": "yong3yu2",
+        "intermediate_2": "yǒngyú",
+        "native_1": "have the courage to; be brave enough",
+        "primary_1": "勇于",
+        "primary_2": "勇于"
+    },
+    {
+        "intermediate_1": "yong3xian4",
+        "intermediate_2": "yǒngxiàn",
+        "native_1": "spring up; emerge prominently",
+        "primary_1": "涌现",
+        "primary_2": "湧現"
+    },
+    {
+        "intermediate_1": "yong3yue4",
+        "intermediate_2": "yǒngyuè",
+        "native_1": "eager; enthusiastically",
+        "primary_1": "踊跃",
+        "primary_2": "踴躍"
+    },
+    {
+        "intermediate_1": "yong4hu4",
+        "intermediate_2": "yònghù",
+        "native_1": "user; consumer; subscriber; customer",
+        "primary_1": "用户",
+        "primary_2": "用戶"
+    },
+    {
+        "intermediate_1": "you1sheng4lie4tai4",
+        "intermediate_2": "yōushèngliètài",
+        "native_1": "survival of the fittest",
+        "primary_1": "优胜劣汰",
+        "primary_2": "優勝劣汰"
+    },
+    {
+        "intermediate_1": "you1xian1",
+        "intermediate_2": "yōuxiān",
+        "native_1": "priority; preferential",
+        "primary_1": "优先",
+        "primary_2": "優先"
+    },
+    {
+        "intermediate_1": "you1yi4",
+        "intermediate_2": "yōuyì",
+        "native_1": "exceptional; excellent; outstandingly good",
+        "primary_1": "优异",
+        "primary_2": "優異"
+    },
+    {
+        "intermediate_1": "you1yue4",
+        "intermediate_2": "yōuyuè",
+        "native_1": "superior; superiority",
+        "primary_1": "优越",
+        "primary_2": "優越"
+    },
+    {
+        "intermediate_1": "you1yu4",
+        "intermediate_2": "yōuyù",
+        "native_1": "melancholy; dejected",
+        "primary_1": "忧郁",
+        "primary_2": "憂郁"
+    },
+    {
+        "intermediate_1": "you2ru2",
+        "intermediate_2": "yóurú",
+        "native_1": "just as; similar to; appearing to be",
+        "primary_1": "犹如",
+        "primary_2": "猶如"
+    },
+    {
+        "intermediate_1": "you2ni4",
+        "intermediate_2": "yóunì",
+        "native_1": "greasy or oily (food)",
+        "primary_1": "油腻",
+        "primary_2": "油膩"
+    },
+    {
+        "intermediate_1": "you2qi1",
+        "intermediate_2": "yóuqī",
+        "native_1": "oil paint; varnish",
+        "primary_1": "油漆",
+        "primary_2": "油漆"
+    },
+    {
+        "intermediate_1": "you3tiao2bu4wen3",
+        "intermediate_2": "yǒutiáobùwěn",
+        "native_1": "in an orderly way; methodically; systematically; methodical",
+        "primary_1": "有条不紊",
+        "primary_2": "有條不紊"
+    },
+    {
+        "intermediate_1": "you4zhi4",
+        "intermediate_2": "yòuzhì",
+        "native_1": "childish; naïve; immature",
+        "primary_1": "幼稚",
+        "primary_2": "幼稚"
+    },
+    {
+        "intermediate_1": "you4huo4",
+        "intermediate_2": "yòuhuò",
+        "native_1": "tempt; temptation; entice; lure; attract",
+        "primary_1": "诱惑",
+        "primary_2": "誘惑"
+    },
+    {
+        "intermediate_1": "yu2min2",
+        "intermediate_2": "yúmín",
+        "native_1": "fisherman; fisher folk",
+        "primary_1": "渔民",
+        "primary_2": "漁民"
+    },
+    {
+        "intermediate_1": "yu2chun3",
+        "intermediate_2": "yúchǔn",
+        "native_1": "silly; stupid",
+        "primary_1": "愚蠢",
+        "primary_2": "愚蠢"
+    },
+    {
+        "intermediate_1": "yu2mei4",
+        "intermediate_2": "yúmèi",
+        "native_1": "ignorant; benighted",
+        "primary_1": "愚昧",
+        "primary_2": "愚昧"
+    },
+    {
+        "intermediate_1": "yu2lun4",
+        "intermediate_2": "yúlùn",
+        "native_1": "public opinion",
+        "primary_1": "舆论",
+        "primary_2": "輿論"
+    },
+    {
+        "intermediate_1": "yu3ri4ju4zeng1",
+        "intermediate_2": "yǔrìjùzēng",
+        "native_1": "grow with each passing day",
+        "primary_1": "与日俱增",
+        "primary_2": "與日俱增"
+    },
+    {
+        "intermediate_1": "yu3zhou4",
+        "intermediate_2": "yǔzhòu",
+        "native_1": "universe; cosmos",
+        "primary_1": "宇宙",
+        "primary_2": "宇宙"
+    },
+    {
+        "intermediate_1": "yu3rong2fu2",
+        "intermediate_2": "yǔróngfú",
+        "native_1": "down jacket",
+        "primary_1": "羽绒服",
+        "primary_2": "羽絨服"
+    },
+    {
+        "intermediate_1": "yu4",
+        "intermediate_2": "yù",
+        "native_1": "jade (Kangxi radical 96)",
+        "primary_1": "玉",
+        "primary_2": "玉"
+    },
+    {
+        "intermediate_1": "yu4liao4",
+        "intermediate_2": "yùliào",
+        "native_1": "anticipate; to forecast; expectation",
+        "primary_1": "预料",
+        "primary_2": "預料"
+    },
+    {
+        "intermediate_1": "yu4qi1",
+        "intermediate_2": "yùqī",
+        "native_1": "expect; expected; anticipate",
+        "primary_1": "预期",
+        "primary_2": "預期"
+    },
+    {
+        "intermediate_1": "yu4suan4",
+        "intermediate_2": "yùsuàn",
+        "native_1": "budget",
+        "primary_1": "预算",
+        "primary_2": "預算"
+    },
+    {
+        "intermediate_1": "yu4xian1",
+        "intermediate_2": "yùxiān",
+        "native_1": "beforehand; prior",
+        "primary_1": "预先",
+        "primary_2": "預先"
+    },
+    {
+        "intermediate_1": "yu4yan2",
+        "intermediate_2": "yùyán",
+        "native_1": "predict; prophecy",
+        "primary_1": "预言",
+        "primary_2": "預言"
+    },
+    {
+        "intermediate_1": "yu4zhao4",
+        "intermediate_2": "yùzhào",
+        "native_1": "omen, sign",
+        "primary_1": "预兆",
+        "primary_2": "預兆"
+    },
+    {
+        "intermediate_1": "yu4wang4",
+        "intermediate_2": "yùwàng",
+        "native_1": "desire; lust",
+        "primary_1": "欲望",
+        "primary_2": "欲望"
+    },
+    {
+        "intermediate_1": "yu4yan2",
+        "intermediate_2": "yùyán",
+        "native_1": "fable",
+        "primary_1": "寓言",
+        "primary_2": "寓言"
+    },
+    {
+        "intermediate_1": "yu4",
+        "intermediate_2": "yù",
+        "native_1": "recover; heal; the more ... the more",
+        "primary_1": "愈",
+        "primary_2": "愈"
+    },
+    {
+        "intermediate_1": "yuan1wang",
+        "intermediate_2": "yuānwang",
+        "native_1": "to wrong; injustice; not worthwhile",
+        "primary_1": "冤枉",
+        "primary_2": "冤枉"
+    },
+    {
+        "intermediate_1": "yuan2shou3",
+        "intermediate_2": "yuánshǒu",
+        "native_1": "head of state",
+        "primary_1": "元首",
+        "primary_2": "元首"
+    },
+    {
+        "intermediate_1": "yuan2su4",
+        "intermediate_2": "yuánsù",
+        "native_1": "element; element of a set; chemical element",
+        "primary_1": "元素",
+        "primary_2": "元素"
+    },
+    {
+        "intermediate_1": "Yuan2xiao1 Jie2",
+        "intermediate_2": "Yuánxiāo Jié",
+        "native_1": "the Lantern Festival",
+        "primary_1": "元宵节",
+        "primary_2": "元宵節"
+    },
+    {
+        "intermediate_1": "yuan2lin2",
+        "intermediate_2": "yuánlín",
+        "native_1": "gardens; park; landscape",
+        "primary_1": "园林",
+        "primary_2": "園林"
+    },
+    {
+        "intermediate_1": "yuang2ao4",
+        "intermediate_2": "yuángào",
+        "native_1": "plaintiff; complainant; accuser",
+        "primary_1": "原告",
+        "primary_2": "原告"
+    },
+    {
+        "intermediate_1": "yuan2li3",
+        "intermediate_2": "yuánlǐ",
+        "native_1": "principle; theory",
+        "primary_1": "原理",
+        "primary_2": "原理"
+    },
+    {
+        "intermediate_1": "yuan2shi3",
+        "intermediate_2": "yuánshǐ",
+        "native_1": "first; original; primitive",
+        "primary_1": "原始",
+        "primary_2": "原始"
+    },
+    {
+        "intermediate_1": "yuan2xian1",
+        "intermediate_2": "yuánxiān",
+        "native_1": "former; original",
+        "primary_1": "原先",
+        "primary_2": "原先"
+    },
+    {
+        "intermediate_1": "yuan2man3",
+        "intermediate_2": "yuánmǎn",
+        "native_1": "satisfactory",
+        "primary_1": "圆满",
+        "primary_2": "圓滿"
+    },
+    {
+        "intermediate_1": "yuang2u4",
+        "intermediate_2": "yuángù",
+        "native_1": "reason; cause",
+        "primary_1": "缘故",
+        "primary_2": "緣故"
+    },
+    {
+        "intermediate_1": "yuan2quan2",
+        "intermediate_2": "yuánquán",
+        "native_1": "headspring; fountainhead; water source",
+        "primary_1": "源泉",
+        "primary_2": "源泉"
+    },
+    {
+        "intermediate_1": "yue1shu4",
+        "intermediate_2": "yuēshù",
+        "native_1": "restrict; limit to; constrain; restriction",
+        "primary_1": "约束",
+        "primary_2": "約束"
+    },
+    {
+        "intermediate_1": "yue4pu3",
+        "intermediate_2": "yuèpǔ",
+        "native_1": "sheet music",
+        "primary_1": "乐谱",
+        "primary_2": "樂譜"
+    },
+    {
+        "intermediate_1": "yue4mu3",
+        "intermediate_2": "yuèmǔ",
+        "native_1": "wife's mother; mother-in-law",
+        "primary_1": "岳母",
+        "primary_2": "嶽母"
+    },
+    {
+        "intermediate_1": "yun4yu4",
+        "intermediate_2": "yùnyù",
+        "native_1": "be pregnant; to produce offspring; nurture (a development, school of thought, artwork, etc.)",
+        "primary_1": "孕育",
+        "primary_2": "孕育"
+    },
+    {
+        "intermediate_1": "yun4suan4",
+        "intermediate_2": "yùnsuàn",
+        "native_1": "(mathematical) operation",
+        "primary_1": "运算",
+        "primary_2": "運算"
+    },
+    {
+        "intermediate_1": "yun4xing2",
+        "intermediate_2": "yùnxíng",
+        "native_1": "movement; be in motion; run",
+        "primary_1": "运行",
+        "primary_2": "運行"
+    },
+    {
+        "intermediate_1": "yun4niang4",
+        "intermediate_2": "yùnniàng",
+        "native_1": "mull over (an issue); hold a preliminary round of exploratory discussions",
+        "primary_1": "酝酿",
+        "primary_2": "醞釀"
+    },
+    {
+        "intermediate_1": "yun4cang2",
+        "intermediate_2": "yùncáng",
+        "native_1": "hold in store; contain untapped quantities",
+        "primary_1": "蕴藏",
+        "primary_2": "蘊藏"
+    },
+    {
+        "intermediate_1": "yun4",
+        "intermediate_2": "yùn",
+        "native_1": "iron; press",
+        "primary_1": "熨",
+        "primary_2": "熨"
+    },
+    {
+        "intermediate_1": "za2ji4",
+        "intermediate_2": "zájì",
+        "native_1": "acrobatics",
+        "primary_1": "杂技",
+        "primary_2": "雜技"
+    },
+    {
+        "intermediate_1": "za2jiao1",
+        "intermediate_2": "zájiāo",
+        "native_1": "create a hybrid; cross-fertilize",
+        "primary_1": "杂交",
+        "primary_2": "雜交"
+    },
+    {
+        "intermediate_1": "za2",
+        "intermediate_2": "zá",
+        "native_1": "to smash; to pound; to break; fail",
+        "primary_1": "砸",
+        "primary_2": "砸"
+    },
+    {
+        "intermediate_1": "za3",
+        "intermediate_2": "zǎ",
+        "native_1": "how/why (contraction of 怎么)",
+        "primary_1": "咋",
+        "primary_2": "咋"
+    },
+    {
+        "intermediate_1": "zai1nan4",
+        "intermediate_2": "zāinàn",
+        "native_1": "disaster; catastrophe",
+        "primary_1": "灾难",
+        "primary_2": "災難"
+    },
+    {
+        "intermediate_1": "zai1pei2",
+        "intermediate_2": "zāipéi",
+        "native_1": "grow; educate; cultivate",
+        "primary_1": "栽培",
+        "primary_2": "栽培"
+    },
+    {
+        "intermediate_1": "zai3",
+        "intermediate_2": "zǎi",
+        "native_1": "slaughter; butcher; govern; rule; imperial official in dynastic China",
+        "primary_1": "宰",
+        "primary_2": "宰"
+    },
+    {
+        "intermediate_1": "zai4jie1zai4li4",
+        "intermediate_2": "zàijiēzàilì",
+        "native_1": "continue the struggle; persist; unremitting efforts",
+        "primary_1": "再接再厉",
+        "primary_2": "再接再厲"
+    },
+    {
+        "intermediate_1": "zai4 yi4",
+        "intermediate_2": "zài yì",
+        "native_1": "care about; mind; care",
+        "primary_1": "在意",
+        "primary_2": "在意"
+    },
+    {
+        "intermediate_1": "zan3",
+        "intermediate_2": "zǎn",
+        "native_1": "save; hoard",
+        "primary_1": "攒",
+        "primary_2": "攢"
+    },
+    {
+        "intermediate_1": "zan4qie3",
+        "intermediate_2": "zànqiě",
+        "native_1": "for the moment; for the time being; temporarily",
+        "primary_1": "暂且",
+        "primary_2": "暫且"
+    },
+    {
+        "intermediate_1": "zan4tan4",
+        "intermediate_2": "zàntàn",
+        "native_1": "sigh or grasp in admiration; highly praise",
+        "primary_1": "赞叹",
+        "primary_2": "贊歎"
+    },
+    {
+        "intermediate_1": "zan4zhu4",
+        "intermediate_2": "zànzhù",
+        "native_1": "support; sponsor",
+        "primary_1": "赞助",
+        "primary_2": "贊助"
+    },
+    {
+        "intermediate_1": "zao1shou4",
+        "intermediate_2": "zāoshòu",
+        "native_1": "suffer; suffering; be subjected to (something unfortunate)",
+        "primary_1": "遭受",
+        "primary_2": "遭受"
+    },
+    {
+        "intermediate_1": "zao1 yang1",
+        "intermediate_2": "zāo yāng",
+        "native_1": "to suffer a calamity; go through a disaster",
+        "primary_1": "遭殃",
+        "primary_2": "遭殃"
+    },
+    {
+        "intermediate_1": "zao1yu4",
+        "intermediate_2": "zāoyù",
+        "native_1": "befall; suffer; encounter",
+        "primary_1": "遭遇",
+        "primary_2": "遭遇"
+    },
+    {
+        "intermediate_1": "zao1ta4",
+        "intermediate_2": "zāotà",
+        "native_1": "waste; ruin; wreck; spoil; slander",
+        "primary_1": "糟蹋",
+        "primary_2": "糟蹋"
+    },
+    {
+        "intermediate_1": "zao4xing2",
+        "intermediate_2": "zàoxíng",
+        "native_1": "make a model; to mold",
+        "primary_1": "造型",
+        "primary_2": "造型"
+    },
+    {
+        "intermediate_1": "zao4yin1",
+        "intermediate_2": "zàoyīn",
+        "native_1": "uproar; rumble; noise; static",
+        "primary_1": "噪音",
+        "primary_2": "噪音"
+    },
+    {
+        "intermediate_1": "ze2guai4",
+        "intermediate_2": "zéguài",
+        "native_1": "blame; rebuke",
+        "primary_1": "责怪",
+        "primary_2": "責怪"
+    },
+    {
+        "intermediate_1": "zei2",
+        "intermediate_2": "zéi",
+        "native_1": "thief",
+        "primary_1": "贼",
+        "primary_2": "賊"
+    },
+    {
+        "intermediate_1": "zeng1tian1",
+        "intermediate_2": "zēngtiān",
+        "native_1": "add to; increase",
+        "primary_1": "增添",
+        "primary_2": "增添"
+    },
+    {
+        "intermediate_1": "zeng4song4",
+        "intermediate_2": "zèngsòng",
+        "native_1": "give as a present",
+        "primary_1": "赠送",
+        "primary_2": "贈送"
+    },
+    {
+        "intermediate_1": "zha1",
+        "intermediate_2": "zhā",
+        "native_1": "to prick; push a needle into; penetrating",
+        "primary_1": "扎",
+        "primary_2": "紮"
+    },
+    {
+        "intermediate_1": "zha1shi",
+        "intermediate_2": "zhāshi",
+        "native_1": "strong; sturdy; practical",
+        "primary_1": "扎实",
+        "primary_2": "紮實"
+    },
+    {
+        "intermediate_1": "zha1",
+        "intermediate_2": "zhā",
+        "native_1": "dregs; slag",
+        "primary_1": "渣",
+        "primary_2": "渣"
+    },
+    {
+        "intermediate_1": "zha3",
+        "intermediate_2": "zhǎ",
+        "native_1": "wink; blink",
+        "primary_1": "眨",
+        "primary_2": "眨"
+    },
+    {
+        "intermediate_1": "zha4pian4",
+        "intermediate_2": "zhàpiàn",
+        "native_1": "defraud; swindle; blackmail",
+        "primary_1": "诈骗",
+        "primary_2": "詐騙"
+    },
+    {
+        "intermediate_1": "zhai1yao4",
+        "intermediate_2": "zhāiyào",
+        "native_1": "summary; abstract",
+        "primary_1": "摘要",
+        "primary_2": "摘要"
+    },
+    {
+        "intermediate_1": "zhai4quan4",
+        "intermediate_2": "zhàiquàn",
+        "native_1": "bond",
+        "primary_1": "债券",
+        "primary_2": "債券"
+    },
+    {
+        "intermediate_1": "zhan1 guang1",
+        "intermediate_2": "zhān guāng",
+        "native_1": "bask in the light; benefit from association with sth.; reflected glory",
+        "primary_1": "沾光",
+        "primary_2": "沾光"
+    },
+    {
+        "intermediate_1": "zhan1yang3",
+        "intermediate_2": "zhānyǎng",
+        "native_1": "look at with reverence; admire",
+        "primary_1": "瞻仰",
+        "primary_2": "瞻仰"
+    },
+    {
+        "intermediate_1": "zhan3 ding1 jie2 tie3",
+        "intermediate_2": "zhǎn dīng jié tiě",
+        "native_1": "to chop the nail and slice the iron (idiom); resolute and decisive; definitely",
+        "primary_1": "斩钉截铁",
+        "primary_2": "斬釘截鐵"
+    },
+    {
+        "intermediate_1": "zhan3shi4",
+        "intermediate_2": "zhǎnshì",
+        "native_1": "open up; reveal; to display",
+        "primary_1": "展示",
+        "primary_2": "展示"
+    },
+    {
+        "intermediate_1": "zhan3wang4",
+        "intermediate_2": "zhǎnwàng",
+        "native_1": "outlook; prospect; to look ahead; look forward to",
+        "primary_1": "展望",
+        "primary_2": "展望"
+    },
+    {
+        "intermediate_1": "zhan3xian4",
+        "intermediate_2": "zhǎnxiàn",
+        "native_1": "come out; emerge; express; show",
+        "primary_1": "展现",
+        "primary_2": "展現"
+    },
+    {
+        "intermediate_1": "zhan3xin1",
+        "intermediate_2": "zhǎnxīn",
+        "native_1": "brand new",
+        "primary_1": "崭新",
+        "primary_2": "嶄新"
+    },
+    {
+        "intermediate_1": "zhan4ju4",
+        "intermediate_2": "zhànjù",
+        "native_1": "occupy; hold; inhabit",
+        "primary_1": "占据",
+        "primary_2": "占據"
+    },
+    {
+        "intermediate_1": "zhan4ling3",
+        "intermediate_2": "zhànlǐng",
+        "native_1": "occupy (a territory); capture; seize",
+        "primary_1": "占领",
+        "primary_2": "占領"
+    },
+    {
+        "intermediate_1": "zhan4dou4",
+        "intermediate_2": "zhàndòu",
+        "native_1": "to fight; to battle; to struggle",
+        "primary_1": "战斗",
+        "primary_2": "戰鬥"
+    },
+    {
+        "intermediate_1": "zhan4lüe4",
+        "intermediate_2": "zhànlüè",
+        "native_1": "strategy",
+        "primary_1": "战略",
+        "primary_2": "戰略"
+    },
+    {
+        "intermediate_1": "zhan4shu4",
+        "intermediate_2": "zhànshù",
+        "native_1": "(military) tactics",
+        "primary_1": "战术",
+        "primary_2": "戰術"
+    },
+    {
+        "intermediate_1": "zhan4yi4",
+        "intermediate_2": "zhànyì",
+        "native_1": "military campaign; battle",
+        "primary_1": "战役",
+        "primary_2": "戰役"
+    },
+    {
+        "intermediate_1": "zhang1cheng2",
+        "intermediate_2": "zhāngchéng",
+        "native_1": "written rules; statute; regulations; charter of a corporation",
+        "primary_1": "章程",
+        "primary_2": "章程"
+    },
+    {
+        "intermediate_1": "zhang4peng",
+        "intermediate_2": "zhàngpeng",
+        "native_1": "tent",
+        "primary_1": "帐篷",
+        "primary_2": "帳篷"
+    },
+    {
+        "intermediate_1": "zhang4'ai4",
+        "intermediate_2": "zhàng'ài",
+        "native_1": "barrier; obstacle",
+        "primary_1": "障碍",
+        "primary_2": "障礙"
+    },
+    {
+        "intermediate_1": "zhao1biao1",
+        "intermediate_2": "zhāobiāo",
+        "native_1": "to beckon; to invite bids",
+        "primary_1": "招标",
+        "primary_2": "招標"
+    },
+    {
+        "intermediate_1": "zhao1shou1",
+        "intermediate_2": "zhāoshōu",
+        "native_1": "recruit; take in; to hire",
+        "primary_1": "招收",
+        "primary_2": "招收"
+    },
+    {
+        "intermediate_1": "zhao1 qi4 peng2 bo2",
+        "intermediate_2": "zhāo qì péng bó",
+        "native_1": "full of youthful energy (idiom); full of vigour and vitality; energetic; spirited; a bright spark",
+        "primary_1": "朝气蓬勃",
+        "primary_2": "朝氣蓬勃"
+    },
+    {
+        "intermediate_1": "zhao2mi2",
+        "intermediate_2": "zháomí",
+        "native_1": "to be fascinated",
+        "primary_1": "着迷",
+        "primary_2": "著迷"
+    },
+    {
+        "intermediate_1": "zhao3ze2",
+        "intermediate_2": "zhǎozé",
+        "native_1": "marsh; swamp; glade; wetlands",
+        "primary_1": "沼泽",
+        "primary_2": "沼澤"
+    },
+    {
+        "intermediate_1": "zhao4yang4",
+        "intermediate_2": "zhàoyàng",
+        "native_1": "as before; (same) as usual",
+        "primary_1": "照样",
+        "primary_2": "照樣"
+    },
+    {
+        "intermediate_1": "zhao4yao4",
+        "intermediate_2": "zhàoyào",
+        "native_1": "to shine; illuminate",
+        "primary_1": "照耀",
+        "primary_2": "照耀"
+    },
+    {
+        "intermediate_1": "zhe1teng",
+        "intermediate_2": "zhēteng",
+        "native_1": "toss from side to side (e.g. sleeplessly); do something over and over again; cause suffering; play crazy; screw around",
+        "primary_1": "折腾",
+        "primary_2": "折騰"
+    },
+    {
+        "intermediate_1": "zhe1dang3",
+        "intermediate_2": "zhēdǎng",
+        "native_1": "shelter from; keep out",
+        "primary_1": "遮挡",
+        "primary_2": "遮擋"
+    },
+    {
+        "intermediate_1": "zhe2",
+        "intermediate_2": "zhé",
+        "native_1": "to break; to fracture; convert into; to fold",
+        "primary_1": "折",
+        "primary_2": "折"
+    },
+    {
+        "intermediate_1": "zhe2mo",
+        "intermediate_2": "zhémo",
+        "native_1": "persecute; to torture",
+        "primary_1": "折磨",
+        "primary_2": "折磨"
+    },
+    {
+        "intermediate_1": "zhen1tan4",
+        "intermediate_2": "zhēntàn",
+        "native_1": "detective",
+        "primary_1": "侦探",
+        "primary_2": "偵探"
+    },
+    {
+        "intermediate_1": "zheng1ui4",
+        "intermediate_2": "zhēnguì",
+        "native_1": "precious",
+        "primary_1": "珍贵",
+        "primary_2": "珍貴"
+    },
+    {
+        "intermediate_1": "zhen1xi1",
+        "intermediate_2": "zhēnxī",
+        "native_1": "rare; precious and uncommon",
+        "primary_1": "珍稀",
+        "primary_2": "珍稀"
+    },
+    {
+        "intermediate_1": "zhen1zhu1",
+        "intermediate_2": "zhēnzhū",
+        "native_1": "pearl",
+        "primary_1": "珍珠",
+        "primary_2": "珍珠"
+    },
+    {
+        "intermediate_1": "zhen1li3",
+        "intermediate_2": "zhēnlǐ",
+        "native_1": "truth",
+        "primary_1": "真理",
+        "primary_2": "真理"
+    },
+    {
+        "intermediate_1": "zhen1xiang4",
+        "intermediate_2": "zhēnxiàng",
+        "native_1": "the actual facts; reality",
+        "primary_1": "真相",
+        "primary_2": "真相"
+    },
+    {
+        "intermediate_1": "zhen1zhi4",
+        "intermediate_2": "zhēnzhì",
+        "native_1": "sincere; sincerity; genuine",
+        "primary_1": "真挚",
+        "primary_2": "真摯"
+    },
+    {
+        "intermediate_1": "zhen1zhuo2",
+        "intermediate_2": "zhēnzhuó",
+        "native_1": "Consider; deliberate",
+        "primary_1": "斟酌",
+        "primary_2": "斟酌"
+    },
+    {
+        "intermediate_1": "zhen3tou",
+        "intermediate_2": "zhěntou",
+        "native_1": "pillow",
+        "primary_1": "枕头",
+        "primary_2": "枕頭"
+    },
+    {
+        "intermediate_1": "zhen4di4",
+        "intermediate_2": "zhèndì",
+        "native_1": "position; battlefront",
+        "primary_1": "阵地",
+        "primary_2": "陣地"
+    },
+    {
+        "intermediate_1": "zhen4rong2",
+        "intermediate_2": "zhènróng",
+        "native_1": "line-up; troop arrangement",
+        "primary_1": "阵容",
+        "primary_2": "陣容"
+    },
+    {
+        "intermediate_1": "zhen4fen4",
+        "intermediate_2": "zhènfèn",
+        "native_1": "stir oneself up; raise one's spirits; inspire",
+        "primary_1": "振奋",
+        "primary_2": "振奮"
+    },
+    {
+        "intermediate_1": "zhen4xing1",
+        "intermediate_2": "zhènxīng",
+        "native_1": "develop vigorously; promote; revive; revitalize; invigorate; re-energize",
+        "primary_1": "振兴",
+        "primary_2": "振興"
+    },
+    {
+        "intermediate_1": "zhen4han4",
+        "intermediate_2": "zhènhàn",
+        "native_1": "to shake",
+        "primary_1": "震撼",
+        "primary_2": "震撼"
+    },
+    {
+        "intermediate_1": "zhen4jing1",
+        "intermediate_2": "zhènjīng",
+        "native_1": "shock; astonish; amaze",
+        "primary_1": "震惊",
+        "primary_2": "震驚"
+    },
+    {
+        "intermediate_1": "zhen4ding4",
+        "intermediate_2": "zhèndìng",
+        "native_1": "cool; calm; unperturbed",
+        "primary_1": "镇定",
+        "primary_2": "鎮定"
+    },
+    {
+        "intermediate_1": "zhen4jing4",
+        "intermediate_2": "zhènjìng",
+        "native_1": "calm; cool; tranquil",
+        "primary_1": "镇静",
+        "primary_2": "鎮靜"
+    },
+    {
+        "intermediate_1": "zheng1yue4",
+        "intermediate_2": "zhēngyuè",
+        "native_1": "the first month of the lunar calendar",
+        "primary_1": "正月",
+        "primary_2": "正月"
+    },
+    {
+        "intermediate_1": "zheng1duan1",
+        "intermediate_2": "zhēngduān",
+        "native_1": "dispute; controversy; conflict",
+        "primary_1": "争端",
+        "primary_2": "爭端"
+    },
+    {
+        "intermediate_1": "zheng1duo2",
+        "intermediate_2": "zhēngduó",
+        "native_1": "fight over",
+        "primary_1": "争夺",
+        "primary_2": "爭奪"
+    },
+    {
+        "intermediate_1": "zheng1 qi4",
+        "intermediate_2": "zhēng qì",
+        "native_1": "work hard for sth.; determined not to fall short",
+        "primary_1": "争气",
+        "primary_2": "爭氣"
+    },
+    {
+        "intermediate_1": "zheng1 xian1 kong3 hou4",
+        "intermediate_2": "zhēng xiān kǒng hòu",
+        "native_1": "striving to be first; compete with each other",
+        "primary_1": "争先恐后",
+        "primary_2": "爭先恐後"
+    },
+    {
+        "intermediate_1": "zheng1yi4",
+        "intermediate_2": "zhēngyì",
+        "native_1": "controversy; dispute; contention",
+        "primary_1": "争议",
+        "primary_2": "爭議"
+    },
+    {
+        "intermediate_1": "zheng1fu2",
+        "intermediate_2": "zhēngfú",
+        "native_1": "conquer; subdue",
+        "primary_1": "征服",
+        "primary_2": "征服"
+    },
+    {
+        "intermediate_1": "zheng1shou1",
+        "intermediate_2": "zhēngshōu",
+        "native_1": "levy (fine); impose (tariff)",
+        "primary_1": "征收",
+        "primary_2": "征收"
+    },
+    {
+        "intermediate_1": "zheng1zha2",
+        "intermediate_2": "zhēngzhá",
+        "native_1": "to struggle",
+        "primary_1": "挣扎",
+        "primary_2": "掙紮"
+    },
+    {
+        "intermediate_1": "zheng1fa1",
+        "intermediate_2": "zhēngfā",
+        "native_1": "evaporate; evaporation",
+        "primary_1": "蒸发",
+        "primary_2": "蒸發"
+    },
+    {
+        "intermediate_1": "zheng3dun4",
+        "intermediate_2": "zhěngdùn",
+        "native_1": "organize; consolidate",
+        "primary_1": "整顿",
+        "primary_2": "整頓"
+    },
+    {
+        "intermediate_1": "zheng4 dang1",
+        "intermediate_2": "zhèng dāng",
+        "native_1": "timely; just when, (dàng) proper",
+        "primary_1": "正当",
+        "primary_2": "正當"
+    },
+    {
+        "intermediate_1": "zheng4fu4",
+        "intermediate_2": "zhèngfù",
+        "native_1": "positive and negative; plus-minus",
+        "primary_1": "正负",
+        "primary_2": "正負"
+    },
+    {
+        "intermediate_1": "zheng4gui1",
+        "intermediate_2": "zhèngguī",
+        "native_1": "formal; regular; according to standards",
+        "primary_1": "正规",
+        "primary_2": "正規"
+    },
+    {
+        "intermediate_1": "zheng4jing",
+        "intermediate_2": "zhèngjing",
+        "native_1": "decent; serious; standard; really",
+        "primary_1": "正经",
+        "primary_2": "正經"
+    },
+    {
+        "intermediate_1": "zheng4qi4",
+        "intermediate_2": "zhèngqì",
+        "native_1": "healthy environment; healthy atmosphere",
+        "primary_1": "正气",
+        "primary_2": "正氣"
+    },
+    {
+        "intermediate_1": "zheng4yi4",
+        "intermediate_2": "zhèngyì",
+        "native_1": "justice; righteous",
+        "primary_1": "正义",
+        "primary_2": "正義"
+    },
+    {
+        "intermediate_1": "zheng4zong1",
+        "intermediate_2": "zhèngzōng",
+        "native_1": "authentic, orthodox; old school",
+        "primary_1": "正宗",
+        "primary_2": "正宗"
+    },
+    {
+        "intermediate_1": "zheng4shi2",
+        "intermediate_2": "zhèngshí",
+        "native_1": "confirm; verify",
+        "primary_1": "证实",
+        "primary_2": "證實"
+    },
+    {
+        "intermediate_1": "zheng4shu1",
+        "intermediate_2": "zhèngshū",
+        "native_1": "certificate; credentials",
+        "primary_1": "证书",
+        "primary_2": "證書"
+    },
+    {
+        "intermediate_1": "zheng4zhong4",
+        "intermediate_2": "zhèngzhòng",
+        "native_1": "serious; solemn",
+        "primary_1": "郑重",
+        "primary_2": "鄭重"
+    },
+    {
+        "intermediate_1": "zheng4ce4",
+        "intermediate_2": "zhèngcè",
+        "native_1": "policy",
+        "primary_1": "政策",
+        "primary_2": "政策"
+    },
+    {
+        "intermediate_1": "zheng4quan2",
+        "intermediate_2": "zhèngquán",
+        "native_1": "regime; political power; authority",
+        "primary_1": "政权",
+        "primary_2": "政權"
+    },
+    {
+        "intermediate_1": "zheng4zhuang4",
+        "intermediate_2": "zhèngzhuàng",
+        "native_1": "symptom (of an illness)",
+        "primary_1": "症状",
+        "primary_2": "症狀"
+    },
+    {
+        "intermediate_1": "zhi1ji4",
+        "intermediate_2": "zhījì",
+        "native_1": "during; at the time of; the time when something happens",
+        "primary_1": "之际",
+        "primary_2": "之際"
+    },
+    {
+        "intermediate_1": "zhi1cheng1",
+        "intermediate_2": "zhīchēng",
+        "native_1": "support; prop up; crutch; brace",
+        "primary_1": "支撑",
+        "primary_2": "支撐"
+    },
+    {
+        "intermediate_1": "zhi1chu1",
+        "intermediate_2": "zhīchū",
+        "native_1": "spend; pay out; expense",
+        "primary_1": "支出",
+        "primary_2": "支出"
+    },
+    {
+        "intermediate_1": "zhi1liu2",
+        "intermediate_2": "zhīliú",
+        "native_1": "tributary; minor aspect; offshoot",
+        "primary_1": "支流",
+        "primary_2": "支流"
+    },
+    {
+        "intermediate_1": "zhi1pei4",
+        "intermediate_2": "zhīpèi",
+        "native_1": "to control",
+        "primary_1": "支配",
+        "primary_2": "支配"
+    },
+    {
+        "intermediate_1": "zhi1yuan2",
+        "intermediate_2": "zhīyuán",
+        "native_1": "to support; assist; aid",
+        "primary_1": "支援",
+        "primary_2": "支援"
+    },
+    {
+        "intermediate_1": "zhi1zhu4",
+        "intermediate_2": "zhīzhù",
+        "native_1": "pillar; prop; mainstay; backbone",
+        "primary_1": "支柱",
+        "primary_2": "支柱"
+    },
+    {
+        "intermediate_1": "zhi1",
+        "intermediate_2": "zhī",
+        "native_1": "branch; twig; (mw for sticks, rods, pencils)",
+        "primary_1": "枝",
+        "primary_2": "枝"
+    },
+    {
+        "intermediate_1": "zhi1jue2",
+        "intermediate_2": "zhījué",
+        "native_1": "perception; consciousness; feeling",
+        "primary_1": "知觉",
+        "primary_2": "知覺"
+    },
+    {
+        "intermediate_1": "zhi1zu2chang2le4",
+        "intermediate_2": "zhīzúchánglè",
+        "native_1": "content with what one has",
+        "primary_1": "知足常乐",
+        "primary_2": "知足常樂"
+    },
+    {
+        "intermediate_1": "zhi1fang2",
+        "intermediate_2": "zhīfáng",
+        "native_1": "body fat",
+        "primary_1": "脂肪",
+        "primary_2": "脂肪"
+    },
+    {
+        "intermediate_1": "zhi2xing2",
+        "intermediate_2": "zhíxíng",
+        "native_1": "implementation; carry out; execute",
+        "primary_1": "执行",
+        "primary_2": "執行"
+    },
+    {
+        "intermediate_1": "zhi2zhuo2",
+        "intermediate_2": "zhízhuó",
+        "native_1": "to refuse to change one's viewpoint",
+        "primary_1": "执着",
+        "primary_2": "執著"
+    },
+    {
+        "intermediate_1": "zhi2bo1",
+        "intermediate_2": "zhíbō",
+        "native_1": "live broadcast (not recorded)",
+        "primary_1": "直播",
+        "primary_2": "直播"
+    },
+    {
+        "intermediate_1": "zhi2jing4",
+        "intermediate_2": "zhíjìng",
+        "native_1": "diameter",
+        "primary_1": "直径",
+        "primary_2": "直徑"
+    },
+    {
+        "intermediate_1": "zhi2zi",
+        "intermediate_2": "zhízi",
+        "native_1": "nephew; brother's son or daughter",
+        "primary_1": "侄子",
+        "primary_2": "侄子"
+    },
+    {
+        "intermediate_1": "zhi2 ban1",
+        "intermediate_2": "zhí bān",
+        "native_1": "be on duty; work a shift",
+        "primary_1": "值班",
+        "primary_2": "值班"
+    },
+    {
+        "intermediate_1": "zhin2eng2",
+        "intermediate_2": "zhínéng",
+        "native_1": "function; role",
+        "primary_1": "职能",
+        "primary_2": "職能"
+    },
+    {
+        "intermediate_1": "zhi2wei4",
+        "intermediate_2": "zhíwèi",
+        "native_1": "(professional) position",
+        "primary_1": "职位",
+        "primary_2": "職位"
+    },
+    {
+        "intermediate_1": "zhi2wu4",
+        "intermediate_2": "zhíwù",
+        "native_1": "post; a position; job; duties",
+        "primary_1": "职务",
+        "primary_2": "職務"
+    },
+    {
+        "intermediate_1": "zhi2min2di4",
+        "intermediate_2": "zhímíndì",
+        "native_1": "colony",
+        "primary_1": "殖民地",
+        "primary_2": "殖民地"
+    },
+    {
+        "intermediate_1": "zhi3biao1",
+        "intermediate_2": "zhǐbiāo",
+        "native_1": "target; norm; index; indicator",
+        "primary_1": "指标",
+        "primary_2": "指標"
+    },
+    {
+        "intermediate_1": "zhi3ding4",
+        "intermediate_2": "zhǐdìng",
+        "native_1": "appoint; designate",
+        "primary_1": "指定",
+        "primary_2": "指定"
+    },
+    {
+        "intermediate_1": "zhi3jia",
+        "intermediate_2": "zhǐjia",
+        "native_1": "fingernail",
+        "primary_1": "指甲",
+        "primary_2": "指甲"
+    },
+    {
+        "intermediate_1": "zhi3ling4",
+        "intermediate_2": "zhǐlìng",
+        "native_1": "order; command; instruction",
+        "primary_1": "指令",
+        "primary_2": "指令"
+    },
+    {
+        "intermediate_1": "zhin3an2zhen1",
+        "intermediate_2": "zhǐnánzhēn",
+        "native_1": "compass",
+        "primary_1": "指南针",
+        "primary_2": "指南針"
+    },
+    {
+        "intermediate_1": "zhi3shi4",
+        "intermediate_2": "zhǐshì",
+        "native_1": "indicate; instruct; instructions",
+        "primary_1": "指示",
+        "primary_2": "指示"
+    },
+    {
+        "intermediate_1": "zhi3wang4",
+        "intermediate_2": "zhǐwàng",
+        "native_1": "hope for; count on; hope",
+        "primary_1": "指望",
+        "primary_2": "指望"
+    },
+    {
+        "intermediate_1": "zhi3ze2",
+        "intermediate_2": "zhǐzé",
+        "native_1": "to censure; criticize; find fault with",
+        "primary_1": "指责",
+        "primary_2": "指責"
+    },
+    {
+        "intermediate_1": "zhi4qi4",
+        "intermediate_2": "zhìqì",
+        "native_1": "ambition; resolve; backbone; drive; spirit",
+        "primary_1": "志气",
+        "primary_2": "志氣"
+    },
+    {
+        "intermediate_1": "zhi4cai2",
+        "intermediate_2": "zhìcái",
+        "native_1": "punish; (economic) sanctions",
+        "primary_1": "制裁",
+        "primary_2": "制裁"
+    },
+    {
+        "intermediate_1": "zhi4fu2",
+        "intermediate_2": "zhìfú",
+        "native_1": "uniform; to subdue; to bring under control",
+        "primary_1": "制服",
+        "primary_2": "制服"
+    },
+    {
+        "intermediate_1": "zhi4yue1",
+        "intermediate_2": "zhìyuē",
+        "native_1": "restrict; condition",
+        "primary_1": "制约",
+        "primary_2": "制約"
+    },
+    {
+        "intermediate_1": "zhi4zhi3",
+        "intermediate_2": "zhìzhǐ",
+        "native_1": "to curb; to put a stop to",
+        "primary_1": "制止",
+        "primary_2": "制止"
+    },
+    {
+        "intermediate_1": "zhi4'an1",
+        "intermediate_2": "zhì'ān",
+        "native_1": "law and order; public security",
+        "primary_1": "治安",
+        "primary_2": "治安"
+    },
+    {
+        "intermediate_1": "zhi4li3",
+        "intermediate_2": "zhìlǐ",
+        "native_1": "to bring under control; to govern; to manage",
+        "primary_1": "治理",
+        "primary_2": "治理"
+    },
+    {
+        "intermediate_1": "zhi4ci2",
+        "intermediate_2": "zhìcí",
+        "native_1": "make/deliver a speech",
+        "primary_1": "致辞",
+        "primary_2": "致辭"
+    },
+    {
+        "intermediate_1": "zhi4li4",
+        "intermediate_2": "zhìlì",
+        "native_1": "work for; devote one's efforts",
+        "primary_1": "致力",
+        "primary_2": "致力"
+    },
+    {
+        "intermediate_1": "zhi4shi3",
+        "intermediate_2": "zhìshǐ",
+        "native_1": "cause; result in",
+        "primary_1": "致使",
+        "primary_2": "致使"
+    },
+    {
+        "intermediate_1": "zhi4li4",
+        "intermediate_2": "zhìlì",
+        "native_1": "intelligence; intellect",
+        "primary_1": "智力",
+        "primary_2": "智力"
+    },
+    {
+        "intermediate_1": "zhin4eng2",
+        "intermediate_2": "zhìnéng",
+        "native_1": "intelligent; capability; smart (phone, system, bomb, etc.)",
+        "primary_1": "智能",
+        "primary_2": "智能"
+    },
+    {
+        "intermediate_1": "zhi4shang1",
+        "intermediate_2": "zhìshāng",
+        "native_1": "IQ (intelligence quotient)",
+        "primary_1": "智商",
+        "primary_2": "智商"
+    },
+    {
+        "intermediate_1": "zhi4liu2",
+        "intermediate_2": "zhìliú",
+        "native_1": "detain; retention",
+        "primary_1": "滞留",
+        "primary_2": "滯留"
+    },
+    {
+        "intermediate_1": "zhong1duan4",
+        "intermediate_2": "zhōngduàn",
+        "native_1": "interrupt; break off",
+        "primary_1": "中断",
+        "primary_2": "中斷"
+    },
+    {
+        "intermediate_1": "zhong1li4",
+        "intermediate_2": "zhōnglì",
+        "native_1": "neutral; neutrality",
+        "primary_1": "中立",
+        "primary_2": "中立"
+    },
+    {
+        "intermediate_1": "zhong1yang1",
+        "intermediate_2": "zhōngyāng",
+        "native_1": "central; middle; center",
+        "primary_1": "中央",
+        "primary_2": "中央"
+    },
+    {
+        "intermediate_1": "zhong1cheng2",
+        "intermediate_2": "zhōngchéng",
+        "native_1": "honest; loyalty; devoted",
+        "primary_1": "忠诚",
+        "primary_2": "忠誠"
+    },
+    {
+        "intermediate_1": "zhong1shi2",
+        "intermediate_2": "zhōngshí",
+        "native_1": "faithful; dependable",
+        "primary_1": "忠实",
+        "primary_2": "忠實"
+    },
+    {
+        "intermediate_1": "zhong1dian3",
+        "intermediate_2": "zhōngdiǎn",
+        "native_1": "the end; end point; destination; finish line (in a race)",
+        "primary_1": "终点",
+        "primary_2": "終點"
+    },
+    {
+        "intermediate_1": "zhong1jiu1",
+        "intermediate_2": "zhōngjiū",
+        "native_1": "in the end; after all is said and done; eventually",
+        "primary_1": "终究",
+        "primary_2": "終究"
+    },
+    {
+        "intermediate_1": "zhong1shen1",
+        "intermediate_2": "zhōngshēn",
+        "native_1": "lifelong",
+        "primary_1": "终身",
+        "primary_2": "終身"
+    },
+    {
+        "intermediate_1": "zhong1zhi3",
+        "intermediate_2": "zhōngzhǐ",
+        "native_1": "stop; cease; terminate (legal)",
+        "primary_1": "终止",
+        "primary_2": "終止"
+    },
+    {
+        "intermediate_1": "zhong1xin1",
+        "intermediate_2": "zhōngxīn",
+        "native_1": "heartfelt; wholehearted; cordial",
+        "primary_1": "衷心",
+        "primary_2": "衷心"
+    },
+    {
+        "intermediate_1": "zhong3liu2",
+        "intermediate_2": "zhǒngliú",
+        "native_1": "tumor; neoplasm",
+        "primary_1": "肿瘤",
+        "primary_2": "腫瘤"
+    },
+    {
+        "intermediate_1": "zhong3zi",
+        "intermediate_2": "zhǒngzi",
+        "native_1": "seed",
+        "primary_1": "种子",
+        "primary_2": "種子"
+    },
+    {
+        "intermediate_1": "zhong3zu2",
+        "intermediate_2": "zhǒngzú",
+        "native_1": "race; ethnicity",
+        "primary_1": "种族",
+        "primary_2": "種族"
+    },
+    {
+        "intermediate_1": "zhong4 suo3 zhou1 zhi1",
+        "intermediate_2": "zhòng suǒ zhōu zhī",
+        "native_1": "as everyone knows; (saying) as is known to everyone",
+        "primary_1": "众所周知",
+        "primary_2": "衆所周知"
+    },
+    {
+        "intermediate_1": "zhong4zhi2",
+        "intermediate_2": "zhòngzhí",
+        "native_1": "plant; grow; crop",
+        "primary_1": "种植",
+        "primary_2": "種植"
+    },
+    {
+        "intermediate_1": "zhong4xin1",
+        "intermediate_2": "zhòngxīn",
+        "native_1": "center of gravity; central core; main part",
+        "primary_1": "重心",
+        "primary_2": "重心"
+    },
+    {
+        "intermediate_1": "zhou1",
+        "intermediate_2": "zhōu",
+        "native_1": "boat (Kangxi radical 137)",
+        "primary_1": "舟",
+        "primary_2": "舟"
+    },
+    {
+        "intermediate_1": "zhou1",
+        "intermediate_2": "zhōu",
+        "native_1": "province; sub-prefecture; (United States) state",
+        "primary_1": "州",
+        "primary_2": "州"
+    },
+    {
+        "intermediate_1": "zhou1bian1",
+        "intermediate_2": "zhōubiān",
+        "native_1": "surrounding",
+        "primary_1": "周边",
+        "primary_2": "周邊"
+    },
+    {
+        "intermediate_1": "zhou1mi4",
+        "intermediate_2": "zhōumì",
+        "native_1": "meticulous; careful; thorough",
+        "primary_1": "周密",
+        "primary_2": "周密"
+    },
+    {
+        "intermediate_1": "zhou1nian2",
+        "intermediate_2": "zhōunián",
+        "native_1": "anniversary; annual",
+        "primary_1": "周年",
+        "primary_2": "周年"
+    },
+    {
+        "intermediate_1": "zhou1qi1",
+        "intermediate_2": "zhōuqī",
+        "native_1": "period; cycle; rhythm",
+        "primary_1": "周期",
+        "primary_2": "周期"
+    },
+    {
+        "intermediate_1": "zhou1zhe2",
+        "intermediate_2": "zhōuzhé",
+        "native_1": "setback; twists and turns; problem; complication",
+        "primary_1": "周折",
+        "primary_2": "周折"
+    },
+    {
+        "intermediate_1": "zhou1zhuan3",
+        "intermediate_2": "zhōuzhuǎn",
+        "native_1": "turnover (in cash or personnel); have enough resources to cover a need",
+        "primary_1": "周转",
+        "primary_2": "周轉"
+    },
+    {
+        "intermediate_1": "zhou1",
+        "intermediate_2": "zhōu",
+        "native_1": "porridge; congee; gruel",
+        "primary_1": "粥",
+        "primary_2": "粥"
+    },
+    {
+        "intermediate_1": "zhou4ye4",
+        "intermediate_2": "zhòuyè",
+        "native_1": "day and night; continuously without stop",
+        "primary_1": "昼夜",
+        "primary_2": "晝夜"
+    },
+    {
+        "intermediate_1": "zhou4wen2",
+        "intermediate_2": "zhòuwén",
+        "native_1": "wrinkle; furrow",
+        "primary_1": "皱纹",
+        "primary_2": "皺紋"
+    },
+    {
+        "intermediate_1": "zhu1",
+        "intermediate_2": "zhū",
+        "native_1": "stem; root; trunk; (mw for plants)",
+        "primary_1": "株",
+        "primary_2": "株"
+    },
+    {
+        "intermediate_1": "zhu1wei4",
+        "intermediate_2": "zhūwèi",
+        "native_1": "(pronoun) everyone; ladies and gentlemen",
+        "primary_1": "诸位",
+        "primary_2": "諸位"
+    },
+    {
+        "intermediate_1": "zhun2ian2",
+        "intermediate_2": "zhúnián",
+        "native_1": "year after year; on an annual basis",
+        "primary_1": "逐年",
+        "primary_2": "逐年"
+    },
+    {
+        "intermediate_1": "zhu3ban4",
+        "intermediate_2": "zhǔbàn",
+        "native_1": "to host (a conference or sports event)",
+        "primary_1": "主办",
+        "primary_2": "主辦"
+    },
+    {
+        "intermediate_1": "zhu3dao3",
+        "intermediate_2": "zhǔdǎo",
+        "native_1": "leading; dominant; guiding",
+        "primary_1": "主导",
+        "primary_2": "主導"
+    },
+    {
+        "intermediate_1": "zhu3guan3",
+        "intermediate_2": "zhǔguǎn",
+        "native_1": "person in charge of (a position, etc.); preside over; Chief Operating Officer (COO)",
+        "primary_1": "主管",
+        "primary_2": "主管"
+    },
+    {
+        "intermediate_1": "zhu3liu2",
+        "intermediate_2": "zhǔliú",
+        "native_1": "main stream (of a river); the essential point",
+        "primary_1": "主流",
+        "primary_2": "主流"
+    },
+    {
+        "intermediate_1": "zhu3quan2",
+        "intermediate_2": "zhǔquán",
+        "native_1": "sovereignty",
+        "primary_1": "主权",
+        "primary_2": "主權"
+    },
+    {
+        "intermediate_1": "zhu3yi4",
+        "intermediate_2": "zhǔyì",
+        "native_1": "-ism; ideology",
+        "primary_1": "主义",
+        "primary_2": "主義"
+    },
+    {
+        "intermediate_1": "zhu3",
+        "intermediate_2": "zhǔ",
+        "native_1": "post; lean on a stick; prop",
+        "primary_1": "拄",
+        "primary_2": "拄"
+    },
+    {
+        "intermediate_1": "zhu3fu4",
+        "intermediate_2": "zhǔfù",
+        "native_1": "enjoin; to tell; exhort",
+        "primary_1": "嘱咐",
+        "primary_2": "囑咐"
+    },
+    {
+        "intermediate_1": "zhu4li3",
+        "intermediate_2": "zhùlǐ",
+        "native_1": "assistant",
+        "primary_1": "助理",
+        "primary_2": "助理"
+    },
+    {
+        "intermediate_1": "zhu4shou3",
+        "intermediate_2": "zhùshǒu",
+        "native_1": "assistant; helper",
+        "primary_1": "助手",
+        "primary_2": "助手"
+    },
+    {
+        "intermediate_1": "zhu4zhai2",
+        "intermediate_2": "zhùzhái",
+        "native_1": "residence; tenement",
+        "primary_1": "住宅",
+        "primary_2": "住宅"
+    },
+    {
+        "intermediate_1": "zhu4she4",
+        "intermediate_2": "zhùshè",
+        "native_1": "injection; inject (medicine)",
+        "primary_1": "注射",
+        "primary_2": "注射"
+    },
+    {
+        "intermediate_1": "zhu4shi4",
+        "intermediate_2": "zhùshì",
+        "native_1": "watch attentively; gaze at; stare",
+        "primary_1": "注视",
+        "primary_2": "注視"
+    },
+    {
+        "intermediate_1": "zhu4shi4",
+        "intermediate_2": "zhùshì",
+        "native_1": "annotate; annotation; note; make notes in the margin",
+        "primary_1": "注释",
+        "primary_2": "注釋"
+    },
+    {
+        "intermediate_1": "zhu4zhong4",
+        "intermediate_2": "zhùzhòng",
+        "native_1": "pay attention; emphasize; put stress on",
+        "primary_1": "注重",
+        "primary_2": "注重"
+    },
+    {
+        "intermediate_1": "zhu4zha1",
+        "intermediate_2": "zhùzhā",
+        "native_1": "to station; to garrison (troops)",
+        "primary_1": "驻扎",
+        "primary_2": "駐紮"
+    },
+    {
+        "intermediate_1": "zhu4zuo4",
+        "intermediate_2": "zhùzuò",
+        "native_1": "work; book; writing",
+        "primary_1": "著作",
+        "primary_2": "著作"
+    },
+    {
+        "intermediate_1": "zhu4zao4",
+        "intermediate_2": "zhùzào",
+        "native_1": "cast (pour metal into a mold)",
+        "primary_1": "铸造",
+        "primary_2": "鑄造"
+    },
+    {
+        "intermediate_1": "zhuai4",
+        "intermediate_2": "zhuài",
+        "native_1": "drag; haul",
+        "primary_1": "拽",
+        "primary_2": "拽"
+    },
+    {
+        "intermediate_1": "zhuan1chang2",
+        "intermediate_2": "zhuāncháng",
+        "native_1": "specialty; special knowledge or ability",
+        "primary_1": "专长",
+        "primary_2": "專長"
+    },
+    {
+        "intermediate_1": "zhuan1cheng2",
+        "intermediate_2": "zhuānchéng",
+        "native_1": "special-purpose trip",
+        "primary_1": "专程",
+        "primary_2": "專程"
+    },
+    {
+        "intermediate_1": "zhuan1li4",
+        "intermediate_2": "zhuānlì",
+        "native_1": "patent",
+        "primary_1": "专利",
+        "primary_2": "專利"
+    },
+    {
+        "intermediate_1": "zhuan1ti2",
+        "intermediate_2": "zhuāntí",
+        "native_1": "special topic; questions; special matter or subject",
+        "primary_1": "专题",
+        "primary_2": "專題"
+    },
+    {
+        "intermediate_1": "zhuan1",
+        "intermediate_2": "zhuān",
+        "native_1": "brick",
+        "primary_1": "砖",
+        "primary_2": "磚"
+    },
+    {
+        "intermediate_1": "zhuan3da2",
+        "intermediate_2": "zhuǎndá",
+        "native_1": "pass on; convey; communicate",
+        "primary_1": "转达",
+        "primary_2": "轉達"
+    },
+    {
+        "intermediate_1": "zhuan3rang4",
+        "intermediate_2": "zhuǎnràng",
+        "native_1": "transfer (technology, good, etc.); make over",
+        "primary_1": "转让",
+        "primary_2": "轉讓"
+    },
+    {
+        "intermediate_1": "zhuan3yi2",
+        "intermediate_2": "zhuǎnyí",
+        "native_1": "to shift; divert; migrate",
+        "primary_1": "转移",
+        "primary_2": "轉移"
+    },
+    {
+        "intermediate_1": "zhuan3zhe2",
+        "intermediate_2": "zhuǎnzhé",
+        "native_1": "turning point; shift in the trend of events; plot twist in a book",
+        "primary_1": "转折",
+        "primary_2": "轉折"
+    },
+    {
+        "intermediate_1": "zhuan4ji4",
+        "intermediate_2": "zhuànjì",
+        "native_1": "biography",
+        "primary_1": "传记",
+        "primary_2": "傳記"
+    },
+    {
+        "intermediate_1": "zhuang1jia",
+        "intermediate_2": "zhuāngjia",
+        "native_1": "farm crops",
+        "primary_1": "庄稼",
+        "primary_2": "莊稼"
+    },
+    {
+        "intermediate_1": "zhuang1yan2",
+        "intermediate_2": "zhuāngyán",
+        "native_1": "stately; dignified",
+        "primary_1": "庄严",
+        "primary_2": "莊嚴"
+    },
+    {
+        "intermediate_1": "zhuang1zhong4",
+        "intermediate_2": "zhuāngzhòng",
+        "native_1": "grave; solemn; dignified",
+        "primary_1": "庄重",
+        "primary_2": "莊重"
+    },
+    {
+        "intermediate_1": "zhuang1bei4",
+        "intermediate_2": "zhuāngbèi",
+        "native_1": "equipment; to equip; to outfit",
+        "primary_1": "装备",
+        "primary_2": "裝備"
+    },
+    {
+        "intermediate_1": "zhuang1xie4",
+        "intermediate_2": "zhuāngxiè",
+        "native_1": "load and unload; to transfer",
+        "primary_1": "装卸",
+        "primary_2": "裝卸"
+    },
+    {
+        "intermediate_1": "zhuang4guan1",
+        "intermediate_2": "zhuàngguān",
+        "native_1": "spectacular; grand (of buildings, monuments, scenery, etc.)",
+        "primary_1": "壮观",
+        "primary_2": "壯觀"
+    },
+    {
+        "intermediate_1": "zhuang4li4",
+        "intermediate_2": "zhuànglì",
+        "native_1": "magnificence; splendid; majestic",
+        "primary_1": "壮丽",
+        "primary_2": "壯麗"
+    },
+    {
+        "intermediate_1": "zhuang4lie4",
+        "intermediate_2": "zhuàngliè",
+        "native_1": "brave and honorable",
+        "primary_1": "壮烈",
+        "primary_2": "壯烈"
+    },
+    {
+        "intermediate_1": "zhuang4",
+        "intermediate_2": "zhuàng",
+        "native_1": "(mw for houses, buildings); tent",
+        "primary_1": "幢",
+        "primary_2": "幢"
+    },
+    {
+        "intermediate_1": "zhui1dao4",
+        "intermediate_2": "zhuīdào",
+        "native_1": "mourning; memorial (service, etc.)",
+        "primary_1": "追悼",
+        "primary_2": "追悼"
+    },
+    {
+        "intermediate_1": "zhui1jiu1",
+        "intermediate_2": "zhuījiū",
+        "native_1": "investigate; look into; find out",
+        "primary_1": "追究",
+        "primary_2": "追究"
+    },
+    {
+        "intermediate_1": "zhui4",
+        "intermediate_2": "zhuì",
+        "native_1": "fall; drop",
+        "primary_1": "坠",
+        "primary_2": "墜"
+    },
+    {
+        "intermediate_1": "zhun3ze2",
+        "intermediate_2": "zhǔnzé",
+        "native_1": "principle; standard or norm; criterion",
+        "primary_1": "准则",
+        "primary_2": "准則"
+    },
+    {
+        "intermediate_1": "zhuo2yue4",
+        "intermediate_2": "zhuóyuè",
+        "native_1": "distinction; excellence; splendid",
+        "primary_1": "卓越",
+        "primary_2": "卓越"
+    },
+    {
+        "intermediate_1": "zhuo2shou3",
+        "intermediate_2": "zhuóshǒu",
+        "native_1": "put one's hand to; commence",
+        "primary_1": "着手",
+        "primary_2": "著手"
+    },
+    {
+        "intermediate_1": "zhuo2xiang3",
+        "intermediate_2": "zhuóxiǎng",
+        "native_1": "give consideration to; consider (other people's) needs",
+        "primary_1": "着想",
+        "primary_2": "著想"
+    },
+    {
+        "intermediate_1": "zhuo2zhong4",
+        "intermediate_2": "zhuózhòng",
+        "native_1": "put emphasis on; to stress",
+        "primary_1": "着重",
+        "primary_2": "著重"
+    },
+    {
+        "intermediate_1": "zuo2mo",
+        "intermediate_2": "zuómo",
+        "native_1": "ponder; (also zhuómó: to polish (gems or literary works))",
+        "primary_1": "琢磨",
+        "primary_2": "琢磨"
+    },
+    {
+        "intermediate_1": "zi1tai4",
+        "intermediate_2": "zītài",
+        "native_1": "attitude; posture; stance",
+        "primary_1": "姿态",
+        "primary_2": "姿態"
+    },
+    {
+        "intermediate_1": "zi1ben3",
+        "intermediate_2": "zīběn",
+        "native_1": "(Economics) capital; asset",
+        "primary_1": "资本",
+        "primary_2": "資本"
+    },
+    {
+        "intermediate_1": "zi1chan3",
+        "intermediate_2": "zīchǎn",
+        "native_1": "property; assets",
+        "primary_1": "资产",
+        "primary_2": "資産"
+    },
+    {
+        "intermediate_1": "zi1shen1",
+        "intermediate_2": "zīshēn",
+        "native_1": "experienced; senior",
+        "primary_1": "资深",
+        "primary_2": "資深"
+    },
+    {
+        "intermediate_1": "zi1zhu4",
+        "intermediate_2": "zīzhù",
+        "native_1": "subsidy; provide financial aid",
+        "primary_1": "资助",
+        "primary_2": "資助"
+    },
+    {
+        "intermediate_1": "zi1run4",
+        "intermediate_2": "zīrùn",
+        "native_1": "quenched; moist",
+        "primary_1": "滋润",
+        "primary_2": "滋潤"
+    },
+    {
+        "intermediate_1": "zi1wei4",
+        "intermediate_2": "zīwèi",
+        "native_1": "taste; flavor; the way one feels",
+        "primary_1": "滋味",
+        "primary_2": "滋味"
+    },
+    {
+        "intermediate_1": "zi3dan4",
+        "intermediate_2": "zǐdàn",
+        "native_1": "bullet; cartridge",
+        "primary_1": "子弹",
+        "primary_2": "子彈"
+    },
+    {
+        "intermediate_1": "zi4bei1",
+        "intermediate_2": "zìbēi",
+        "native_1": "feel inferior; be self-abased",
+        "primary_1": "自卑",
+        "primary_2": "自卑"
+    },
+    {
+        "intermediate_1": "zi4fa1",
+        "intermediate_2": "zìfā",
+        "native_1": "spontaneous; unprompted",
+        "primary_1": "自发",
+        "primary_2": "自發"
+    },
+    {
+        "intermediate_1": "zi4 li4 geng1 sheng1",
+        "intermediate_2": "zì lì gēng shēng",
+        "native_1": "(idiom) self reliance",
+        "primary_1": "自力更生",
+        "primary_2": "自力更生"
+    },
+    {
+        "intermediate_1": "zi4man3",
+        "intermediate_2": "zìmǎn",
+        "native_1": "complacent; self-satisfied",
+        "primary_1": "自满",
+        "primary_2": "自滿"
+    },
+    {
+        "intermediate_1": "zi4zhu3",
+        "intermediate_2": "zìzhǔ",
+        "native_1": "independent; to act for oneself; autonomous",
+        "primary_1": "自主",
+        "primary_2": "自主"
+    },
+    {
+        "intermediate_1": "zong1jiao4",
+        "intermediate_2": "zōngjiào",
+        "native_1": "religion",
+        "primary_1": "宗教",
+        "primary_2": "宗教"
+    },
+    {
+        "intermediate_1": "zong1zhi3",
+        "intermediate_2": "zōngzhǐ",
+        "native_1": "purpose; objective; aim; goal",
+        "primary_1": "宗旨",
+        "primary_2": "宗旨"
+    },
+    {
+        "intermediate_1": "zong1se4",
+        "intermediate_2": "zōngsè",
+        "native_1": "brown (the color)",
+        "primary_1": "棕色",
+        "primary_2": "棕色"
+    },
+    {
+        "intermediate_1": "zong1ji4",
+        "intermediate_2": "zōngjì",
+        "native_1": "tracks; trail; footprint; trace; vestige",
+        "primary_1": "踪迹",
+        "primary_2": "蹤迹"
+    },
+    {
+        "intermediate_1": "zong3er2yan2zhi1",
+        "intermediate_2": "zǒngéryánzhī",
+        "native_1": "in short; in a word",
+        "primary_1": "总而言之",
+        "primary_2": "總而言之"
+    },
+    {
+        "intermediate_1": "zong3he2",
+        "intermediate_2": "zǒnghé",
+        "native_1": "sum",
+        "primary_1": "总和",
+        "primary_2": "總和"
+    },
+    {
+        "intermediate_1": "zong4heng2",
+        "intermediate_2": "zònghéng",
+        "native_1": "able to move unhindered; length and breadth",
+        "primary_1": "纵横",
+        "primary_2": "縱橫"
+    },
+    {
+        "intermediate_1": "zou3lang2",
+        "intermediate_2": "zǒuláng",
+        "native_1": "corridor; hallway",
+        "primary_1": "走廊",
+        "primary_2": "走廊"
+    },
+    {
+        "intermediate_1": "zou3lou4",
+        "intermediate_2": "zǒulòu",
+        "native_1": "leak (information, liquid, etc); divulge; reveal",
+        "primary_1": "走漏",
+        "primary_2": "走漏"
+    },
+    {
+        "intermediate_1": "zou3 si1",
+        "intermediate_2": "zǒu sī",
+        "native_1": "smuggle; have an illicit affair",
+        "primary_1": "走私",
+        "primary_2": "走私"
+    },
+    {
+        "intermediate_1": "zou4",
+        "intermediate_2": "zòu",
+        "native_1": "(informal) beat; hit; (regional) smash; break",
+        "primary_1": "揍",
+        "primary_2": "揍"
+    },
+    {
+        "intermediate_1": "zu1lin4",
+        "intermediate_2": "zūlìn",
+        "native_1": "rent; lease",
+        "primary_1": "租赁",
+        "primary_2": "租賃"
+    },
+    {
+        "intermediate_1": "zu2yi3",
+        "intermediate_2": "zúyǐ",
+        "native_1": "sufficient to ...; so much so that; sufficiently",
+        "primary_1": "足以",
+        "primary_2": "足以"
+    },
+    {
+        "intermediate_1": "zu3'ai4",
+        "intermediate_2": "zǔ'ài",
+        "native_1": "obstruct; hinder; impede",
+        "primary_1": "阻碍",
+        "primary_2": "阻礙"
+    },
+    {
+        "intermediate_1": "zu3lan2",
+        "intermediate_2": "zǔlán",
+        "native_1": "to stop; obstruct; block off",
+        "primary_1": "阻拦",
+        "primary_2": "阻攔"
+    },
+    {
+        "intermediate_1": "zun3ao2",
+        "intermediate_2": "zǔnáo",
+        "native_1": "thwart; to obstruct (something); stand in the way",
+        "primary_1": "阻挠",
+        "primary_2": "阻撓"
+    },
+    {
+        "intermediate_1": "zu3fu4",
+        "intermediate_2": "zǔfù",
+        "native_1": "paternal grandfather",
+        "primary_1": "祖父",
+        "primary_2": "祖父"
+    },
+    {
+        "intermediate_1": "zu3guo2",
+        "intermediate_2": "zǔguó",
+        "native_1": "homeland; motherland; fatherland",
+        "primary_1": "祖国",
+        "primary_2": "祖國"
+    },
+    {
+        "intermediate_1": "zu3xian1",
+        "intermediate_2": "zǔxiān",
+        "native_1": "ancestor; forbearer",
+        "primary_1": "祖先",
+        "primary_2": "祖先"
+    },
+    {
+        "intermediate_1": "zuan1yan2",
+        "intermediate_2": "zuānyán",
+        "native_1": "study intensively; delve into",
+        "primary_1": "钻研",
+        "primary_2": "鑽研"
+    },
+    {
+        "intermediate_1": "zuan4shi2",
+        "intermediate_2": "zuànshí",
+        "native_1": "diamond",
+        "primary_1": "钻石",
+        "primary_2": "鑽石"
+    },
+    {
+        "intermediate_1": "zui3chun2",
+        "intermediate_2": "zuǐchún",
+        "native_1": "lip",
+        "primary_1": "嘴唇",
+        "primary_2": "嘴唇"
+    },
+    {
+        "intermediate_1": "zui4fan4",
+        "intermediate_2": "zuìfàn",
+        "native_1": "criminal",
+        "primary_1": "罪犯",
+        "primary_2": "罪犯"
+    },
+    {
+        "intermediate_1": "zun1yan2",
+        "intermediate_2": "zūnyán",
+        "native_1": "dignity; sanctity; honor",
+        "primary_1": "尊严",
+        "primary_2": "尊嚴"
+    },
+    {
+        "intermediate_1": "zun1xun2",
+        "intermediate_2": "zūnxún",
+        "native_1": "follow; abide by",
+        "primary_1": "遵循",
+        "primary_2": "遵循"
+    },
+    {
+        "intermediate_1": "zuo4bi4",
+        "intermediate_2": "zuòbì",
+        "native_1": "practice fraud; cheat",
+        "primary_1": "作弊",
+        "primary_2": "作弊"
+    },
+    {
+        "intermediate_1": "zuo4fei4",
+        "intermediate_2": "zuòfèi",
+        "native_1": "cancellation; delete; to nullify; to expire and thus lose validity",
+        "primary_1": "作废",
+        "primary_2": "作廢"
+    },
+    {
+        "intermediate_1": "zuo4feng1",
+        "intermediate_2": "zuòfēng",
+        "native_1": "work style; way",
+        "primary_1": "作风",
+        "primary_2": "作風"
+    },
+    {
+        "intermediate_1": "zuo4xi1",
+        "intermediate_2": "zuòxī",
+        "native_1": "work and rest",
+        "primary_1": "作息",
+        "primary_2": "作息"
+    },
+    {
+        "intermediate_1": "zuo4you4ming2",
+        "intermediate_2": "zuòyòumíng",
+        "native_1": "motto",
+        "primary_1": "座右铭",
+        "primary_2": "座右銘"
+    },
+    {
+        "intermediate_1": "zuo4zhu3",
+        "intermediate_2": "zuòzhǔ",
+        "native_1": "decide; take the responsibility for a decision",
+        "primary_1": "做主",
+        "primary_2": "做主"
+    }
+]

--- a/vocab/mandarin/radicals.csv
+++ b/vocab/mandarin/radicals.csv
@@ -1,0 +1,215 @@
+PRIMARY,NATIVE,INTERMEDIATE
+一,one,yī
+丨,line,shù
+丶,dot,diǎn
+丿 or 乀 or 乁,slash,piě
+乙 or 乚 or 乛,second,yǐ
+亅,hook,gōu
+二,two,èr
+亠,lid,tóu
+人 or 亻,person,rén
+儿,legs,ér
+入,enter,rù
+八 or 丷,eight,bā
+冂,down box,jiǒng
+冖,cover,mì
+冫,ice,bīng
+几,table,jī or jǐ
+凵,open box,qǔ
+刀 or刂,knife,dāo
+力,power,lì    
+勹,wrap,bāo
+匕,ladle,bǐ
+匚,right open box,fāng
+匸,hiding enclosure,xǐ
+十,ten,shí
+卜,divination,bǔ
+卩,seal,jié
+厂,cliff,hàn
+厶,private,sī
+又,again,yòu
+口,mouth,kǒu
+囗,enclosure,wéi
+土,earth,tǔ
+士,scholar,shì
+夂,go,zhī
+夊,go slowly,suī
+夕,night,xī
+大,big,dà
+女,woman,nǚ
+子,child,zǐ
+宀,roof,gài
+寸,inch,cùn
+小,small,xiǎo
+尢 or 尣,lame,yóu    
+尸,corpse,shī
+屮,sprout,chè
+山,mountain,shān
+川 or 巛 or 巜,river,chuān    
+工,work,gōng
+己,oneself,jǐ
+巾,towel,jīn
+干,dry,gān
+幺,thread,yāo
+广,shelter,guǎng
+廴,stride,yǐn
+廾,hands joined,gǒng
+弋,shoot with a bow,yì
+弓,bow,gōng
+彐 or 彑,snout,jì    
+彡,hair,shān
+彳,step,chì
+心 or 忄,heart,xīn    
+戈,spear,gē
+户,door,hù
+手 or 扌,hand,shǒu    
+支,branch,zhī
+攴 or 攵,rap,pū    
+文,script,wén
+斗,dipper,dǒu
+斤,axe,jīn
+方,square,fāng
+无,not,wú
+日,sun,rì
+曰,say,yuē
+月,moon,yuè
+木,tree,mù
+欠,lack,qiàn
+止,stop,zhǐ    
+歹,death,dǎi
+殳,weapon,shū
+母 or 毋,mother,mǔ    
+比,compare,bǐ
+毛,fur,máo
+氏,clan,shì
+气,steam,qì
+水 or 氵,water,shuǐ 
+火 or 灬,fire,huǒ 
+爪 or 爫,claw,zhǎo
+父,father,fù
+爻,lines on a trigram,yáo
+爿,half of a tree trunk,qiáng
+片,slice,piàn
+牙,tooth,yá
+牛 or 牜,cow,niú
+犭 or 犬,dog,quǎn
+玄,profound,xuán
+玉 or 王,jade,yù
+瓜,melon,guā
+瓦,tile,wǎ
+甘,sweet,gān
+生,life,shēng
+用,use,yòng
+田,field,tián
+疋,cloth,pǐ
+疒,ill,bìng
+癶,foot steps,bō
+白,white,bái
+皮,skin,pí
+皿,dish,mǐn
+目,eye,mù
+矛,spear,máo
+矢,arrow,shǐ
+石,stone,shí
+示 or 礻,spirit,shì    
+禸,track,róu
+禾,grain,hé
+穴,cave,xuè
+立,stand,lì    
+竹,bamboo,zhú    
+米,rice,mǐ    
+纟 or (糸),silk,sī
+缶,jar,fǒu    
+网 or 罒,net,wǎng    
+羊,sheep,yáng    
+羽,feather,yǔ    
+老,old,lǎo    
+而,and,ér    
+耒,plow,lěi    
+耳,ear,ěr    
+聿,brush,yù    
+肉,meat,ròu
+臣,minister,chén    
+自,oneself,zì
+至,arrive,zhì    
+臼,mortar,jiù    
+舌,tongue,shé    
+舛,contrary,chuǎn    
+舟,boat,zhōu
+艮,mountain,gèn    
+色,color,sè    
+艹,grass,cǎo    
+虍,tiger,hǔ    
+虫,insect,chóng    
+血,blood,xuě    
+行,walk,xíng    
+衣 or 衤,clothes,yī
+西 or 覀,west,xī
+见 or (見),see,jiàn
+角,horn,jiǎo
+讠or (言),speech,yán
+谷,valley,gǔ    
+豆,bean,dòu    
+豕,pig,shǐ
+豸,badger,zhì
+贝 or (貝),shell,bèi    
+赤,red,chì    
+走,walk,zǒu    
+足,foot,zú    
+身,body,shēn    
+车 or (車),cart,chē    
+辛,bitter,xīn    
+辰,morning,chén
+辶,walk,chuò    
+邑 or 阝,city,yì
+酉,wine,yǒu   
+釆,distinguish,biàn
+里,village,lǐ    
+钅 or 金,metal,jīn
+长 or (長),long,cháng  
+门 or (門),gate,mén
+阜 or 阝,mound,fù
+隶,slave,lì
+隹,short-tailed bird,zhuī
+雨,rain,yǔ    
+青,blue,qīng
+非,wrong,fēi    
+面,face,miàn
+革,leather,gé    
+韦 or (韋),soft leather,wěi    
+韭,leek,jiǔ    
+音,sound,yīn    
+页 or (頁),page,yè 
+风 or (風),wind,fēng
+飞 or (飛),fly,fēi 
+饣 or 飠 or 食,eat,shí    
+首,head,shǒu 
+香,fragrant,xiāng
+马 or (馬),horse,mǎ
+骨,bone,gǔ
+高,high,gāo
+髟,long hair,biāo    
+鬥,fight,dòu  
+鬯,sacrificial wine,chàng    
+鬲,cauldron,lì    
+鬼,ghost,guǐ    
+鱼 or (魚),fish,yú
+鸟 or (鳥),bird,niǎo   
+卤,salty,lǔ  
+鹿,deer,lù
+麦 or (麥),wheat,mài 
+麻,hemp,má    
+黄,yellow,huáng    
+黍,millet,shǔ    
+黑,black,hēi    
+黹,embroidery,zhǐ    
+黾 or (黽),frog,mǐn    
+鼎,tripod,dǐng    
+鼓,drum,gǔ    
+鼠,rat,shǔ
+鼻,nose,bí  
+齐 or (齊),even,qí    
+齿 or (齒),tooth,chǐ
+龙 or (龍),dragon,lóng    
+龟 or (龜),turtle,guī    
+龠,flute,yuè

--- a/vocab/mandarin/radicals.json
+++ b/vocab/mandarin/radicals.json
@@ -1,0 +1,1072 @@
+[
+    {
+        "intermediate_1": "yī",
+        "native_1": "one",
+        "primary_1": "一"
+    },
+    {
+        "intermediate_1": "shù",
+        "native_1": "line",
+        "primary_1": "丨"
+    },
+    {
+        "intermediate_1": "diǎn",
+        "native_1": "dot",
+        "primary_1": "丶"
+    },
+    {
+        "intermediate_1": "piě",
+        "native_1": "slash",
+        "primary_1": "丿 or 乀 or 乁"
+    },
+    {
+        "intermediate_1": "yǐ",
+        "native_1": "second",
+        "primary_1": "乙 or 乚 or 乛"
+    },
+    {
+        "intermediate_1": "gōu",
+        "native_1": "hook",
+        "primary_1": "亅"
+    },
+    {
+        "intermediate_1": "èr",
+        "native_1": "two",
+        "primary_1": "二"
+    },
+    {
+        "intermediate_1": "tóu",
+        "native_1": "lid",
+        "primary_1": "亠"
+    },
+    {
+        "intermediate_1": "rén",
+        "native_1": "person",
+        "primary_1": "人 or 亻"
+    },
+    {
+        "intermediate_1": "ér",
+        "native_1": "legs",
+        "primary_1": "儿"
+    },
+    {
+        "intermediate_1": "rù",
+        "native_1": "enter",
+        "primary_1": "入"
+    },
+    {
+        "intermediate_1": "bā",
+        "native_1": "eight",
+        "primary_1": "八 or 丷"
+    },
+    {
+        "intermediate_1": "jiǒng",
+        "native_1": "down box",
+        "primary_1": "冂"
+    },
+    {
+        "intermediate_1": "mì",
+        "native_1": "cover",
+        "primary_1": "冖"
+    },
+    {
+        "intermediate_1": "bīng",
+        "native_1": "ice",
+        "primary_1": "冫"
+    },
+    {
+        "intermediate_1": "jī or jǐ",
+        "native_1": "table",
+        "primary_1": "几"
+    },
+    {
+        "intermediate_1": "qǔ",
+        "native_1": "open box",
+        "primary_1": "凵"
+    },
+    {
+        "intermediate_1": "dāo",
+        "native_1": "knife",
+        "primary_1": "刀 or刂"
+    },
+    {
+        "intermediate_1": "lì",
+        "native_1": "power",
+        "primary_1": "力"
+    },
+    {
+        "intermediate_1": "bāo",
+        "native_1": "wrap",
+        "primary_1": "勹"
+    },
+    {
+        "intermediate_1": "bǐ",
+        "native_1": "ladle",
+        "primary_1": "匕"
+    },
+    {
+        "intermediate_1": "fāng",
+        "native_1": "right open box",
+        "primary_1": "匚"
+    },
+    {
+        "intermediate_1": "xǐ",
+        "native_1": "hiding enclosure",
+        "primary_1": "匸"
+    },
+    {
+        "intermediate_1": "shí",
+        "native_1": "ten",
+        "primary_1": "十"
+    },
+    {
+        "intermediate_1": "bǔ",
+        "native_1": "divination",
+        "primary_1": "卜"
+    },
+    {
+        "intermediate_1": "jié",
+        "native_1": "seal",
+        "primary_1": "卩"
+    },
+    {
+        "intermediate_1": "hàn",
+        "native_1": "cliff",
+        "primary_1": "厂"
+    },
+    {
+        "intermediate_1": "sī",
+        "native_1": "private",
+        "primary_1": "厶"
+    },
+    {
+        "intermediate_1": "yòu",
+        "native_1": "again",
+        "primary_1": "又"
+    },
+    {
+        "intermediate_1": "kǒu",
+        "native_1": "mouth",
+        "primary_1": "口"
+    },
+    {
+        "intermediate_1": "wéi",
+        "native_1": "enclosure",
+        "primary_1": "囗"
+    },
+    {
+        "intermediate_1": "tǔ",
+        "native_1": "earth",
+        "primary_1": "土"
+    },
+    {
+        "intermediate_1": "shì",
+        "native_1": "scholar",
+        "primary_1": "士"
+    },
+    {
+        "intermediate_1": "zhī",
+        "native_1": "go",
+        "primary_1": "夂"
+    },
+    {
+        "intermediate_1": "suī",
+        "native_1": "go slowly",
+        "primary_1": "夊"
+    },
+    {
+        "intermediate_1": "xī",
+        "native_1": "night",
+        "primary_1": "夕"
+    },
+    {
+        "intermediate_1": "dà",
+        "native_1": "big",
+        "primary_1": "大"
+    },
+    {
+        "intermediate_1": "nǚ",
+        "native_1": "woman",
+        "primary_1": "女"
+    },
+    {
+        "intermediate_1": "zǐ",
+        "native_1": "child",
+        "primary_1": "子"
+    },
+    {
+        "intermediate_1": "gài",
+        "native_1": "roof",
+        "primary_1": "宀"
+    },
+    {
+        "intermediate_1": "cùn",
+        "native_1": "inch",
+        "primary_1": "寸"
+    },
+    {
+        "intermediate_1": "xiǎo",
+        "native_1": "small",
+        "primary_1": "小"
+    },
+    {
+        "intermediate_1": "yóu",
+        "native_1": "lame",
+        "primary_1": "尢 or 尣"
+    },
+    {
+        "intermediate_1": "shī",
+        "native_1": "corpse",
+        "primary_1": "尸"
+    },
+    {
+        "intermediate_1": "chè",
+        "native_1": "sprout",
+        "primary_1": "屮"
+    },
+    {
+        "intermediate_1": "shān",
+        "native_1": "mountain",
+        "primary_1": "山"
+    },
+    {
+        "intermediate_1": "chuān",
+        "native_1": "river",
+        "primary_1": "川 or 巛 or 巜"
+    },
+    {
+        "intermediate_1": "gōng",
+        "native_1": "work",
+        "primary_1": "工"
+    },
+    {
+        "intermediate_1": "jǐ",
+        "native_1": "oneself",
+        "primary_1": "己"
+    },
+    {
+        "intermediate_1": "jīn",
+        "native_1": "towel",
+        "primary_1": "巾"
+    },
+    {
+        "intermediate_1": "gān",
+        "native_1": "dry",
+        "primary_1": "干"
+    },
+    {
+        "intermediate_1": "yāo",
+        "native_1": "thread",
+        "primary_1": "幺"
+    },
+    {
+        "intermediate_1": "guǎng",
+        "native_1": "shelter",
+        "primary_1": "广"
+    },
+    {
+        "intermediate_1": "yǐn",
+        "native_1": "stride",
+        "primary_1": "廴"
+    },
+    {
+        "intermediate_1": "gǒng",
+        "native_1": "hands joined",
+        "primary_1": "廾"
+    },
+    {
+        "intermediate_1": "yì",
+        "native_1": "shoot with a bow",
+        "primary_1": "弋"
+    },
+    {
+        "intermediate_1": "gōng",
+        "native_1": "bow",
+        "primary_1": "弓"
+    },
+    {
+        "intermediate_1": "jì",
+        "native_1": "snout",
+        "primary_1": "彐 or 彑"
+    },
+    {
+        "intermediate_1": "shān",
+        "native_1": "hair",
+        "primary_1": "彡"
+    },
+    {
+        "intermediate_1": "chì",
+        "native_1": "step",
+        "primary_1": "彳"
+    },
+    {
+        "intermediate_1": "xīn",
+        "native_1": "heart",
+        "primary_1": "心 or 忄"
+    },
+    {
+        "intermediate_1": "gē",
+        "native_1": "spear",
+        "primary_1": "戈"
+    },
+    {
+        "intermediate_1": "hù",
+        "native_1": "door",
+        "primary_1": "户"
+    },
+    {
+        "intermediate_1": "shǒu",
+        "native_1": "hand",
+        "primary_1": "手 or 扌"
+    },
+    {
+        "intermediate_1": "zhī",
+        "native_1": "branch",
+        "primary_1": "支"
+    },
+    {
+        "intermediate_1": "pū",
+        "native_1": "rap",
+        "primary_1": "攴 or 攵"
+    },
+    {
+        "intermediate_1": "wén",
+        "native_1": "script",
+        "primary_1": "文"
+    },
+    {
+        "intermediate_1": "dǒu",
+        "native_1": "dipper",
+        "primary_1": "斗"
+    },
+    {
+        "intermediate_1": "jīn",
+        "native_1": "axe",
+        "primary_1": "斤"
+    },
+    {
+        "intermediate_1": "fāng",
+        "native_1": "square",
+        "primary_1": "方"
+    },
+    {
+        "intermediate_1": "wú",
+        "native_1": "not",
+        "primary_1": "无"
+    },
+    {
+        "intermediate_1": "rì",
+        "native_1": "sun",
+        "primary_1": "日"
+    },
+    {
+        "intermediate_1": "yuē",
+        "native_1": "say",
+        "primary_1": "曰"
+    },
+    {
+        "intermediate_1": "yuè",
+        "native_1": "moon",
+        "primary_1": "月"
+    },
+    {
+        "intermediate_1": "mù",
+        "native_1": "tree",
+        "primary_1": "木"
+    },
+    {
+        "intermediate_1": "qiàn",
+        "native_1": "lack",
+        "primary_1": "欠"
+    },
+    {
+        "intermediate_1": "zhǐ",
+        "native_1": "stop",
+        "primary_1": "止"
+    },
+    {
+        "intermediate_1": "dǎi",
+        "native_1": "death",
+        "primary_1": "歹"
+    },
+    {
+        "intermediate_1": "shū",
+        "native_1": "weapon",
+        "primary_1": "殳"
+    },
+    {
+        "intermediate_1": "mǔ",
+        "native_1": "mother",
+        "primary_1": "母 or 毋"
+    },
+    {
+        "intermediate_1": "bǐ",
+        "native_1": "compare",
+        "primary_1": "比"
+    },
+    {
+        "intermediate_1": "máo",
+        "native_1": "fur",
+        "primary_1": "毛"
+    },
+    {
+        "intermediate_1": "shì",
+        "native_1": "clan",
+        "primary_1": "氏"
+    },
+    {
+        "intermediate_1": "qì",
+        "native_1": "steam",
+        "primary_1": "气"
+    },
+    {
+        "intermediate_1": "shuǐ",
+        "native_1": "water",
+        "primary_1": "水 or 氵"
+    },
+    {
+        "intermediate_1": "huǒ",
+        "native_1": "fire",
+        "primary_1": "火 or 灬"
+    },
+    {
+        "intermediate_1": "zhǎo",
+        "native_1": "claw",
+        "primary_1": "爪 or 爫"
+    },
+    {
+        "intermediate_1": "fù",
+        "native_1": "father",
+        "primary_1": "父"
+    },
+    {
+        "intermediate_1": "yáo",
+        "native_1": "lines on a trigram",
+        "primary_1": "爻"
+    },
+    {
+        "intermediate_1": "qiáng",
+        "native_1": "half of a tree trunk",
+        "primary_1": "爿"
+    },
+    {
+        "intermediate_1": "piàn",
+        "native_1": "slice",
+        "primary_1": "片"
+    },
+    {
+        "intermediate_1": "yá",
+        "native_1": "tooth",
+        "primary_1": "牙"
+    },
+    {
+        "intermediate_1": "niú",
+        "native_1": "cow",
+        "primary_1": "牛 or 牜"
+    },
+    {
+        "intermediate_1": "quǎn",
+        "native_1": "dog",
+        "primary_1": "犭 or 犬"
+    },
+    {
+        "intermediate_1": "xuán",
+        "native_1": "profound",
+        "primary_1": "玄"
+    },
+    {
+        "intermediate_1": "yù",
+        "native_1": "jade",
+        "primary_1": "玉 or 王"
+    },
+    {
+        "intermediate_1": "guā",
+        "native_1": "melon",
+        "primary_1": "瓜"
+    },
+    {
+        "intermediate_1": "wǎ",
+        "native_1": "tile",
+        "primary_1": "瓦"
+    },
+    {
+        "intermediate_1": "gān",
+        "native_1": "sweet",
+        "primary_1": "甘"
+    },
+    {
+        "intermediate_1": "shēng",
+        "native_1": "life",
+        "primary_1": "生"
+    },
+    {
+        "intermediate_1": "yòng",
+        "native_1": "use",
+        "primary_1": "用"
+    },
+    {
+        "intermediate_1": "tián",
+        "native_1": "field",
+        "primary_1": "田"
+    },
+    {
+        "intermediate_1": "pǐ",
+        "native_1": "cloth",
+        "primary_1": "疋"
+    },
+    {
+        "intermediate_1": "bìng",
+        "native_1": "ill",
+        "primary_1": "疒"
+    },
+    {
+        "intermediate_1": "bō",
+        "native_1": "foot steps",
+        "primary_1": "癶"
+    },
+    {
+        "intermediate_1": "bái",
+        "native_1": "white",
+        "primary_1": "白"
+    },
+    {
+        "intermediate_1": "pí",
+        "native_1": "skin",
+        "primary_1": "皮"
+    },
+    {
+        "intermediate_1": "mǐn",
+        "native_1": "dish",
+        "primary_1": "皿"
+    },
+    {
+        "intermediate_1": "mù",
+        "native_1": "eye",
+        "primary_1": "目"
+    },
+    {
+        "intermediate_1": "máo",
+        "native_1": "spear",
+        "primary_1": "矛"
+    },
+    {
+        "intermediate_1": "shǐ",
+        "native_1": "arrow",
+        "primary_1": "矢"
+    },
+    {
+        "intermediate_1": "shí",
+        "native_1": "stone",
+        "primary_1": "石"
+    },
+    {
+        "intermediate_1": "shì",
+        "native_1": "spirit",
+        "primary_1": "示 or 礻"
+    },
+    {
+        "intermediate_1": "róu",
+        "native_1": "track",
+        "primary_1": "禸"
+    },
+    {
+        "intermediate_1": "hé",
+        "native_1": "grain",
+        "primary_1": "禾"
+    },
+    {
+        "intermediate_1": "xuè",
+        "native_1": "cave",
+        "primary_1": "穴"
+    },
+    {
+        "intermediate_1": "lì",
+        "native_1": "stand",
+        "primary_1": "立"
+    },
+    {
+        "intermediate_1": "zhú",
+        "native_1": "bamboo",
+        "primary_1": "竹"
+    },
+    {
+        "intermediate_1": "mǐ",
+        "native_1": "rice",
+        "primary_1": "米"
+    },
+    {
+        "intermediate_1": "sī",
+        "native_1": "silk",
+        "primary_1": "纟 or (糸)"
+    },
+    {
+        "intermediate_1": "fǒu",
+        "native_1": "jar",
+        "primary_1": "缶"
+    },
+    {
+        "intermediate_1": "wǎng",
+        "native_1": "net",
+        "primary_1": "网 or 罒"
+    },
+    {
+        "intermediate_1": "yáng",
+        "native_1": "sheep",
+        "primary_1": "羊"
+    },
+    {
+        "intermediate_1": "yǔ",
+        "native_1": "feather",
+        "primary_1": "羽"
+    },
+    {
+        "intermediate_1": "lǎo",
+        "native_1": "old",
+        "primary_1": "老"
+    },
+    {
+        "intermediate_1": "ér",
+        "native_1": "and",
+        "primary_1": "而"
+    },
+    {
+        "intermediate_1": "lěi",
+        "native_1": "plow",
+        "primary_1": "耒"
+    },
+    {
+        "intermediate_1": "ěr",
+        "native_1": "ear",
+        "primary_1": "耳"
+    },
+    {
+        "intermediate_1": "yù",
+        "native_1": "brush",
+        "primary_1": "聿"
+    },
+    {
+        "intermediate_1": "ròu",
+        "native_1": "meat",
+        "primary_1": "肉"
+    },
+    {
+        "intermediate_1": "chén",
+        "native_1": "minister",
+        "primary_1": "臣"
+    },
+    {
+        "intermediate_1": "zì",
+        "native_1": "oneself",
+        "primary_1": "自"
+    },
+    {
+        "intermediate_1": "zhì",
+        "native_1": "arrive",
+        "primary_1": "至"
+    },
+    {
+        "intermediate_1": "jiù",
+        "native_1": "mortar",
+        "primary_1": "臼"
+    },
+    {
+        "intermediate_1": "shé",
+        "native_1": "tongue",
+        "primary_1": "舌"
+    },
+    {
+        "intermediate_1": "chuǎn",
+        "native_1": "contrary",
+        "primary_1": "舛"
+    },
+    {
+        "intermediate_1": "zhōu",
+        "native_1": "boat",
+        "primary_1": "舟"
+    },
+    {
+        "intermediate_1": "gèn",
+        "native_1": "mountain",
+        "primary_1": "艮"
+    },
+    {
+        "intermediate_1": "sè",
+        "native_1": "color",
+        "primary_1": "色"
+    },
+    {
+        "intermediate_1": "cǎo",
+        "native_1": "grass",
+        "primary_1": "艹"
+    },
+    {
+        "intermediate_1": "hǔ",
+        "native_1": "tiger",
+        "primary_1": "虍"
+    },
+    {
+        "intermediate_1": "chóng",
+        "native_1": "insect",
+        "primary_1": "虫"
+    },
+    {
+        "intermediate_1": "xuě",
+        "native_1": "blood",
+        "primary_1": "血"
+    },
+    {
+        "intermediate_1": "xíng",
+        "native_1": "walk",
+        "primary_1": "行"
+    },
+    {
+        "intermediate_1": "yī",
+        "native_1": "clothes",
+        "primary_1": "衣 or 衤"
+    },
+    {
+        "intermediate_1": "xī",
+        "native_1": "west",
+        "primary_1": "西 or 覀"
+    },
+    {
+        "intermediate_1": "jiàn",
+        "native_1": "see",
+        "primary_1": "见 or (見)"
+    },
+    {
+        "intermediate_1": "jiǎo",
+        "native_1": "horn",
+        "primary_1": "角"
+    },
+    {
+        "intermediate_1": "yán",
+        "native_1": "speech",
+        "primary_1": "讠or (言)"
+    },
+    {
+        "intermediate_1": "gǔ",
+        "native_1": "valley",
+        "primary_1": "谷"
+    },
+    {
+        "intermediate_1": "dòu",
+        "native_1": "bean",
+        "primary_1": "豆"
+    },
+    {
+        "intermediate_1": "shǐ",
+        "native_1": "pig",
+        "primary_1": "豕"
+    },
+    {
+        "intermediate_1": "zhì",
+        "native_1": "badger",
+        "primary_1": "豸"
+    },
+    {
+        "intermediate_1": "bèi",
+        "native_1": "shell",
+        "primary_1": "贝 or (貝)"
+    },
+    {
+        "intermediate_1": "chì",
+        "native_1": "red",
+        "primary_1": "赤"
+    },
+    {
+        "intermediate_1": "zǒu",
+        "native_1": "walk",
+        "primary_1": "走"
+    },
+    {
+        "intermediate_1": "zú",
+        "native_1": "foot",
+        "primary_1": "足"
+    },
+    {
+        "intermediate_1": "shēn",
+        "native_1": "body",
+        "primary_1": "身"
+    },
+    {
+        "intermediate_1": "chē",
+        "native_1": "cart",
+        "primary_1": "车 or (車)"
+    },
+    {
+        "intermediate_1": "xīn",
+        "native_1": "bitter",
+        "primary_1": "辛"
+    },
+    {
+        "intermediate_1": "chén",
+        "native_1": "morning",
+        "primary_1": "辰"
+    },
+    {
+        "intermediate_1": "chuò",
+        "native_1": "walk",
+        "primary_1": "辶"
+    },
+    {
+        "intermediate_1": "yì",
+        "native_1": "city",
+        "primary_1": "邑 or 阝"
+    },
+    {
+        "intermediate_1": "yǒu",
+        "native_1": "wine",
+        "primary_1": "酉"
+    },
+    {
+        "intermediate_1": "biàn",
+        "native_1": "distinguish",
+        "primary_1": "釆"
+    },
+    {
+        "intermediate_1": "lǐ",
+        "native_1": "village",
+        "primary_1": "里"
+    },
+    {
+        "intermediate_1": "jīn",
+        "native_1": "metal",
+        "primary_1": "钅 or 金"
+    },
+    {
+        "intermediate_1": "cháng",
+        "native_1": "long",
+        "primary_1": "长 or (長)"
+    },
+    {
+        "intermediate_1": "mén",
+        "native_1": "gate",
+        "primary_1": "门 or (門)"
+    },
+    {
+        "intermediate_1": "fù",
+        "native_1": "mound",
+        "primary_1": "阜 or 阝"
+    },
+    {
+        "intermediate_1": "lì",
+        "native_1": "slave",
+        "primary_1": "隶"
+    },
+    {
+        "intermediate_1": "zhuī",
+        "native_1": "short-tailed bird",
+        "primary_1": "隹"
+    },
+    {
+        "intermediate_1": "yǔ",
+        "native_1": "rain",
+        "primary_1": "雨"
+    },
+    {
+        "intermediate_1": "qīng",
+        "native_1": "blue",
+        "primary_1": "青"
+    },
+    {
+        "intermediate_1": "fēi",
+        "native_1": "wrong",
+        "primary_1": "非"
+    },
+    {
+        "intermediate_1": "miàn",
+        "native_1": "face",
+        "primary_1": "面"
+    },
+    {
+        "intermediate_1": "gé",
+        "native_1": "leather",
+        "primary_1": "革"
+    },
+    {
+        "intermediate_1": "wěi",
+        "native_1": "soft leather",
+        "primary_1": "韦 or (韋)"
+    },
+    {
+        "intermediate_1": "jiǔ",
+        "native_1": "leek",
+        "primary_1": "韭"
+    },
+    {
+        "intermediate_1": "yīn",
+        "native_1": "sound",
+        "primary_1": "音"
+    },
+    {
+        "intermediate_1": "yè",
+        "native_1": "page",
+        "primary_1": "页 or (頁)"
+    },
+    {
+        "intermediate_1": "fēng",
+        "native_1": "wind",
+        "primary_1": "风 or (風)"
+    },
+    {
+        "intermediate_1": "fēi",
+        "native_1": "fly",
+        "primary_1": "飞 or (飛)"
+    },
+    {
+        "intermediate_1": "shí",
+        "native_1": "eat",
+        "primary_1": "饣 or 飠 or 食"
+    },
+    {
+        "intermediate_1": "shǒu",
+        "native_1": "head",
+        "primary_1": "首"
+    },
+    {
+        "intermediate_1": "xiāng",
+        "native_1": "fragrant",
+        "primary_1": "香"
+    },
+    {
+        "intermediate_1": "mǎ",
+        "native_1": "horse",
+        "primary_1": "马 or (馬)"
+    },
+    {
+        "intermediate_1": "gǔ",
+        "native_1": "bone",
+        "primary_1": "骨"
+    },
+    {
+        "intermediate_1": "gāo",
+        "native_1": "high",
+        "primary_1": "高"
+    },
+    {
+        "intermediate_1": "biāo",
+        "native_1": "long hair",
+        "primary_1": "髟"
+    },
+    {
+        "intermediate_1": "dòu",
+        "native_1": "fight",
+        "primary_1": "鬥"
+    },
+    {
+        "intermediate_1": "chàng",
+        "native_1": "sacrificial wine",
+        "primary_1": "鬯"
+    },
+    {
+        "intermediate_1": "lì",
+        "native_1": "cauldron",
+        "primary_1": "鬲"
+    },
+    {
+        "intermediate_1": "guǐ",
+        "native_1": "ghost",
+        "primary_1": "鬼"
+    },
+    {
+        "intermediate_1": "yú",
+        "native_1": "fish",
+        "primary_1": "鱼 or (魚)"
+    },
+    {
+        "intermediate_1": "niǎo",
+        "native_1": "bird",
+        "primary_1": "鸟 or (鳥)"
+    },
+    {
+        "intermediate_1": "lǔ",
+        "native_1": "salty",
+        "primary_1": "卤"
+    },
+    {
+        "intermediate_1": "lù",
+        "native_1": "deer",
+        "primary_1": "鹿"
+    },
+    {
+        "intermediate_1": "mài",
+        "native_1": "wheat",
+        "primary_1": "麦 or (麥)"
+    },
+    {
+        "intermediate_1": "má",
+        "native_1": "hemp",
+        "primary_1": "麻"
+    },
+    {
+        "intermediate_1": "huáng",
+        "native_1": "yellow",
+        "primary_1": "黄"
+    },
+    {
+        "intermediate_1": "shǔ",
+        "native_1": "millet",
+        "primary_1": "黍"
+    },
+    {
+        "intermediate_1": "hēi",
+        "native_1": "black",
+        "primary_1": "黑"
+    },
+    {
+        "intermediate_1": "zhǐ",
+        "native_1": "embroidery",
+        "primary_1": "黹"
+    },
+    {
+        "intermediate_1": "mǐn",
+        "native_1": "frog",
+        "primary_1": "黾 or (黽)"
+    },
+    {
+        "intermediate_1": "dǐng",
+        "native_1": "tripod",
+        "primary_1": "鼎"
+    },
+    {
+        "intermediate_1": "gǔ",
+        "native_1": "drum",
+        "primary_1": "鼓"
+    },
+    {
+        "intermediate_1": "shǔ",
+        "native_1": "rat",
+        "primary_1": "鼠"
+    },
+    {
+        "intermediate_1": "bí",
+        "native_1": "nose",
+        "primary_1": "鼻"
+    },
+    {
+        "intermediate_1": "qí",
+        "native_1": "even",
+        "primary_1": "齐 or (齊)"
+    },
+    {
+        "intermediate_1": "chǐ",
+        "native_1": "tooth",
+        "primary_1": "齿 or (齒)"
+    },
+    {
+        "intermediate_1": "lóng",
+        "native_1": "dragon",
+        "primary_1": "龙 or (龍)"
+    },
+    {
+        "intermediate_1": "guī",
+        "native_1": "turtle",
+        "primary_1": "龟 or (龜)"
+    },
+    {
+        "intermediate_1": "yuè",
+        "native_1": "flute",
+        "primary_1": "龠"
+    }
+]

--- a/vocab/util/csv_parser.py
+++ b/vocab/util/csv_parser.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python
+
+import sys
+import json
+import os.path
+
+CSV_EXT = ".csv"
+JSON_EXT = ".json"
+
+VALID_COLUMN_LABELS = {
+    "primary": 0,
+    "intermediate": 0 ,
+    "meaining": 0, 
+    "native" : 0
+}
+
+VALID_SEP_FLAGS = {
+    "-c": ",",
+    "-t": "\t"
+}
+
+
+def usage():
+    """
+    Displays csv script usage flag descriptions
+
+    """
+
+    print("\n\n--> USAGE\n\n")
+    print(" $ chmod +x csv_parser.py")
+    print(" $ ./csv_parser.py [-c, -t] <csv_file_path_1> <csv_file_path_2> ...")
+    print("\n                         --OR--\n")
+    print(" $ python3 csv_parser.py <csv_file_path_1> <csv_file_path_2> ...")
+    print("-----------------------------------------------------------------------")
+    print("\n--> FLAGS\n")
+    print("----- Separator Flags")
+    print()
+    print("-c")
+    print("\tdenotes the following csv are comma-separated")
+    print()
+    print("-t")
+    print("\tdenotes the following csv are tab-separated")
+    print()
+    print("\n\n")
+
+
+def validateInputFiles(args):
+    """
+    Determines whether or not the csv files provided have csv file extensions
+    and exist 
+
+    :param args: the array of csv files command-line arguements
+    :returns: true when all of the provided files exist and have csv extensions, otherwise false
+
+    """
+
+    file_list = []
+    for csv_file in args:
+        if csv_file[-4:] == CSV_EXT and os.path.isfile(csv_file):
+            file_list.append(csv_file)
+        elif csv_file[-4:] != CSV_EXT:
+            print("\nError: CSV file extension does not exist for %s\n" % (csv_file))
+            exit(-1)
+        else:
+            print("\nError: %s was not found. Make sure you specify a valid absolute or realtive path \n" % (csv_file))
+            exit(-1)
+
+    return file_list
+
+def generateTermLabels(file_header):
+    """
+    Creates the numbered labels for each json term object in accordance with their csv's header
+
+    :param file_header: the file_header which provides every term objects field labels
+    :returns: the numbered file_header labels or an empty array when the csv contains an invalid term template
+    
+    """
+
+    labels = []
+    for label in file_header:
+        label = label.lower()
+        if label not in VALID_COLUMN_LABELS:
+            return []
+        else:
+            VALID_COLUMN_LABELS[label] += 1
+            labels.append("%s_%d" % (label, VALID_COLUMN_LABELS[label]))
+    return labels
+
+
+def convert(csv_files, sep=","):
+    """
+    Iterates through all csv files and coverts them into a single json array based on the csv's
+    term template header. This json array is then outputed to the same directory as the associated
+    csv file
+
+    :param csv_files: the array of csv file names
+    :param sep: the delimeter for the list of csv files 
+
+    """
+
+    for csv in csv_files:
+        with open(csv) as file:
+            labels = generateTermLabels((file.readline().rstrip("\n").strip()).split(sep))
+            if len(labels) == 0:
+                print("\nError: The column header for \"%s\" is invalid... aborting conversion\n" % csv)
+                continue
+
+            # Read in all terms contained in the csv file
+            term_array = []
+            for i, line in enumerate(file, start=1):
+
+                # term_data = [item.strip() for item in (line.rstrip("\n").split(sep))]
+                term_data = []
+                for item in (line.rstrip("\n").strip()).split(sep):
+                    term_data.append(item)
+
+                if len(labels) != len(term_data):
+                    print(term_data)
+                    print("\nError while reading: %s\nLine %d does not contain the file's %d specified labeled values.\n" % (csv, i, len(labels)))
+                    exit(-1)
+                else:
+                    term_object = {}
+                    for index in range(len(labels)):
+                        term_object[labels[index]] = term_data[index]
+
+                    term_array.append(term_object)
+            
+            with open(csv[:len(csv)-4]+JSON_EXT, "w") as json_output:
+                json_output.write(json.dumps(term_array, indent=4, sort_keys=True, ensure_ascii=False))
+
+def main():
+    sys.argv.pop(0)
+    if("-h" in sys.argv):
+        usage()
+        exit(0)
+
+    if(len(sys.argv) == 1):
+        print("\nError: You must specify at least one csv file and the csv separator. Run with -h for more details\n")
+        exit(0)
+
+    if(sys.argv[0] not in VALID_SEP_FLAGS):
+        print("\nError: Invalid seperator argument provided: %s\n Valid separators %s" % (sys.argv[0], str(VALID_SEP_FLAGS.keys())))
+        exit(-1)
+    
+    sep = VALID_SEP_FLAGS[sys.argv[0]]
+    sys.argv.pop(0)
+    convert(validateInputFiles(sys.argv), sep)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION

1. **Description of the Change**
Adds short csv to json python conversion script. Adds HSK mandarin and radicals csv/json files.


2. **Alternate Designs**

The conversion script supports any number of columns labeled with
- Native - the column contains words in the person's native language
- Primary - the column containing the words being learned
- Intermediate - the column contains an intermediate representation of the primary word. For instance romanization phonetics etc.
- Meaning - additional useful information for the native speaker

3. **Why Should This Be In Core?**

Adds support for English to Mandarin language learners

4. **Benefits**

Can use simple csv -> json script to serialize other vocabulary lists

5. **Possible Drawbacks**

The conversion script needs tests

### Verification Process

1. **What process did you follow to verify that your change has the desired effects?**
	- How did you confirm that all new functionality works as expected?
           Tested on HSK and radical mandarin vocabulary lists

	- How did you confirm that all changed functionality works as expected?
          Copied the newly produced json files into a json format checker

	- How did you confirm that the change has not introduced any regressions?
          This is the only code currently in the repo

2. **Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.**
Added column labels described above
```
$ chmod +x csv_parser.py
$ ./csv_parser -t hsk1.csv
```
Produces `hsk1.json`
